### PR TITLE
added x47 entries in the language_subtag_registry

### DIFF
--- a/dev/tools/localization/language_subtag_registry.dart
+++ b/dev/tools/localization/language_subtag_registry.dart
@@ -47915,4 +47915,649 @@ Description: Cantonese
 Added: 1999-12-18
 Deprecated: 2009-07-29
 Preferred-Value: yue
+%%
+Type: language
+Subtag: acm
+Description: ACM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: acq
+Description: ACQ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: aeb
+Description: AEB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: als
+Description: ALS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: apc
+Description: Levantine
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ars
+Description: ARS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ary
+Description: Moroccan
+Added: 2024-01-01
+%%
+Type: language
+Subtag: arz
+Description: Egyptian
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ayr
+Description: AYR
+Added: 2024-01-01
+%%
+Type: language
+Subtag: azb
+Description: South
+Added: 2024-01-01
+%%
+Type: language
+Subtag: azj
+Description: AZJ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ba
+Description: BA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: bho
+Description: Bhojpuri
+Added: 2024-01-01
+%%
+Type: language
+Subtag: bo
+Description: BO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: brx
+Description: BRX
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ceb
+Description: Cebuano
+Added: 2024-01-01
+%%
+Type: language
+Subtag: cjk
+Description: CJK
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ckb
+Description: CKB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: crh
+Description: CRH
+Added: 2024-01-01
+%%
+Type: language
+Subtag: dik
+Description: DIK
+Added: 2024-01-01
+%%
+Type: language
+Subtag: doi
+Description: DOI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: dsb
+Description: DSB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: dv
+Description: DV
+Added: 2024-01-01
+%%
+Type: language
+Subtag: dyu
+Description: DYU
+Added: 2024-01-01
+%%
+Type: language
+Subtag: dzo
+Description: DZO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ee
+Description: Ewe
+Added: 2024-01-01
+%%
+Type: language
+Subtag: epo
+Description: EPO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: fj
+Description: FJ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: fo
+Description: FO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: fon
+Description: FON
+Added: 2024-01-01
+%%
+Type: language
+Subtag: fur
+Description: FUR
+Added: 2024-01-01
+%%
+Type: language
+Subtag: fuv
+Description: FUV
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ga
+Description: GA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: gla
+Description: GLA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: gn
+Description: Guarani
+Added: 2024-01-01
+%%
+Type: language
+Subtag: gom
+Description: GOM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ha
+Description: Hausa
+Added: 2024-01-01
+%%
+Type: language
+Subtag: hne
+Description: HNE
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ht
+Description: Haitian
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ig
+Description: Igbo
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ikt
+Description: IKT
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ilo
+Description: ILO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: iu
+Description: IU
+Added: 2024-01-01
+%%
+Type: language
+Subtag: jv
+Description: Javanese
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kab
+Description: KAB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kac
+Description: KAC
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kam
+Description: KAM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kbp
+Description: KBP
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kea
+Description: KEA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kg
+Description: Kongo
+Added: 2024-01-01
+%%
+Type: language
+Subtag: khk
+Description: KHK
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ki
+Description: Kikuyu
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kmb
+Description: KMB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: kmr
+Description: KMR
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ks
+Description: Kashmiri
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ku
+Description: Kurdish
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lg
+Description: Ganda
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lij
+Description: LIJ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lim
+Description: LIM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lmo
+Description: LMO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ln
+Description: Lingala
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ltg
+Description: LTG
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ltz
+Description: LTZ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lua
+Description: LUA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: luo
+Description: LUO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lus
+Description: LUS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lvs
+Description: LVS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: lzh
+Description: LZH
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mag
+Description: MAG
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mai
+Description: Maithili
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mg
+Description: Malagasy
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mi
+Description: MI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: min
+Description: MIN
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mni
+Description: MNI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mos
+Description: MOS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mt
+Description: MT
+Added: 2024-01-01
+%%
+Type: language
+Subtag: mww
+Description: MWW
+Added: 2024-01-01
+%%
+Type: language
+Subtag: nno
+Description: NNO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: npi
+Description: NPI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: nso
+Description: NSO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: nus
+Description: NUS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ny
+Description: Nyanja
+Added: 2024-01-01
+%%
+Type: language
+Subtag: oci
+Description: OCI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: om
+Description: Oromo
+Added: 2024-01-01
+%%
+Type: language
+Subtag: otq
+Description: OTQ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: pag
+Description: PAG
+Added: 2024-01-01
+%%
+Type: language
+Subtag: pap
+Description: PAP
+Added: 2024-01-01
+%%
+Type: language
+Subtag: pbt
+Description: PBT
+Added: 2024-01-01
+%%
+Type: language
+Subtag: pes
+Description: Persian
+Added: 2024-01-01
+%%
+Type: language
+Subtag: plt
+Description: PLT
+Added: 2024-01-01
+%%
+Type: language
+Subtag: prs
+Description: PRS
+Added: 2024-01-01
+%%
+Type: language
+Subtag: rn
+Description: Rundi
+Added: 2024-01-01
+%%
+Type: language
+Subtag: rw
+Description: Kinyarwanda
+Added: 2024-01-01
+%%
+Type: language
+Subtag: sag
+Description: SAG
+Added: 2024-01-01
+%%
+Type: language
+Subtag: san
+Description: SAN
+Added: 2024-01-01
+%%
+Type: language
+Subtag: scn
+Description: SCN
+Added: 2024-01-01
+%%
+Type: language
+Subtag: sd
+Description: Sindhi
+Added: 2024-01-01
+%%
+Type: language
+Subtag: shn
+Description: SHN
+Added: 2024-01-01
+%%
+Type: language
+Subtag: sm
+Description: SM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: sn
+Description: Shona
+Added: 2024-01-01
+%%
+Type: language
+Subtag: so
+Description: Somali
+Added: 2024-01-01
+%%
+Type: language
+Subtag: srd
+Description: SRD
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ss
+Description: Swati
+Added: 2024-01-01
+%%
+Type: language
+Subtag: st
+Description: Sotho
+Added: 2024-01-01
+%%
+Type: language
+Subtag: su
+Description: Sundanese
+Added: 2024-01-01
+%%
+Type: language
+Subtag: szl
+Description: SZL
+Added: 2024-01-01
+%%
+Type: language
+Subtag: taq
+Description: TAQ
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tg
+Description: Tajik
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ti
+Description: Tigrinya
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tk
+Description: Turkmen
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tn
+Description: Tswana
+Added: 2024-01-01
+%%
+Type: language
+Subtag: to
+Description: TO
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tpi
+Description: TPI
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ts
+Description: Tsonga
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tt
+Description: Tatar
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tum
+Description: TUM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tw
+Description: Twi
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ty
+Description: TY
+Added: 2024-01-01
+%%
+Type: language
+Subtag: tzm
+Description: TZM
+Added: 2024-01-01
+%%
+Type: language
+Subtag: umb
+Description: UMB
+Added: 2024-01-01
+%%
+Type: language
+Subtag: uzn
+Description: Northern
+Added: 2024-01-01
+%%
+Type: language
+Subtag: vec
+Description: VEC
+Added: 2024-01-01
+%%
+Type: language
+Subtag: war
+Description: WAR
+Added: 2024-01-01
+%%
+Type: language
+Subtag: wo
+Description: Wolof
+Added: 2024-01-01
+%%
+Type: language
+Subtag: xh
+Description: Xhosa
+Added: 2024-01-01
+%%
+Type: language
+Subtag: ydd
+Description: YDD
+Added: 2024-01-01
+%%
+Type: language
+Subtag: yo
+Description: Yoruba
+Added: 2024-01-01
+%%
+Type: language
+Subtag: yua
+Description: YUA
+Added: 2024-01-01
+%%
+Type: language
+Subtag: zsm
+Description: Standard
+Added: 2024-01-01
 ''';

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_acm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_acm.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خَطْفُ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "المشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "الرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خريط القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_acq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_acq.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ترحيل",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ارفض القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_aeb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_aeb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تنبيهات",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خَطِّطْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "كُنْتِ تَمْرِي",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "فستة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختروا الكل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "إطلعو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "فَتِّشْ فِي الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "شُرْكُوا",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "طرد",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مَنْطِقْ القُدْسْ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_als.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_als.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Të prerë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopje",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zgjidh të gjitha",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Shiko lart.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Kërkoni në internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ndarja",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Shkarkimi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menyu i shkarkimit",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kanclojnë",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_apc.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_apc.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تنبيهات",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نطاق",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "البصمة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "إرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خريط القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ars.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ars.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ترحيل",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خفيف القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ary.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ary.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "التنبيه",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خَطّْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "بحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "الشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "الرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "طرد القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_arz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_arz.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نُسُخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "إرفاق",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "إرفض القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ayr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ayr.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Isthapiwinaka",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Q'ipisiña",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kunjamtï amuyki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Jisk'a ch'uqt'añ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taqpach ajllipxam",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Amuyasipxam",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Internetan thaqhapjjam",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Mayt'aña",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Q'umachata",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Manü apanukuñ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Q'alpun apsuta",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_azb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_azb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "آذر",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "کَس",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نُسخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "هامیسی سئچیب",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "يوخاري باخ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "اینترنتده آختار",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "بؤلوم",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "رد",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "رد کردن مینیو",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "لغو",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_azj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_azj.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Təhlükəsizlik",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kəsmək",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "İmzala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Qovşaq",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünləri seçin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Qula bax.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "İnternetdə axtarış aparın",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "İndirmə",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "İndirmə menyusu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "İndirim",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ba.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ba.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ҡырҡып алыу",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Күсермәһе",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бөтәһен дә һайлап алыу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Өҫкә ҡарағыҙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Поиск в сети",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Уртаҡлашыу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Эштән сығарыу",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Менюнан баш тартыу",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Бөтөрөргә",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_bho.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_bho.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "काटल जाला ।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चयन करीं",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ऊपर देखीं ।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "जाल खोज लीं ।",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू के खारिज कर दीं ।",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "कैंसिल",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_bo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_bo.arb
@@ -1,39 +1,216 @@
 {
-  "datePickerHourSemanticsLabelOne": "$hour ཆུ་ཚོད།",
-  "datePickerHourSemanticsLabelOther": "$hour ཆུ་ཚོད།",
-  "datePickerMinuteSemanticsLabelOne": "སྐར་མ། 1",
-  "datePickerMinuteSemanticsLabelOther": "$minute སྐར་མ་དུ་མ།",
-  "datePickerDateOrder": "ymd",
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
   "datePickerDateTimeOrder": "date_time_dayPeriod",
-  "anteMeridiemAbbreviation": "སྔ་དྲོ",
-  "postMeridiemAbbreviation": "ཕྱི་དྲོ།",
-  "todayLabel": "དེ་རིང་།",
-  "alertDialogLabel": "གསལ་བརྡ།",
-  "tabSemanticsLabel": "འཛར་གནོན་ $tabIndex ཡི $tabCount",
-  "timerPickerHourLabelOne": "ཆུ་ཚོད།",
-  "timerPickerHourLabelOther": "ཆུ་ཚོད་དུ་མ།",
-  "timerPickerMinuteLabelOne": "སྐར་མ།",
-  "timerPickerMinuteLabelOther": "སྐར་མ།",
-  "timerPickerSecondLabelOne": "སྐར་ཆ།",
-  "timerPickerSecondLabelOther": "སྐར་ཆ།",
-  "cutButtonLabel": "གཅོད།",
-  "copyButtonLabel": "བཤུས།",
-  "pasteButtonLabel": "འཕོས་པ།",
-  "clearButtonLabel": "གཙང་བཟོ།",
-  "selectAllButtonLabel": "ཚང་འདེམས།",
-  "lookUpButtonLabel": "འཚོལ་བ།",
-  "searchWebButtonLabel": "དྲ་ཐོག་འཚོལ་བཤེར།",
-  "shareButtonLabel": "མཉམ་སྤྱོད།…",
-  "noSpellCheckReplacementsLabel": "བརྗེས་ལེན་མ་རྙེད།",
-  "searchTextFieldPlaceholderLabel": "འཚོལ་བཤེར།",
-  "modalBarrierDismissLabel": "འདོར་བ།",
-  "menuDismissLabel": "ཐོ་གཞུང་འདོར་བ།",
-  "cancelButtonLabel": "ཕྱིར་འཐེན།",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ཉེན་བརྡ་གཏོང་བ།",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "གཏུབ་པ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "འདྲ་བཟོ་བྱས་པ།",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "རབ་རིབ་ཏུ་གྱུར",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ཡོངས་རྫོགས་འདེམས་བསྐོ་བྱ་དགོས",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "㚧།",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "འཚོལ་ཞིབ་Webཞེས་པ།",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "མཉམ་དུ་ལོངས་སུ་སྤྱོད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ལས་ཁོངས་ནས་ཕྱིར་འབུད་",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ཟ་མའི་མིང་ཐོ་ སྒོ་བརྒྱབ་པ་རེད།",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "མེད་པར་བཟོ་དགོས།",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
   "backButtonLabel": "Back",
-  "expansionTileExpandedHint": "ཕྱོགས་བསྡུའི་ཆེད་ཐེངས་གཉིས་གནོན།",
-  "expansionTileCollapsedHint": "ཁྱབ་སྤེལ་ཆེད་ཐེངས་གཉིས་གནོན།",
-  "expansionTileExpandedTapHint": "ཕྱོགས་བསྡུ།",
-  "expansionTileCollapsedTapHint": "ཞིབ་རྒྱས་ཆེད་ཁྱབ་སྤེལ།",
-  "expandedHint": "ཕྱོགས་བསྡུས།",
-  "collapsedHint": "ཁྱབ་སྤེལ་ཟིན།"
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
 }

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_brx.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_brx.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "एलार्ट",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "दान।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "कपि खालाम",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "गासैखौबो सायख'",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "नाय।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेबखौ नागिर",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "सेयार खालाम",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "होखार।",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनुखौ केनसेल खालाम।",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "दानगार",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ceb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ceb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Pag-alabot",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili sa tanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tan-awa sa itaas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Pagpangita sa Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Pag-undang",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pag-usab sa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Pagkansela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_cjk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_cjk.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kutachikiza",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kuchima",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kuzachisa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Kukutwa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Solola yeswe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Talenu mwakwoloka",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sokola muInternet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kuhanjikanga",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kufumisa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kufumisa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kuhichisa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ckb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ckb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ئاگاداری",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "پست",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەمووان هەڵبژێرە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "سەیری بەرز بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "گەڕان لە تۆڕەکەدا",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "دابەشکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "دوورخستنەوە",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مێنووى هەڵبوەشاندن",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "هەڵوەشاندنەوە",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_crh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_crh.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kesilgen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopiyalanğan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pasta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünlerini sayla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Yukarğa baq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "İnternette qıdıruv",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "İndirüv",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "İndirmek menüsi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "lâğu etilmek",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_dik.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_dik.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Wël ye kɔc yɔ̈ɔ̈k",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Lɔnë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pël ëlök",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Päm ëbën",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ku döt nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Kuen në wɛ̈t yic",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Loi käpuɔth",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Thɛ̈ɛ̈k wei",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Thɛ̈ɛ̈c menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Thɛ̈ɛ̈k",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_doi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_doi.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कटोई देओ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभनें दा चनाऽ करो",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "दिक्खो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वैब तुप्पो",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "सांझा करो",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करो",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू गी मिस करो",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द करना",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_dsb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_dsb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Wóskam",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Rězaś",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopěrowaś",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Kleister",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wšykne wuzwóliś.",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Zabitki",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Pśeglědajśo web web.",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Lichotne zapódaś.",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ze źěła pušćiś",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Meni verm",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Pśetergnuś",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_dv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_dv.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "އެލާޓް",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ކަނޑާލުން",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ކޮޕީ ކުރޭ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "ޕޭސްޓް ކުރުން",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ހުރިހާ އެންމެން އިޚްތިޔާރު ކުރޭ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "އިސްއުފުލާ ބަލާށެވެ.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ވެބް ސާޗް ކުރޭ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ޙިއްޞާ ކުރުން",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "މަގާމުން ވަކިކުރުން",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "މެނޫ ބޭރުކޮށްލާ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ބާތިލު",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_dyu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_dyu.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kɔrɔbɔli",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ka tigɛ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "O sɛbɛ nin sɛbɛra",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Fanga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Aw ye bɛɛ sugandi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "I ka filɛli kɛ sanfɛ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "N'i ye mɔgɔ dɔ ye, a ɲini o yɔrɔ la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ka dɔ fara a kan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ka ban",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ka ban",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ka ban",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_dzo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_dzo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ཉེན་བརྡ་",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "བཅད་བཟོ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ཡིག་སྣོད་",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "སྦྱོར་སྣོད་",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ག་ར་ གདམ་ཁ་རྐྱབས་",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ཡར་བལྟ་",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ཝིང་ནང་ལུ་འཚོལ་",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "བརྗེ་སོར་འབད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "དགོངས་ཞུ་འབད་",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ཁ་གཏང་ནིའི་མེ་ལོང་",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ཆ་མེད་གཏང་ནི་",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ee.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ee.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Nuxlɔ̃ame",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Wotso",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Woɖe wo ɖe go",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Nu siwo wotsɔna doa gbe",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tia nu siwo katã",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kpɔ dzi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Di Internet dzi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Wona Nuwo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ðe asi le eŋu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ðe asi le menu ŋu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ðe asi le eŋu",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_epo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_epo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerto",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tranĉita",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopio",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pesto",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Elektu ĉiujn",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Rigardu supren",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Serĉu en la reto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Dividi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Forĵetu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Forĵetu menuon",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Nu, nu, nu, nu, nu!",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fj.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Yadrava",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Musu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Lavetaki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Vakabira",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Digitaka kece",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Rai cake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Vakasaqaqara ena mataveilawa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Wasea",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Vagalalataki",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Vakasuka na menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Bokoci",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ávaring",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Skera",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopiera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Líma inn",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velja alt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Hygg/Hyggið upp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Leita á netinum",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Deila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Vísa burtur",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Vís matseðilin burtur",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Avlýsa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fon.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fon.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Xlɛ́n",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Wǔ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Wǔxwɛ́",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Wǔvɔ́",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi bǐ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kpɔ́n jǐ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Nɔ́ xo ɖò Internet ɔ mɛ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Wě nǔ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kún nǔ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kún nǔɖokpo",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ÐáñÜãåé",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fur.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alertazion",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Taglât",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezionâ ducj",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Cjale sù",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cîr su la rêt",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Parcjâ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Disponsâ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dispose di menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancelâ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_fuv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_fuv.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Wurooji",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ɓanngoo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Koode",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Fedde",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taƴi fuu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ndaaree dow",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Fandita nder web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Wondirde",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Fulide",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fulii menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Fulide",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ga.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ga.arb
@@ -1,54 +1,216 @@
 {
-  "timerPickerSecondLabelFew": "soic.",
-  "datePickerHourSemanticsLabelTwo": "$hour a chlog",
-  "datePickerHourSemanticsLabelFew": "$hour a chlog",
-  "datePickerHourSemanticsLabelMany": "$hour a chlog",
-  "datePickerMinuteSemanticsLabelTwo": "$minute nóiméad",
-  "datePickerMinuteSemanticsLabelFew": "$minute nóiméad",
-  "datePickerMinuteSemanticsLabelMany": "$minute nóiméad",
-  "timerPickerHourLabelTwo": "uair an chloig",
-  "timerPickerHourLabelFew": "uair an chloig",
-  "timerPickerHourLabelMany": "n-uair an chloig",
-  "timerPickerMinuteLabelTwo": "nóim.",
-  "timerPickerMinuteLabelFew": "nóim.",
-  "timerPickerMinuteLabelMany": "nóim.",
-  "timerPickerSecondLabelMany": "soic.",
-  "timerPickerSecondLabelTwo": "soic.",
-  "datePickerHourSemanticsLabelOne": "$hour a chlog",
-  "datePickerHourSemanticsLabelOther": "$hour a chlog",
-  "datePickerMinuteSemanticsLabelOne": "Aon nóiméad amháin",
-  "datePickerMinuteSemanticsLabelOther": "$minute nóiméad",
-  "datePickerDateOrder": "dmy",
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
   "datePickerDateTimeOrder": "date_time_dayPeriod",
-  "anteMeridiemAbbreviation": "R.N.",
-  "postMeridiemAbbreviation": "I.N.",
-  "todayLabel": "Inniu",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
   "alertDialogLabel": "Foláireamh",
-  "tabSemanticsLabel": "Cluaisín $tabIndex de $tabCount",
-  "timerPickerHourLabelOne": "uair an chloig",
-  "timerPickerHourLabelOther": "uair an chloig",
-  "timerPickerMinuteLabelOne": "nóim.",
-  "timerPickerMinuteLabelOther": "nóim.",
-  "timerPickerSecondLabelOne": "soic.",
-  "timerPickerSecondLabelOther": "soic.",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
   "cutButtonLabel": "Gearr",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
   "copyButtonLabel": "Cóipeáil",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
   "pasteButtonLabel": "Greamaigh",
-  "clearButtonLabel": "Glan",
-  "selectAllButtonLabel": "Roghnaigh Gach Rud",
-  "lookUpButtonLabel": "Cuardaigh",
-  "searchWebButtonLabel": "Cuardaigh an Gréasán",
-  "shareButtonLabel": "Comhroinn...",
-  "noSpellCheckReplacementsLabel": "Níor Aimsíodh Aon Fhocal Oiriúnach le Cur ina Áit",
-  "searchTextFieldPlaceholderLabel": "Cuardaigh",
-  "modalBarrierDismissLabel": "Ruaig",
-  "menuDismissLabel": "Ruaig an roghchlár",
-  "cancelButtonLabel": "Cealaigh",
-  "backButtonLabel": "Siar",
-  "expansionTileExpandedHint": "tapáil faoi dhó chun laghdú",
-  "expansionTileCollapsedHint": "tapáil faoi dhó chun leathnú",
-  "expansionTileExpandedTapHint": "Laghdaigh",
-  "expansionTileCollapsedTapHint": "Leathnaigh chun tuilleadh sonraí a fháil",
-  "expandedHint": "Laghdaithe",
-  "collapsedHint": "Leathnaithe"
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Roghnaigh gach rud",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Cuardaigh suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cuardaigh ar an ngréasán",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Comhroinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Díbhe",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Díbh roghchlár",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cuir ar ceal",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
 }

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_gla.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_gla.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tarraing",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Gearradh",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Còmhdach",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tagh uile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Thoir sùil suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Lorg air an lìonra",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "A ' roinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Cùl-seachad",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Mean-làimhe a dhùnadh",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "A dh ' ath-dhùnadh",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_gn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_gn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ojeja'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Ñemohenda",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Eiporavo opaite",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ehecha yvate",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Eipukuaa ñandutípe",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ñembojoajúva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ñemboyke",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ñemohendaha",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ñemomombyry",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_gom.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_gom.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "सतर्क",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कातरप",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "प्रत",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सगलें वेंचून काडप",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "देखीक",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेब सोद",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "वांटप",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "बरखास्त",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Usmiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द करचें",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ha.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ha.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Faɗakarwa",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Yanke",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kwafi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Manna",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zaɓi duka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Duba sama",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Bincika yanar gizo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Raba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dakatar da shi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fitar da menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Sokewa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_hne.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_hne.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "जम्मो चुनव",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ऊपर देख",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेब म खोज",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करे",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "डिस्पोजेबल मेनू",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द करे",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ht.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ht.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Vijilan",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Koupé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "kale",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Chwazi tout",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Gade anlè/anwo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Rechèch entènèt la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pataje",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Rejte",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Meni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Anile",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ig.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ig.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ịdọ aka ná ntị",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Bee",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Debata",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Mado",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Họrọ ihe niile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Lelee elu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Kwa ụbọchị WEB",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ịkekọrịta",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Chụpụ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Hichaa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kagbuo",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ikt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ikt.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tuhaqtidjutit",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Aadjiliuqhimayuq",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Kinguani",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilugit tamaita",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Qinirlutin",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Qinirlugu qaritauyakkut",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Atuqatigilugu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Naammagijaungitun",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ikhitaanga",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Taimaaqtauyuq",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ilo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ilo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Panangputot",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilien ti amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kitaem ti ngato",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Agbirok iti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Agpartak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Panagsina",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Panagipalawag",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Panagansela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_iu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_iu.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ᐊᓘᑦ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ᑭᐱᔭᐅᓂᖅ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ᐊᔾᔨᖓ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "ᑭᖑᒻᖏᕐᓂᑯ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ᐃᓘᓐᓇᓯ ᓂᕈᐊᖅᑕᐃᓐᓇᕆᓗᒋᑦ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ᑕᑯᒋᐊᕐᓂᖅ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ᕿᓂᕐᓗᒍ ᐃᑭᐊᖅᑭᕕᒃ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ᐊᒥᖅᑳᖃᑎᖃᕐᓂᖅ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ᓄᖅᑲᖅᑎᑕᐅᓂᖅ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ᖁᔭᓈᖅᑕᐅᔪᑦ ᓂᕆᔭᒃᓴᑦ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ᓄᖅᑲᖅᑎᓪᓗᒍᑦ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_jv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_jv.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Peringatan",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Sampul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih kabeh",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ndeleng munggah",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Goleki ing web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Bagéyan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Pemberhentian",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu ora dilakoni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Mbatalake",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kab.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kab.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tẓegger",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tameẓla",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Taɣawsa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select akk",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Muqel ɣer lqaεa",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Afed deg web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ssekni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ad d-yeǧǧ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ad d-yeǧǧ adlis",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ad t-tekkes",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kac.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kac.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Chyeju Dum",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kaja ai lam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy galaw",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Hkrak",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yawng hpe lata u",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Yu u",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Internet kaw tam u",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Hkawp",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Jahten kau ai lam",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu hpe jahkrat kau",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Galaw kau",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kam.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kam.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kũsiw'a",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ĩvathũkany'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Ĩĩ, nĩ ya w'o.",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Ĩnyunga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ũnyuve onthe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Sisya ĩũlũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Mantha ũvoo ũla wĩ vo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kũĩva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kũeka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ĩvathũkany'a maũndũ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kũvetanga",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kbp.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kbp.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tʋma wena awɛ yɔ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Pɩɩwɛɛ se pɛlɛɣzɩ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Pɩsɩ takayɩhayʋʋ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ñɔɔzɩ tɔm tɩŋa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kpaɣ nɛ ŋna",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Ñɩnɩ intɛrnɛɛtɩ lone taa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ñɩnɩ ɖama",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Lɩzɩ-ɩ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ñɔɔzɩ tɔm",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kʋyɩ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kea.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kea.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tudu algen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopiadu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pásta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleksa tudu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Odja na kel lugar li",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Buska na internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Partilha",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dispensa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu di diziginason",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kansela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kg.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Bangibusa",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Katula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kubaka yo",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Bima ya kutula",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pona yonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tala na zulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sosa na Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kabula",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kubuya",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Katula menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kuzenga",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_khk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_khk.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ухаалтыг",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Хөрөгдөл",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Хөгжүүлэн",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Хөгжил",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бүх сонго",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Үргэлж үзээрэй",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Интернэтээр хайж үзээрэй",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Хөдөлмөр",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Хөдөлмөрийг хая",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Хөдөлмөрийн жагсаалтыг хая",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Халдах",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ki.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ki.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kũmenyithia",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kũgũrũ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kũrita",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Gĩthaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Thuura ciothe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Rora igũrũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Rora ũhoro thĩinĩ wa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kũgayana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kũrekereria wĩra",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Rora mũtaratara",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kũniina",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kmb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kmb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kikalakalu Kia ku Ngi Bhana Dilangelu",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ku batula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kala ki tua mu mona",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Jimbamba",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sola ioso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tala ku thandu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sota mu internete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ku di Bhana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ku Bhana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "O menu ia ku katula o kitadi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kufuta",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_kmr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_kmr.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Hişyarî",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Jê bike",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Jibergirtin",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hemûyan Hilbijêre",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "binihêre",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Li torê bigere",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Parve bike",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ji kar dûr xistin",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menûyê ji kar dernexê",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Betal kirin",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ks.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ks.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "آگأہی کْریو",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "کٹ کْریو",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "کاپی کْریو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "پیسٹْہ کْریو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "تمام ژأریو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ہیور کْریو نظر",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ویب کْریو تلاش",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "شییر کْریو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ڈیسمِس کْریو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مینیو کْریو ڈیسمِس",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ختم",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ku.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ku.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ئاگادارکردنەوە",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "لکاندن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەموو دیاریبکە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "سەیری سەرەوە بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "گەڕان لە وێب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "بەش پێکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "دەرکردن",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "پێڕست دەربکە",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "هەڵوەشاندنەوه",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lg.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Okulabula",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Londa byonna",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tunuulira waggulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Okugoba",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Okusazaamu",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lij.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lij.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Taggia",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copiaçión",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleçionâ tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Gâ â dõ alan,",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cerca into web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Compartiçioin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dismissâ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismissâ o menù",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancelâ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lim.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lim.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Waarsjlaag",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Snij",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selecteer alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kiek op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Zoek op 't web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Verkeersing",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Verwijder menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Annulere",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lmo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lmo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Avvertenza",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copià",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pesta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleziona tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Guarda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cerca in web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Compartiment",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dispensazion",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menù de scancelament",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancelà",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ln.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ln.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Katá",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Poná bato nyonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Talá na likolo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Rechercher le site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kobengana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kobengana menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Boya",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ltg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ltg.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Pazaudynuojums",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Skurstys",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopiejums",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pīsaceņš",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli vysus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Pazaudēsim augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Izpieteit vītā",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pīsadaleit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Atlaidums",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Atlaiduma menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Atceļšona",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ltz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ltz.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Schneiden",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopéiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "All wielt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kuckt op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sich am Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Entlooss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "D' Menü gëtt ofgeschloss",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Annuléiert",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lua.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Dimuija",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Badi bakosa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Dienza mudimu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Kanyenga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sungula bionso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tangila muulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Keba mu site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Difila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dibenga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kusha menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kukumina",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_luo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_luo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Weche ma Ji Wacho",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ng'ado mar ng'ado",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi mar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yier duto",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ne malo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Many weche e Intanet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Miyo Ji",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Golo",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Golo menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Golo",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lus.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Thuhrilhna",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "A hniam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "A zawng zawng thlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "A chunga en rawh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Web-ah zawng",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Hlawhtling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Thlawp",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu paih",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Chhuahchhiat",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lvs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lvs.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Sārkšana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli visus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Izskatīt augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Izmeklējiet interneta",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pievienojiet",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Atkāpšanās",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Atkāpjas menü",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Atcelt",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_lzh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_lzh.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "警",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "切",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "复制",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "糊",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "全选",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "𴏧",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "搜索 Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "共享",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "解雇",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "闭菜单",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "罢之",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mag.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चुनल जाय",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ऊपर देखहो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेब पर खोज करे",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "निरस्त करे",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू के छोड़ दे",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द करे",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mai.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mai.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "चेतावनी",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "काटू",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "कापी करू",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "साटू",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभटा चुनू",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "उप्पर देखू",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेब खोजू",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "साझा",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करू",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू बर्खास्त करू",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द करु",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mg.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Fanairana",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Hetezo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tahadika mitovy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Apetaho",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny zava-drehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Jereo ny tohiny",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Tadiavo ny tranonkala",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Zarao",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Fandroahana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ario ny karazan-tsafidy",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancel",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mi.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Matohi",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "tapahi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tārua",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Whakapiri",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tīpako Katoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tirohia ake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Rapua te tukutuku",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Tohaina",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ākiritia",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ākiritia te tahua",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Whakakore",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_min.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_min.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Pantauan",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Panjang",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tanda-tanda",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Piliah kasadonyo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Liek ateh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Barbagi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Pambuek",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu indak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Batalkan",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mni.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mni.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "এলেক্সন",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "কাৎপা",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "কপী",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "পেস্ত",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "পুম্নমক খনগৎকনি",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ৱাংখৎকদৌরিবশিং",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ৱেবতা থিদোকপা",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "শেল থাদবা",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "লৌথোকপা",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "মেনু থাদোকপা",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "লৌথোকপা",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mos.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mos.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Dɩt-yã",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "B sẽn yã wã",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Sõng-y n deeg-y-yã",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Dɩt-y n ges-y",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi b fãa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ges-y n gese.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Bao-y Internetã pʋgẽ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "D pʋɩ-ta ne taaba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "B sẽn yiis-a wã",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Yãk-y n yiis-y",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Yãk-y n da wa ye",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mt.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Twissija",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Maqtugħa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Ippejstja",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Agħżel kollox",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Fittex 'il fuq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Fittex fuq il-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Sehem",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Tkeċċi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Neħħi l-menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ikkanċella",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_mww.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_mww.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ceeb toom",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Hlais",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Luam ib daim qauv",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Xaiv tag nrho cov kev xaiv",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Saib",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Nrhiav lub web site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Sib qhia tawm",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "tso tseg",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dhau los tso zaub mov",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "raug muab tso tseg",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_nno.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_nno.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Skjer",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velg alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Sjå opp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sjå på nettet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Deling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kast bort",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Avskjæring",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Avbryt",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_npi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_npi.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "चेतावनी",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कटौती",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "प्रतिलिपि",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सबै चयन गर्नुहोस्",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "माथि हेर्नुहोस्",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेबमा खोज्नुहोस्",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "साझेदारी",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "खारेज",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनु खारेज गर्नुहोस्",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द गर्नु",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_nso.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_nso.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Temošo",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kgaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kgetha ka moka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Lebelela godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Nyakišiša Websaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Khansela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_nus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_nus.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Lätdɛ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kɛn ti̱ ca da̱a̱k",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kä cuɛɛ jɛ cop",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pa̱th",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kɛn diaal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Guic nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Kuɛn rɛy webä",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ŋi̱i̱c",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Lätdɛ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kä cuɛɛ mi̱eth",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Läkdɛ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ny.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ny.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tcheru",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Dulani",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Koperani",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Phala",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani zonse",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Yang'anani m'mwamba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Fufuzani pa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Gawani",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Chotsani",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Chotsani menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kuletsa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_oci.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_oci.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Avís",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cortada",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar totes",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Vòli sus",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Recercar sul web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Compartilhar",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dissar",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú de descart",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancellar",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_om.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_om.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select All",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Look Up",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Search Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share...",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancel",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_otq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_otq.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ar nja̲pu̲",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tu̲ki",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pegar",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar ga̲tho",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Honi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Honi ar web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "T'uni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Despedir",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú Descartar",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancelar",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_pag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_pag.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Pangitok",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Apatalos",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Manpili na amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Manengneng ka ed tagey",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Man-search ed web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Manpabiskegen",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ibatik",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "I-dismiss so menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "I-cancel",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_pap.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_pap.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ta ta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccioná tur",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Wak ariba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Busca riba web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Compartiendo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Descarga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dispensa menú",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_pbt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_pbt.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "د خبرداری",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "د ټوټې کولو لپاره",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "د دې د ثبت کولو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "د پټو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ټولې ټاکل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "پورته وګورئ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "په ویب کې لټون وکړئ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "د شریکولو لپاره",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "د ګوښه کولو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "د ډیسک مینو له منځه وړل",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "د تادیې لغوه کول",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_pes.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_pes.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "هشدار",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "قطع",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "کپی شده",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "همه را انتخاب کنید",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "نگاه کن بالا",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "در اینترنت جستجو کنید",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "اخراج",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "منو رد کردن",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "لغو کردن",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_plt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_plt.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Fampitandremana",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Famoahana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Fandikana",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Fitaovana",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny rehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Jereo ny ambony",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Mitadiava ao amin'ny aterineto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Mizara",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Fandosirana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fanamarihana",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Fanamarinana",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_prs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_prs.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "هشدار",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "برش",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "کپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "خمیر کردن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "انتخاب همه",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "بالا را نگاه کنید",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "جستجو در وب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "اخراج",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "فهرست رد",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "لغو کردن",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_rn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_rn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Kugabisha",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamwo vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Raba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Gusangira",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kwirukana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Guhagarika",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_rw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_rw.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerte",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamo byose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Reba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Shakisha urubuga",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kwirukana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Hagarika",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_sag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_sag.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerte",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "A fâ ni",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "A-Code",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "A yeke zia ni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Soro aye kue",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Bâ ndo na nduzu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Gi na ndo ti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kangbi ni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "A bi ala na gigi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Gbu menu ni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "A yeke zi ni",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_san.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_san.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "सतर्कता",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "कटान",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "अनुच्छेदः",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "पस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "सर्वम् निवस",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "अपरं पश्य",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "वेबं सर्च",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "साझा करना",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "निषेधः",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "निषेधमेनु",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "रद्द",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_scn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_scn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Avvisu",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tagghiatu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copiu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezziunate tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Guarda 'n alto",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cercate in u web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Cumpartiri",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Disponibili",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu di scaricatu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Annullari",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_sd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_sd.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "الرٹ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ڪٽي",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "نقل ڪريو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "پيسٽ ڪريو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "سڀ چونڊيو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "مٿي ڏسو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ويب ڳوليو",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "حصيداري ڪريو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "خارج ڪريو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مينيو کي رد ڪريو",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "منسوخ ڪريو",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_shn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_shn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "လွင်ႈသတိ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ၶၼ်ဢဝ်",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "မဵတ်ႉ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "လိူၵ်ႈဢဝ် တင်းမူတ်း",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "တူၺ်းၼိူဝ်",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "လဵပ်ႈႁဵၼ်းၼႂ်းဝႅပ်ႉသၢႆႉ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ၽႄ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "လွင်ႈပႅတ်ႈ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "မႅၼ်ႇယူဝ်ႇယဵမ်ႈ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ပႅတ်ႈ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_sm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_sm.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Mataala",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tipi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Faapipii",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Filifili uma",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Vaai i luga",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Su'e i luga o le upega tafa'ilagi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Faasoa atu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Fa'ate'a",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Faalēaogāina le lisi autu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Fa'alēāogāina",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_sn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_sn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Yambiro",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cheka",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sarudza zvese",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tarisa kumusoro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Tsvaga iyo webhu",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Goverana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kudzinga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dzinga menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kanzura",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_so.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_so.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Nuqul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Dalbo dhamaantood",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kor u eeg",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Raadi shabakadda internetka",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Eryid",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Eryidda menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Jooji",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_srd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_srd.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tagliu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copia de su nùmeru",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select all",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Iscuras su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Proare in sa web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Compartire",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Iscarrigare",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Discludere su menù",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Annullare",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ss.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ss.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Sicwayiso",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kugawulwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Ikhophi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Umutsi",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetsa tonkhe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Buka etulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sesha ku-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kuyekela",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Khetsa imenyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kuyekela",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_st.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_st.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tlhokomeliso",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Khaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kopitsa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Ho beha",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha tsohle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Sheba holimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Arolelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ho leleka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Leleka menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Hlakola",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_su.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_su.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Perhatosan",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Sampel",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih sadaya",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Tingali nepi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Milarian dina wéb",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Bagikeun",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ngaleungitkeun",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu pikeun nyingkahan",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ngabatalkeun",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_szl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_szl.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Wymŏżŏ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Przeciynty",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kōmprōj",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pasyjo",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wybierz wszyjske",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Wiyź na górã",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Szukaj we internecie",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Dziel sie",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ôdpuszczōny",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ôdmiyniać menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Zaneckować",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_taq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_taq.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ⴰⵏⴳⴰⵍ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ⵜⴰⵔⵔⴰⵜ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⴰⴱⵉⵍⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "ⵜⴰⵔⵔⴰ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⵢⵍⵜ ⴰⴽⴽⵡ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ⴰⴾⴰⵍ ⵉⵉⵉⴰⵏ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵡⴰⵏⵉⵜⵉⵔ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ⵜⴰⵔⴳⴰ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ⴰⵙⵏⴼⵍ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ⴰⵎⴰⴳⵔ ⵏ ⵓⵙⵏⴼⵍ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ⴰⵙⴼⵙⵔ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tg.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Огоҳинома",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Тақсим",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Нусхаи муаллифӣ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ҳамаро интихоб кунед",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Ба боло нигаред",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Дар интернет ҷустуҷӯ кунед",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Мубодила",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Барканор кардан",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Менюи радкунӣ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Таълиф кардан",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ti.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ti.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "መጠንቀቕታ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ቍረጽ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ቅዳሕ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "መቐመጢ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ንዅሉ ምረጽ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ናብ ላዕሊ ጠምት",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ነቲ መርበብ ሓበሬታ ድለዮ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ንኻልኦት ኣካፍሎም",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ካብ ቤት ካባና ተሰጐ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ዝርዝር ኣወጻጽኣ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ደምስስ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tk.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "hüşgär",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "gyrkmak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "nusgala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "ýelmemek",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ehlisini Saýla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "seretmek",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Webi Ahtar",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "paýlaşmak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "işden aýyrmak",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menýuny ýapmak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ýatyrmak",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tlhagiso",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tlhopha sengwe le sengwe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Leba kwa godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Tlosa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Phimola",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_to.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_to.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Fakatokanga",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tuʻusi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tatau",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Fili kotoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Sio hake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Fekumi ʻi he uepisaiti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Vahevahe",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Tukuange",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tukuange ʻa e menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kaniseli",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tpi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tpi.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Tok lukaut",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kisim ol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Tok bilong en",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pas",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Putim olgeta",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Lukim antap",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Ritim long web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ol i save kisim ol samting",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Tok i No Kisim",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Toksave long ol samting",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kisim bek",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ts.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ts.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Xitsundzuxo",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ku tsemiwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Ku kopa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Xitlhoma-ndzeni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hlawula Hinkwaswo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Languta ehenhla",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Lavisisa eka Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ku Avelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ku Lahliwa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tsala ehansi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Ku Tsema",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tt.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ачыклык",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Кисү",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Күчермә",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Паста",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Барысын да сайлап алу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Югарыга карагыз",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Интернетта эзләү",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Уртаклашу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Эштән чыгару",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Меню ябылу",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Баш тарту",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tum.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tum.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Chenjezo",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Kupalasa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Kupokera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Kupaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Wukani",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Penjani pa Intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Kugaŵana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Kulekerathu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Chinthu chinyake",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Kulekeska",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tw.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ɛbɔ a Ɛbɔ no Hyɛ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Wodi mu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Wɔahyehyɛ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Nkyene",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Paw nyinaa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Hwehwɛ soro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Hwehwɛ Intanɛt so",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Fa no",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "W'ayi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fa no kɔ baabiara",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Sɛe",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ty.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ty.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Tapu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Hoho'a",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Te mau nota",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ma'iti i te taatoaraa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Hi'o i ni'a",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Ma'imi i ni'a i te Itenati",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Faaite",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Te faarueraa i te haapiiraa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tabula ohipa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Faaoreraa hapa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_tzm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_tzm.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ⴰⵙⵏⵖⵎⵙ",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "ⴰⵖⵔⴼ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⵓⴱⵉⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "ⵜⴰⴱⵔⴰⵜ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⴰⵢ ⴽⵓⵍⵍⵓ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "ⴰⵥⵕ ⵙ ⵓⵍⵍⴰⵙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵓⵙⵉⵜ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "ⴰⵙⵎⴹⴰⵍ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "ⴰⵙⵏⴼⵍ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ⴰⵙⴳⵓⵎ ⵏ ⵓⵙⵙⵓⴼⵖ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "ⴰⵙⴼⵙⵔ",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_umb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_umb.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ovikele",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Oku teta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Ocisonehua caco",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Oku kapa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Nõla ovina viosi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Liwekapo oku tala",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Sandiliya vo Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Oku Pongolola Oluali",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Oku Puluka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ku ka ecelele oku kongeliwa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Oku liwekapo",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_uzn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_uzn.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ogohlantirish",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Qitish",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Koʻchirilgan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Past",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hamma tanlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Yuqoriga qarang",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Internetda qidirish",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Bajarish",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Qutqarish",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Manunichalarni bekor qilish",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "bekor qilish",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_vec.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_vec.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Aviso",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selesionar tuti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "varda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cerca su la rete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Partage",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dispensa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menù Dispensa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Cancellar",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_war.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_war.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "An Alert",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Pag-ihap",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili han ngatanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kitaa an imo mga mata.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Pag-usisa ha Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Pag-undang",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pag-iwas han Menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Pag-abre",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_wo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_wo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Xët yi ci wàll gi",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Jëf-jëf",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Jëf",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Jëfalu yépp",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Xoollu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Xët ci web bi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Di bokk",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Di dëddu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Jëfandikukat",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Di dëddu",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_xh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_xh.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Isilumkiso",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Sika",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Khuphela",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Cola",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha zonke",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Jonga phezulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Isetyenziswa ngokwemigqaliselo zichazwe akwi-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Ukugxotha",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Susa imenyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Rhoxisa",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ydd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ydd.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "ווארענונג",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "שנייַדן",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "קאָפּע",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "פּאַס",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "אויסקלייַבן אַלע",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "קוק אַרויף",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "זוכן אין די וועב",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "טיילן",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "באַפרייַען",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "אָפּזאָגן מעניו",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "קאנסעלירן",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_yo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_yo.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ìtanijí",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Gé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Ṣẹ̀dà",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Lẹ̀",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yan gbogbo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Wo òkè",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Ṣawari oju-iwe ayelujara",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Pin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Dá wọn sílẹ̀",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pa àtòjọ-ẹ̀yàn tì",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Paá rẹ́",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_yua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_yua.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Ts'aaj",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Ch'ak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Jats'ik",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar tuláakal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Kaxan",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Kaxant ti' le web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Ts'aaj",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Despedir",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú Descartar",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Xu'uls a meyaj",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/cupertino_zsm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_zsm.arb
@@ -1,0 +1,216 @@
+{
+  "@datePickerHourSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOne": "$hour o'clock",
+  "@datePickerHourSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerHourSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerHourSemanticsLabelOther": "$hour o'clock",
+  "@datePickerHourSemanticsLabel": {
+    "description": "Accessibility announcement for the selected hour on a time picker such as '5 o'clock' or '5点'",
+    "plural": "hour"
+  },
+  "@datePickerMinuteSemanticsLabelZero": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOne": "1 minute",
+  "@datePickerMinuteSemanticsLabelOne": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelTwo": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelFew": {
+    "optional": true
+  },
+  "@datePickerMinuteSemanticsLabelMany": {
+    "optional": true
+  },
+  "datePickerMinuteSemanticsLabelOther": "$minute minutes",
+  "@datePickerMinuteSemanticsLabel": {
+    "description": "Accessibility announcement for the selected minute on a time picker such as '15 minutes' or '15分'",
+    "plural": "minute"
+  },
+  "datePickerDateOrder": "mdy",
+  "@datePickerDateOrder": {
+    "description": "Choose a standard order for the locale to arrange day, month and year in a date. Do not transliterate the abbreviations themselves. The only options are dmy, mdy, ymd and ydm. For instance, in French, use dmy (for day month year) but do not translate into jma (for jour mois année). "
+  },
+  "datePickerDateTimeOrder": "date_time_dayPeriod",
+  "@datePickerDateTimeOrder": {
+    "description": "Choose a standard order for the locale to arrange date, time and am/pm in a datetime. Do not transliterate the choices themselves. The only options are date_time_dayPeriod, date_dayPeriod_time, time_dayPeriod_date and dayPeriod_time_date where 'dayPeriod' is am/pm. You can ignore the position of dayPeriod if the locale uses 24h time only. For instance, in French, use date_time_dayPeriod, but do not translate into date_heure_périodeDuJour or some such."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker when it's not using the 24h format. Reference the text iOS uses such as in the iOS clock app."
+  },
+  "todayLabel": "Today",
+  "@todayLabel": {
+    "description": "A label shown in the date picker when the date is today."
+  },
+  "alertDialogLabel": "Peringatan",
+  "@alertDialogLabel": {
+    "description": "The accessibility audio announcement made when an iOS style alert dialog is opened."
+  },
+  "tabSemanticsLabel": "Tab $tabIndex of $tabCount",
+  "@tabSemanticsLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'tab, 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "@timerPickerHourLabelZero": {
+    "optional": true
+  },
+  "timerPickerHourLabelOne": "hour",
+  "@timerPickerHourLabelOne": {
+    "optional": true
+  },
+  "@timerPickerHourLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerHourLabelFew": {
+    "optional": true
+  },
+  "@timerPickerHourLabelMany": {
+    "optional": true
+  },
+  "timerPickerHourLabelOther": "hours",
+  "@timerPickerHourLabel": {
+    "description": "The label adjacent to an hour integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "hour"
+  },
+  "@timerPickerMinuteLabelZero": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOne": "min.",
+  "@timerPickerMinuteLabelOne": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelFew": {
+    "optional": true
+  },
+  "@timerPickerMinuteLabelMany": {
+    "optional": true
+  },
+  "timerPickerMinuteLabelOther": "min.",
+  "@timerPickerMinuteLabel": {
+    "description": "The label adjacent to a minute integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "minute"
+  },
+  "@timerPickerSecondLabelZero": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOne": "sec.",
+  "@timerPickerSecondLabelOne": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelTwo": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelFew": {
+    "optional": true
+  },
+  "@timerPickerSecondLabelMany": {
+    "optional": true
+  },
+  "timerPickerSecondLabelOther": "sec.",
+  "@timerPickerSecondLabel": {
+    "description": "The label adjacent to a second integer number in a countdown timer. The reference abbreviation is what iOS does in the stock clock app's countdown timer.",
+    "plural": "second"
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "clearButtonLabel": "Clear",
+  "@clearButtonLabel": {
+    "description": "The label for clear buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih semua",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items. The reference abbreviation is what iOS shows on text selection toolbars."
+  },
+  "lookUpButtonLabel": "Lihat ke atas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items on iOS."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items on iOS."
+  },
+  "shareButtonLabel": "Berkongsi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items on iOS."
+  },
+  "noSpellCheckReplacementsLabel": "No Replacements Found",
+  "@noSpellCheckReplacementsLabel": {
+    "description": "The label shown in the text selection context menu on iOS when a misspelled word is tapped but the spell checker found no reasonable fixes for it."
+  },
+  "searchTextFieldPlaceholderLabel": "Search",
+  "@searchTextFieldPlaceholderLabel": {
+    "description": "The default placeholder label used in an iOS styled search bar."
+  },
+  "modalBarrierDismissLabel": "Putus",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can, for example, be found behind an alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu menolak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "cancelButtonLabel": "Batalkan",
+  "@cancelButtonLabel": {
+    "description": "Label for the cancel button in modal views."
+  },
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Label for the back button. Used as the semantic label for the back button in CupertinoNavigationBar and CupertinoSliverNavigationBar and as a fallback display when the previous page title is truncated."
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded CupertinoExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed CupertinoExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed CupertinoExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded CupertinoExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when an expanded CupertinoExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the CupertinoExpansionTile state when a collapsed CupertinoExpansionTile is pressed."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_acm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_acm.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "خريطة التنقل المفتوحة",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عُود",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضح",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريب",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "أكثر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر القادم",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحة سابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الاولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الأخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو قائمة",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "مُحَرّر",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورق أسفل",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "الرخصات",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "الصفوف لكل صفحة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريب",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "استمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطْفُ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "نصيّة المسح",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "المشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "حسناً",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "عرض الترخيصات",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "اختر ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقائق",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "الرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خريط القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "السنة المختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ غير محدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فاصل التاريخ غير المحدد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "إدخال التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "صيغة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصل التاريخ غير الصالح",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "التاريخ خارج النطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "خزن",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اختر التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "اختروا النطاق",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "اغترق لنظام التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "اغترق لنظام التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر الوقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "وقت الدخول",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقه",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "الزمنية غير صالحة",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "اغترق لنظام الرقم",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "اغترق لنظام الوقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "اخف الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "عرض الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "قائمة التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط الوجبات",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "قائمة المخرجات",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "الحوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "التاريخ الحالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "التاريخ المختاره",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تحرك إلى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزلوا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرّك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "التجديد",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "الـ الـ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل الحجاب",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "القناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "إفراج",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "نهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "الهروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "الوطن",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "الميتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "النوافذ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفل رقم",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمَبَاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نُمَبَاد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نُمَبَاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نُمَبَاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمَبَاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نُمَبَاد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نُمَبَاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نُمَبَاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "إضافة Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كومة نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "العشرية المُتَعَدّة",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "شقّة النّومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "دخول المفروض",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمَبَاد مساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ضربة نُمباد",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نُمباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نُمَبَادَ بارين اليمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "خفض النمباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "الصفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "الصفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "الطاقة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "التيار خارج",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشة طباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل المتحرر",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختر",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "النقابة",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_acq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_acq.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "قائمة التنقل المفتوحة",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عود",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضح",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريب",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "اكثر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر القادم",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحة سابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الاولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الاخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو شوط الموجات",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "مساحة",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورقة أسفل",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "رخص",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "صفوف لكل صفحة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريب",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "استمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "رسالة مسح",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "اوك اوك",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "عرض رخص",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ام",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "اختار ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقائق",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ترحيل",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ارفض القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سنة مختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ غير محدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فاصل التاريخ غير المحدد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ادخل التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "صيغة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصل التاريخ غير صالح",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاريخ خارج نطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "حفظ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اختر التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "اختروا المجموعة",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "اتبدى لوضع التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "اتبعد لوضع التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر وقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ادخل الوقت",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقه",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "وقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "اتبدى لوضع المفتاح",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "اتبدى لوضع الوقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "تخفي الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "شوف الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "قائمة التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط الوجوه",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "قائمة المفاجئ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "الحوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاريخ حالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "التاريخ المختار",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل الى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل للأسفل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "التجديد",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "التاكسي",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل الحجابات",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "القناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "النهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "الهروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "البيت",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ميكرو",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "نافذة",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفل رقم",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمَبَاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نُمَبَاد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نُمَبَاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نُمَبَاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمَبَاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نُمَبَاد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نُمَبَاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نُمَبَاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "إضافة Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كومة نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "رقم عشري",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسيم النومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "دخول نومباد",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمَبَاد مساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نومباد مضاعف",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نومباد بارين يمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "سحب نومباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "الصفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قوة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "انقطاع الطاقة",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشة طباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل المجلد",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختر",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "نوبة",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_aeb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_aeb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مينو الملاحة مفتوحة",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عُودِين",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضحة",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريبا",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "مَحْذُوفْ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "أكثر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر الجاي",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "الصفحة السابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الأولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الأخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو مينو",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "سكرم",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "سلاسلة تحتية",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "تراخيصات",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "طوابع في صف:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريبا",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "إستمع",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "كُنْتِ تَمْرِي",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطِّطْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "سكان نص",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "إطلعو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "فَتِّشْ فِي الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "شُرْكُوا",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "باهي",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "فستة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختروا الكل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "شوف تراخيص",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "خُذْ الوَقْتْ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اخترو مكاتب",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "طرد",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مَنْطِقْ القُدْسْ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سَنَة مُخْتَارَة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ ما يُحددْ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فاصلة متاع التاريخ ما ما تُحدد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "إدخال التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "فورتة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصلة التاريخ غير صالحة",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاريخ خارج من المدى",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "خليلي",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اخترو تاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "خُترْ المُدَّة",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "تغيّر لوضع تقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "تغيّر لوضع تاريخ الإدخال",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر وقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "وقت دخول",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقة",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "وقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "تغيّر لوضع المخطط",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "تغيّر لوضع وقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت في",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "خفي الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "عَرِّفْ الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ميني التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "بار الموجات",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ميني باڤ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "الحوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تنبيهات",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاريخ الحالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "تاريخ المختارة",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "تمشي للبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تمشي لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "إتحركوا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزلوا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تمشي لليسار",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تمشي يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "مُتَجَدِّدْ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "التا",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "التا جراف",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "فاصلة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "كابيس لاك",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "القناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "القيادة",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "مَحْذُوفْ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "النهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "هربوا",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "بيتك",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "مِيتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "النوافذ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "نوم لاك",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمَبَاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نُمَبَاد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نُمَبَاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نُمَبَاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمَبَاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نُمباد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نُمَبَاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نُمَبَاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "نومباد إضافة",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كما نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "نُمْبَاد دِشِمَالْ",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "نُمَبَادْ يُقْسِمْ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "نومباد إدخل",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمَبَاد متساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نومباد مضاعفة",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نومباد بارين رَاه",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "نومباد سبترا",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "القوة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "الكهرباء مُطفلة",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "طباعة شاشة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "سكرول لاك",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختروا",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "المرحلة",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_als.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_als.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menyu i hapur i navigacionit",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kthehu",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "E qartë",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Afër",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Fshihet",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Më shumë",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Muaji i ardhshëm",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Muaji i kaluar",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Faqja tjetër",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Faqja e mëparshme",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Faqja e parë",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Faqja e fundit",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Shfaqja e menujit",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Shkrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Shtresa e poshtme",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenca",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rregullime për faqe:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kanclojnë",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Afër",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Vazhdo",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopje",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Të prerë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tekst i skanuar",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Shiko lart.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kërkoni në internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ndarja",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Mirë.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zgjidh të gjitha",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Shikoni licencat",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Kryeministri",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Zërat e zgjedhur",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Vlen minutat",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Shkarkimi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menyu i shkarkimit",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Vit i zgjedhur",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data e paqartë",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Rasti i datave të pacaktuara",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Të hyjë data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data e fillimit",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data e përfundimit",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data e fillimit $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data e përfundimit $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format i pavlefshëm i datës",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Rasti i datës së pavlefshme",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data jashtë rreze",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Shpëto",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Vlen datë",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ZBJETË",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Shift në modin e kalendarit",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Shift në reaktivi të datës së hyrjes",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Zgjedhni kohën",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Të futesh kohën",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutë",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Koha e pavlefshme",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Shift në modin e numrit",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Shift në modin e kohës së hyrjes",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "I nënshkruar",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Mbulo llogari",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Shfaqja e llogarive",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menyu i navigimit",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barre e menujve",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menyu i shkarkuar",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kërkim",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data aktuale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data e zgjedhur",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Të lëvizësh për të filluar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Shko deri në fund",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ngrihu lart.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Shko poshtë.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Shko në të majtë",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Shko drejt.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Rresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafi Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Hapësira e pasme",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapsulë të mbyllur",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal poshtë",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal lart",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrolli",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Fshihet",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Shkarko",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fundi",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Largimi",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Shtëpi",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Shpërthimi",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandimi",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Dyer",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Komat e Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numrat e numrat e numrave",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad e barabartë",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Lidhur",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren e drejtë",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtracta e Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Faqja poshtë",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Faqja lart",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Fuqia",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Shkarkimi i energjisë",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ekran printer",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Shklosje e rrotullës",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Vlen",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Hapësira",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_apc.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_apc.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مينو التنقل المفتوح",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عود",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضحة",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريب",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حط",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "أكتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر الجاي",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحة سابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الأولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "آخر صفحة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو مينيو",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "مساحة",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورقة أسفل",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "رخصات",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "صفوف لكل صفة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريب",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "إستمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نطاق",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "متن المسح",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "طيب .",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "البصمة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "شوف رخصات",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "اختر ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقيقات",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "إرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خريط القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سنة مختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ غير محدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "نطاق التاريخ غير محدد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "إدخال التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "صيغة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصل التاريخ غير صالح",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاريخ خارج نطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "خلي",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اختر التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "خيارات المجموعة",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "إنتقل لوضع التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "إنتقل لوضع التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر وقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "إدخال الوقت",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقة",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "وقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "قم بطرق المفتاح",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "إنتقل لوضع الوقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "خفي حسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "شوف الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "مينو التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط الوجبات",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "مينو المفتوح",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "الحوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تنبيهات",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "بحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاريخ حالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "تاريخ المختار",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "حرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرك لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "إتحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "حرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "حرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "إعادة التأرجح",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "الـ (الت)",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلف",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل القابيس",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "قناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حط",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "النهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "هروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "بيتك",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ميكرو",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "النوافذ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمَبَاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نومباد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نومباد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نومباد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمَبَاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نومباد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نومباد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نومباد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كاما نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "نومباد ديسيمال",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسيم النومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "نومباد إدخال",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نومباد متساو",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نومباد مضاعف",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نومباد بارين يمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "خفضة النومباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قوة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "إضرارات الطاقة",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "برنامج طباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "طحالب المفتاح",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "حدد",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "النقابة",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "المساحة",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ars.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ars.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "قائمة التنقل المفتوحة",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عود",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضح",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريب",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "المزيد",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر القادم",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحة سابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الاولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الأخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو شوط الموجات",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "شربة",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورقة أسفل",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "رخصات",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "طوابع لكل صفحة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريب",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "استمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "مسح نص",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "اوك اوك",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "عرض رخصات",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ام",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "اختار ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقائق",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ترحيل",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "خفيف القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سنة مختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ غير محدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فترة التاريخ غير المحددة",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ادخل التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "صيغة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصل التاريخ غير صالح",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاريخ خارج نطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "حفظ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اختر التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "اختروا المجموعة",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "اتبعد لوضع التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "اتبعد لوضع التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر الوقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ادخل الوقت",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقة",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "وقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "اتبدى لوضع المفتاح",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "اتبعد لوضع الوقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "تخفي الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "عرض الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "قائمة التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط الوجبات",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "قائمة المفروشات",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "حوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاريخ حالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "التاريخ المختار",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "انتقل لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل الى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "انتقل يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "إعادة التأقلم",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "التا",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل الحجاب",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "قناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "نهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "الهروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "البيت",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ميكرو",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "نافذات",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفل رقم",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمَبَاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نُمباد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نُمَبَاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نُمَبَاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمَبَاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نُمباد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نُمَبَاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نُمَبَاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "إضافة Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كومة نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "رقم عشري",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسيم النومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "دخول نومباد",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمَبَاد مساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نومباد مضاعف",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نومباد بارين يمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "سحب نومباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قوة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "انقطاع الطاقة",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشة طباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل طاحون",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختر",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "نوبة",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ary.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ary.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مينو التنقل المفتوح",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "رجعوا",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضحة",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريبا",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "مُحْذُوفْ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "أكثر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر الجاي",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر السابق",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "الصفحة السابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الأولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الأخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو شوط الموجات",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "التشريع",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "الصفحة السفلية",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "الترخيصات",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "الصفوف لكل صفحة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريبا",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "استمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطّْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "فديو النص",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "بحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "الشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "حسناً",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "شوف الترخيصات",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "اختر ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقائق",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "الرفض",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "طرد القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "السنة المختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "التاريخ غير المحدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فترة التاريخ غير المحددة",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "دخل التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "التاريخ النهائي",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "التاريخ النهائي $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "فورت التاريخ غير صالح",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فترة التاريخ غير صالحة",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "التاريخ خارج النطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "خلي",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "اختر التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ختروا المجموعة",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "غير لوضع التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "مشى لوضع التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر الوقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "دخل الوقت",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "الساعه",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقة",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "الوقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "غير لوضع الرقم المتحرك",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "غير لوضع الوقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "مُوقّعْ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "خفي الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "شوف الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "القائمة التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط القائمة",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "قائمة المخرجات",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "الحوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "التنبيه",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "التاريخ الحالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "التاريخ المختار",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تمشي لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "خلي لخلا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرك لليسار",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "التجديد",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "التاغ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل القبضات",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "القناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "مُحْذُوفْ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "النهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "الهروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "البيت",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "الميتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "النوافذ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفل رقم",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "النومباد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نومباد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نومباد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نومباد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نومباد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نومباد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نومباد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نومباد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نومباد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نومباد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "إضافة Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كما نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "العشريات المفروضة",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسيم النومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "دخلوا",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نومباد مساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ضربة نومباد",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نومباد بارين يمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "خفض النومباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "الصفحة التالية",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "الصفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "الطاقة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "التيار خارج",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشة الطباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل المجلد",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختر",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "التحول",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_arz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_arz.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مينو التنقل المفتوح",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "عودت",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضحة",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "قريبة",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "أكتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "الشهر الجاي",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "الشهر اللي مضى",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "الصفحة التالية",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحة سابقة",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "الصفحة الاولى",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "الصفحة الأخيرة",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "شو مينو",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "مساحة",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورق أسفل",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "رخصة",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "الصفوف لكل صفحة:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "إلغاء",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "قريبة",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "استمر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نُسُخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "مسح نص",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "اوك اوك",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "عرض رخصات",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ام",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "رئيس الوزراء",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "حدد ساعات",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "اختر دقيقه",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "إرفاق",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "إرفض القائمة",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سنة مختارة",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاريخ مش محدد",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "فاصل التاريخ اللي مش محدد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "أدخل التاريخ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ البدء",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاريخ النهاية",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاريخ البدء $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاريخ النهاية $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "صيغة التاريخ غير صالحة",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "فاصل التاريخ غير صالح",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاريخ خارج النطاق",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "خفيه",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "حدد التاريخ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "حدة اختر",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "اتبدى لوضع التقويم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "اتبدى لوضع التاريخ المدخل",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "اختر وقت",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "وقت دخول",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعة",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقة",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "وقت غير صالح",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "اتبدى لوضع المفتاح",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "اتبدى لوضع وقت المدخل",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "وقعت في",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "مخبأ الحسابات",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "اشوف الحسابات",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "مينو التنقل",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "شريط الوجبات",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "قائمة المخرجات",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "حوار",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "تحذير",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "البحث",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاريخ حالي",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "التاريخ المختار",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "حرك ليبدأ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "اتحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "اتحرك أسفل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "اتحرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "اتحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "التجديد",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "متغيرات",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "الرسم البياني التالي",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "مساحة الخلفية",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل الكابيس",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "قناة أسفل",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "قناة فوق",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "التحكم",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "طرد",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "النهاية",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "الهروب",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "بيتك",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "إدراج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ميتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "القيادة",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "نوافذ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمَبَاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمَبَاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "كومة نومباد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "رقم عشري",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "انقسم النومباد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمَبَاد مساوية",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نُمَبَادُ ضَرْبَة",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نومباد بارين يسار",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren يمين",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "سحب نومباد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحة أسفل",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحة فوق",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قوة",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "اقتناع",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشة طباعة",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل المجلد",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "اختر",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "شفط",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "الفضاء",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ayr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ayr.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menú de navegación jistʼaraña",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Qawqha pachatsa",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Qhanañchasiña",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Jank'aki",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Chhaqtayani",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Juk'amp",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Jutïr phajjsinjja",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Nayra phaxsi",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Jutïr pajjsïwi",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Nayrïr uñnaqa",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Nayrïr uñch'uki",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Qhipa pajjsa",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Manü uñachtʼayaña",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Q'ipinak q'ipinak",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Q'umachata",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "$modalRouteContentName jan uñt 'ayapxamti",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencianakapa",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Sapa página tuqita:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Q'alpun apsuta",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Jank'aki",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Jank'ak sarnaqañ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kunjamtï amuyki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Q'ipisiña",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Kunatix qillqtʼatäki uk uñakipjjañäni",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Amuyasipxam",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internetan thaqhapjjam",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Mayt'aña",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Walikiwa",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Jisk'a ch'uqt'añ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taqpach ajllipxam",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Licencianak uñakipañ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Jilïr Irpirix",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kunapachatï waktʼki uk ajllipjjañäni",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Wakichata",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Q'umachata",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Manü apanukuñ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Yatiyañataki",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Jan uñt'at urüki",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jan uñt'at urunaka",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Taripäwinaka",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Qalltanäwi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Qhipa urunaka",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Qalltanäwi $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Qhipa taripäwi $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Jan walt'ayata taripäwi",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Jan walt'añanakar puriñ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Kunapachasa",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Qhispiyasiñ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Taripäwi ajllipxam",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "LAMPJÄWINAKA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Calendario sarnaqañar sarnaqañ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Kunapachatï apstʼatäki ukhajj",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Kunapachatï waktʼki uk ajllipjjañäni",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kunapachatï mantki",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Kunapachasa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Mä minutot",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Jan walt'añanakan utjañapata",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Q'ipirjam sarnaqañ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Kunapachatï apstʼañäki ukarojj saram",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Amt'asiña",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Conti jan uñtʼayasiñataki",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Akax uñstayaña",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menú de navegación",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu satäki ukata",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Qhipar uñstayaña",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diálogo: aruskipañ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Isthapiwinaka",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kunanaksa thaqhapjjäta",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Jichha pacha",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Taripäwi",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Jaltañ qalltañ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Qhipa tuqir sarnaqañ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "¡Jach'a sarnaqañani!",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Jank'aki sarañani",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kupi tuqir sarnaqañ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kupi tuqir saram",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ch'amañchasiña",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Kunayman",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt grafico",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Qullqi ch'axwanaka",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Q'ipinak jist'antaña",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Qhipar sarañ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Qullqix sartaskiwa",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kunayman ch'aman",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Chhaqtayani",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Q'al chhaqtayani",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Qhipa",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Qullqhi jaltañ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Uta",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Q'ichichasiñatak",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Metajj",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comandantï",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Jallunak",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad ukamp chika",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter sasin",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicas",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ch'iqäx",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren chiqap",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "T'aqanuqtañ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Amtʼañataki",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ch'amanchasiñanaka",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Jan electricus utjkänti",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Qhanancht ' ata",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Q'ipxaruña",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seleccionar sarnaqaña",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kunayman lurañanaka",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Jakaña",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_azb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_azb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "آچیق ناویجیتس مینو",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "گئری دؤن",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "واضح",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "یاخینلاشماق",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "داها چوخ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "آيينجي آييندا",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "اؤنجه آی",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "صاباح صفحه",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "قاباقکی صفحه",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "بیرینجی صفحه",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "آخیر صفحه",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "مینو گؤستری",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "سکرم",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "آلت ورق",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "رخصتلر",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "هر صفحه یه صفلر:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "لغو",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "یاخینلاشماق",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "داوام ائدیر",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نُسخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "کَس",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "متن سکن",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "يوخاري باخ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "اینترنتده آختار",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "بؤلوم",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "باشه",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هامیسی سئچیب",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "مجوزلرین گؤستریلمه سی",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "باش ناظری",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ساعاتینی سئچیب",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "دقیقه لری سئچیب",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "رد",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "رد کردن مینیو",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سئلئکلن ائل",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "معلوم اولماميش تاريخ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "معلوم اولماميش تاريخي",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "تاریخ دن دن دن",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "باشلانما گونو",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "آخيري",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "باشلانما گونو $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "آخيري تاريخ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "فابریکات",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "اعتبارسيز تاريخي آچيقدير",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاریخ ساحه دن چیخمیش",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ساقلاماق",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "تاریخ سئچیب",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "سچه نين سيرا",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "تقویم مودونا گئدیش",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "گئرئش تاریخ مودونا گئدیش",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "واختي سِچ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "واختي گئر",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعات",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقیقه",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "مؤحکم مدت",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "دایره ایله باغلی",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "گئدیش واخت مودونا گئدیش",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "امضا ائتدی",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "حسابلار گئزلَندیر",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "حسابلار گؤرسه ییر",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "یوللاندیرما مینو",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "مینو بار",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "پاپ اپ مینو",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "دیالوگ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "آذر",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "آختارماق",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ایندیکی تاریخ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "سئچئلمیش تاریخ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "حرکت ائدک",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "آخيريندا حرکت ائده",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "حرکت ائده سن",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "آشاغي حرکت ائده",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "سول طرفه حرکت ائده",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ساغ طرفه حرکت ائده",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "تزه لندیر",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "آلتی",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "آلتی گراف",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "آرخاسيز يئر",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قاب قفل",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "کانال آشاغی",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "کانال اون",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کنترل",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "اِشئيه",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "آخیر",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "قاچماق",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ائو",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "یئره سال",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "میتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "فرمان",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "پنجره لر",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نُمپاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نامپاد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نامپاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نُمپاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نامپاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمپاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نامپاد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نُمپاد ۸",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نُمپاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمپاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "نُمپاد کما",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "نُمپاد دَیَسمال",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "نامپاد بؤلوشدور",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نُمپاد برابر",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نُمپاد ضرب",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نامپاد پارن سول",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نامپاد پارن راست",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "نُمپاد سِوْرا",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحه نی آلماق",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحه یئنی",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قدرت",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "برق کسئلسه",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "چاپ صفحه سی",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "رول لوک",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "سئچیب",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "شفقت",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "فضايي",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_azj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_azj.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Açıq naviqasiya menyusu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Geri qayıt.",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Açıq",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Yaxınlaşdı",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Silmək",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Daha çox",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Növbəti ay",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Keçən ay",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Növbəti səhifə",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Öncəki səhifə",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "İlk səhifə",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Son səhifə",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Göstərilən menyü",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Qırmızı",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Alt hissəsi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisenziyalar",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Səhifəyə sətirlər:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "İndirim",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Yaxınlaşdı",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Dövlət",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "İmzala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kəsmək",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Mətn skan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Qula bax.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "İnternetdə axtarış aparın",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Tamam.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Qovşaq",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünləri seçin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "İdarə lisenziyalarını göstərin",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Baş nazir",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seçilən saatlar",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minut seçin",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "İndirmə",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "İndirmə menyusu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seçilmiş il",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Məlumat verilməyən tarix",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Məlumat verilməmiş tarix aralığı",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Gəlin tarix",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Başlama tarixi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Son tarix",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Başlama tarixi $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Son tarix $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Mütləq olmayan tarix formatı",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Mütəxəssislər",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Mətndən kənar tarix",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Qoru",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tarixi seçin",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TƏRKİLƏN",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Qəzet rejiminə keçin",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Giriş tarixinə keç",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Zaman seçin",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Giriş vaxtı",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Saat",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Bir dəqiqə",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ədalətsiz vaxt",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Qeydiyyat rejimi ilə keçin",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Giriş vaxt rejiminə keçin",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "İmzalanmış",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hesabları gizlədirmək",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Hesabları göstərin",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Naviqasiya menyusu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menü çubuğu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menyusu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialoq",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Təhlükəsizlik",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Axtarış",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Hələlik tarix",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Seçilmiş tarix",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Başlamaq üçün hərəkət edin",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Sonuna qədər hərəkət edin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ayağa qalx.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Aşağı gedin.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Soldan hərəkət edin.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sağ hərəkət edin.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Yeniləmə",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Grafi",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Arxa sahə",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapsullar Qapalı",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Aşağı kanal",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Yuxarı kanal",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Nəzarət",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Silmək",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Çıxış",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Son",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Qurtuluş",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ev",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Qeydiyyat",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandanlıq",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Pencerə",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad əlavə",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad bölünür",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad daxil",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad bərabər",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Sol",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren sağ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad azaldılması",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sayt aşağı",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Saytı qaldırın",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Güc",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Elektrik kəsildi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Çap ekranı",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seçim",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Dəyişiklik",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Məkan",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ba.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ba.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Навигация менюһын асыу",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Назад",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Асыҡ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Закрыть",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Удалить",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Подробнее",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Киләһе айҙа",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Үткән ай",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Следующая страница",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Предыдущая страница",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Первая страница",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Һуңғы бите",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Меню күрһәтеү",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Аҫҡы бит",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Лицензиялары",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Строки на страницу:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Бөтөрөргә",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Закрыть",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Дауам итеү",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Күсермәһе",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ҡырҡып алыу",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Тексты сканлау",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Өҫкә ҡарағыҙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Поиск в сети",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Уртаҡлашыу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ЯРАЙ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бөтәһен дә һайлап алыу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Лицензияларҙы ҡарау",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "1990",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Премьер-министр",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Һайланма сәғәттәр",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Һайланма минуттар",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Эштән сығарыу",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Менюнан баш тартыу",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "дд/мм/гггг",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Һайлау йылы",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Дата күрһәтелмәгән",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Даталар диапазоны күрһәтелмәгән",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Введите дату",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Дата начала работы",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Тамамланыу датаһы",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Неверный формат даты",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Неверный диапазон дат",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Дата вне диапазона",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Һаҡлап ҡалыу",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Дата һайлау",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ҺАЙЛАУ ДИАПАЗОНЫ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Календарь режимына күсеү",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Переключиться в режим ввода даты",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Ваҡыт һайлау",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Введите время",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Сәғәт",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Минут",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Дөрөҫ булмаған ваҡыт",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Переключение в режим набора",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Инеү ваҡыты режимына күсеү",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Автор",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Йәшереү аккаунттары",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Аккаунттарҙы күрһәтеү",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Навигация менюһы",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Меню строкаһы",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Pop-up меню",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Диалог",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Эҙләү",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ағымдағы дата",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Һайланған дата",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Башҡа күсереү",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Аҙағынаса күсереү",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өҫкә күтәрелеү",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Аҫҡа күсереү",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Һулға күсереү",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Уңға күсереү",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Яңыртыу",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Альт",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Альт-граф",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Капс лок",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Канал вниз",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Канал Вверх",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Идара итеү",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Удалить",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Катапультлау",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Конец",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ҡасыу",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Фн",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Өй",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Вставка",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Мета",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Командованиеһы",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Тәҙрәләр",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "1 - се һан клавиатураһы",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "2-се һан клавиатураһы",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Һан диаграммаһы 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "5-се һан клавиатураһы",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Һан клавиатураһы 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Һан Клавиатураһы 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "8-се һан клавиатураһы",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Унарлы һан",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Цифр Умножение",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Парен һулға",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren уң",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Цифра Вычитание",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Страница вниз",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Страница вверх",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Власть",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Выключение",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Принт Экран",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Төргәкләү йоҙаҡтары",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Һайлап алыу",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Смена",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Арауыҡ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_bho.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bho.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Back",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "साफ़ बा ।",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "अउरियो",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अगिला महीना",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पिछला महीना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अगिला पन्ना",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पिछला पन्ना",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पहिला पन्ना",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "अंतिम पन्ना",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू देखाईं",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "नीचे के चादर",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenses",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "कैंसिल",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी राखीं",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "काटल जाला ।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "स्कैन टेक्स्ट",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ऊपर देखीं ।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "जाल खोज लीं ।",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीक",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चयन करीं",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "प्रधानमंत्री",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "चुनिंदा घंटा",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "चुनिंदा मिनट",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू के खारिज कर दीं ।",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अनिर्दिष्ट तिथि",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अनिर्दिष्ट तिथि सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enter Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Start Date",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "End Date",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अमान्य तिथि प्रारूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अमान्य तिथि सीमा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "सीमा से बाहर के तारीख",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "बचाईं ।",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Select date",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेण्डर मोड पर स्विच करीं ।",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट डेट मोड पर स्विच करीं",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय के चयन करीं",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समय दर्ज करीं",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Hour",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अमान्य समय",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोड पर स्विच कइल जाई ।",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट टाइम मोड पर स्विच करीं ।",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "में हस्ताक्षरित भइल",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "लेखा छिपावे के बा ।",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "लेखा देखाईं",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Search",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Current date",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चयनित तिथि",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "शुरू करे खातिर चाल चलल जाला ।",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "खतम होखे के चाल चलल जाला ।",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर बढ़ल जाला ।",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे चलि जाई ।",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बायाँ चलि जाई ।",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाईं ओर बढ़ीं ।",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ताज़ा होखे के चाहीं ।",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "End",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "भागि जाला ।",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Command",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad गुणा कइल जाला ।",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नुम्पद घटा दीं",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Power",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Select",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Space",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_bo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_bo.arb
@@ -1,149 +1,641 @@
 {
-  "openAppDrawerTooltip": "ཕྱོགས་སྟོན་ཐོ་གཞུང་ཁ་ཕྱེ་བ།",
-  "backButtonTooltip": "ཕྱིར་ལོག",
-  "clearButtonTooltip": "ཡི་གེ་གཙང་བཟོ།",
-  "closeButtonTooltip": "སྒོ་རྒྱག་པ།",
-  "deleteButtonTooltip": "བསུབ་པ།",
-  "moreButtonTooltip": "ཇེ་མང་།",
-  "nextMonthTooltip": "ཟླ་བ་རྗེས་མ།",
-  "previousMonthTooltip": "ཟླ་བ་སྔོན་མ།",
-  "nextPageTooltip": "ཤོག་ངོ་རྗེས་མ།",
-  "previousPageTooltip": "ཤོག་ངོ་སྔོན་མ།",
-  "firstPageTooltip": "ཤོག་ངོ་ཐོག་མ།",
-  "lastPageTooltip": "ཤོག་ངོ་མཐའ་མ།",
-  "showMenuTooltip": "ཐོ་གཞུང་སྟོན་པ།",
-  "scrimLabel": "ཤོག་ཚོས།",
-  "scriptCategory": "dense",
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
   "timeOfDayFormat": "HH:mm",
-  "bottomSheetLabel": "ཤོག་ལྷེ་འོག་མ།",
-  "scrimOnTapHint": "སྒོ་རྒྱག་པ། $modalRouteContentName",
-  "aboutListTileTitle": "སྐོར། $applicationName",
-  "licensesPageTitle": "ལག་ཁྱེར་ཁག",
-  "licensesPackageDetailTextOne": "ལག་ཁྱེར། 1",
-  "licensesPackageDetailTextOther": "$licenseCount ལག་ཁྱེར་ཁག",
-  "pageRowsInfoTitle": "$firstRow–$lastRow ཡི་ $rowCount",
-  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow ཡི་སྐོར། $rowCount",
-  "rowsPerPageTitle": "ཤོག་ལྷེ་རེའི་འཕྲེད་ཐིག:",
-  "tabLabel": "འཛར་གནོན་ $tabIndex ཡི $tabCount",
-  "selectedRowCountTitleOne": "ཅ་དངོས་ 1 བདམས་པ།",
-  "selectedRowCountTitleOther": "$selectedRowCount ཅ་དངོས་དུ་མ་བདམས་པ།",
-  "cancelButtonLabel": "ཕྱིར་འཐེན།",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ཕྱོགས་སྟོན་གྱི་ཟས་ཐོ་ཕྱེ་བ།",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ཕྱིར་ལོག་པ།",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "གསལ་པོར་ཤེས་པ།",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "སྒོ་རྒྱག་པ།",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "སུབ་དགོས།",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "དེ་བས་ཀྱང་མང་",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ཟླ་བ་རྗེས་མར།",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ཟླ་སྔོན་མའི་ནང་།",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ཤོག་ངོས་རྗེས་མ།",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ཤོག་ངོས་དང་པོ།",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ཤོག་ངོས་དང་པོ།",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "མཇུག་མཐའི་ཤོག་ངོས།",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "SHowཡི་ཟས་ཐོ།",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "རས་སོབ་སོབ།",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "མཐིལ་ཤིང་།",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "འཁྲོལ་འཛིན།",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ཤོག་ངོས་རེ་རེའི་གྲངས་ཀ་",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "མེད་པར་བཟོ་དགོས།",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
   "closeButtonLabel": "སྒོ་རྒྱག་པ།",
-  "continueButtonLabel": "མུ་མཐུད་པ།",
-  "copyButtonLabel": "བཤུས།",
-  "cutButtonLabel": "གཅོད།",
-  "scanTextButtonLabel": "ཡི་གེ་བཤེར་འབེབས།",
-  "lookUpButtonLabel": "འཚོལ་བ།",
-  "searchWebButtonLabel": "དྲ་ཐོག་འཚོལ་བཤེར།",
-  "shareButtonLabel": "མཉམ་སྤྱོད།",
-  "okButtonLabel": "འདོད།",
-  "pasteButtonLabel": "འཕོས་པ།",
-  "selectAllButtonLabel": "ཚང་འདེམས།",
-  "viewLicensesButtonLabel": "ལག་ཁྱེར་ཁག་ལྟ་བ།",
-  "anteMeridiemAbbreviation": "སྔ་དྲོ",
-  "postMeridiemAbbreviation": "ཕྱི་དྲོ།",
-  "timePickerHourModeAnnouncement": "ཆུ་ཚོད་འདེམས་པ།",
-  "timePickerMinuteModeAnnouncement": "སྐར་མ་འདེམས་པ།",
-  "modalBarrierDismissLabel": "འདོར་བ།",
-  "menuDismissLabel": "ཐོ་གཞུང་འདོར་བ།",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "མུ་མཐུད་ནས་ཡོང་",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "འདྲ་བཟོ་བྱས་པ།",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "གཏུབ་པ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ཡིག་ཆ་གཙང་ཕྱག་བྱེད་པ།",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "㚧།",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "འཚོལ་ཞིབ་Webཞེས་པ།",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "མཉམ་དུ་ལོངས་སུ་སྤྱོད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ད་དུང་འགྲིག་གི་རེད།",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "རབ་རིབ་ཏུ་གྱུར",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ཡོངས་རྫོགས་འདེམས་བསྐོ་བྱ་དགོས",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "འཁྲོལ་འཛིན་ལ་ལྟ་ཞིབ་བྱེད་པ།",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "དེ་ནི་རེད།",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ཕྱི་དྲོ།ཕྱི་དྲོ།",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ལས་གཉེར་གྱི་དུས་ཚོད་གདམ་དགོས།",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "སྐར་མ་འགར་འདེམས་པ།",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ལས་ཁོངས་ནས་ཕྱིར་འབུད་",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ཟ་མའི་མིང་ཐོ་ སྒོ་བརྒྱབ་པ་རེད།",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
   "dateSeparator": "/",
-  "dateHelpText": "ལོ། ལོ། ལོ། ལོ།/ཟླ། ཟླ།/ཚེས། ཚེས།",
-  "selectYearSemanticsLabel": "ལོ་འདེམས།",
-  "unspecifiedDate": "ཟླ་ཚེས།",
-  "unspecifiedDateRange": "ཟླ་ཚེས་ཁྱབ་ཚོད།",
-  "dateInputLabel": "ཟླ་ཚེས་ནང་འཇུག",
-  "dateRangeStartLabel": "ཟླ་ཚེས་འགོ་འཛུགས།",
-  "dateRangeEndLabel": "ཟླ་ཚེས་མཇུག་བསྡུ།",
-  "dateRangeStartDateSemanticLabel": "ཟླ་ཚེས་འགོ་འཛུགས། $fullDate",
-  "dateRangeEndDateSemanticLabel": "ཟླ་ཚེས་མཇུག་བསྡུ། $fullDate",
-  "invalidDateFormatLabel": "སྒྲོམ་གཞི་ནོར་འཁྲུལ།",
-  "invalidDateRangeLabel": "ཁྱབ་ཚོད་ནོར་འཁྲུལ།",
-  "dateOutOfRangeLabel": "ཁྱབ་ཚོད་ནང་མ་ཚུད།",
-  "saveButtonLabel": "ཉར་ཚགས།",
-  "datePickerHelpText": "ཟླ་ཚེས་འདེམས་པ།",
-  "dateRangePickerHelpText": "ཁྱབ་ཚོད་འདེམས་པ།",
-  "calendarModeButtonLabel": "ལོ་ཐོར་བསྒྱུར་བ།",
-  "inputDateModeButtonLabel": "ནང་འཇུག་ལ་བསྒྱུར་བ།",
-  "timePickerDialHelpText": "ཆུ་ཚོད་འདེམས་པ།",
-  "timePickerInputHelpText": "ཆུ་ཚོད་ནང་འཇུག",
-  "timePickerHourLabel": "ཆུ་ཚོད།",
-  "timePickerMinuteLabel": "སྐར་མ།",
-  "invalidTimeLabel": "ཆུ་ཚོད་ནོར་འཁྲུལ་མེད་པར་ནང་འཇུག",
-  "dialModeButtonLabel": "ཆུ་ཚོད་འདེམས་སྒྲུག་ལ་བསྒྱུར་བ།",
-  "inputTimeModeButtonLabel": "ཡི་གེ་ནང་འཇུག་ལ་བསྒྱུར་བ།",
-  "signedInLabel": "དྲ་འཛུལ་ཟིན།",
-  "hideAccountsLabel": "ཁ་བྱང་བསྐུང་བ།",
-  "showAccountsLabel": "ཁ་བྱང་སྟོན་པ།",
-  "drawerLabel": "ཕྱོགས་སྟོན་ཐོ་གཞུང་།",
-  "menuBarMenuLabel": "ཐོ་གཞུང་གི་མཐེབ་གནོན་ཐོ་གཞུང་།",
-  "popupMenuLabel": "བསྐུང་སྟོན་ཐོ་གཞུང་།",
-  "dialogLabel": "ཟིན་དེབ།",
-  "alertDialogLabel": "གསལ་བརྡ།",
-  "searchFieldLabel": "འཚོལ་བཤེར།",
-  "currentDateLabel": "དེ་རིང་།",
-  "selectedDateLabel": "བདམས་པ།",
-  "reorderItemToStart": "འགོ་འཛུགས་སར་འགྲོ།",
-  "reorderItemToEnd": "མཇུག་བསྡུ་སར་འགྲོ།",
-  "reorderItemUp": "སྒང་ལ་འགྲོ།",
-  "reorderItemDown": "འོག་ལ་འགྲོ།",
-  "reorderItemLeft": "གཡོན་ལ་འགྲོ།",
-  "reorderItemRight": "གཡས་ལ་འགྲོ།",
-  "expandedIconTapHint": "ཕྱོགས་བསྡུ།",
-  "collapsedIconTapHint": "ཁྱབ་སྤེལ།",
-  "expansionTileExpandedHint": "ཕྱོགས་བསྡུའི་ཆེད་ཐེངས་གཉིས་གནོན།",
-  "expansionTileCollapsedHint": "ཁྱབ་སྤེལ་ཆེད་ཐེངས་གཉིས་གནོན།",
-  "expansionTileExpandedTapHint": "ཕྱོགས་བསྡུ།",
-  "expansionTileCollapsedTapHint": "ཞིབ་རྒྱས་ཆེད་ཁྱབ་སྤེལ།",
-  "expandedHint": "ཕྱོགས་བསྡུས།",
-  "collapsedHint": "ཁྱབ་སྤེལ་ཟིན།",
-  "remainingTextFieldCharacterCountOne": "ཡིག་འབྲུ་ 1 ལྷག་ལུས།",
-  "remainingTextFieldCharacterCountOther": "$remainingCount ཡིག་འབྲུ་ལྷག་ལུས་རྣམས།",
-  "refreshIndicatorSemanticLabel": "བསྐྱར་གསོ།",
-  "keyboardKeyAlt": "ཨལ་ཊི།",
-  "keyboardKeyAltGraph": "ཨལ་ཊི་ཇི་ཨར།",
-  "keyboardKeyBackspace": "ཕྱིར་འགྲོ།",
-  "keyboardKeyCapsLock": "ཡིག་ཆེན།",
-  "keyboardKeyChannelDown": "བརྒྱུད་ལམ་གཤམ།",
-  "keyboardKeyChannelUp": "བརྒྱུད་ལམ་སྟེང་།",
-  "keyboardKeyControl": "སྟངས་འཛིན།",
-  "keyboardKeyDelete": "བསུབ།",
-  "keyboardKeyEject": "ཕྱིར་འདོན།",
-  "keyboardKeyEnd": "རྫོགས།",
-  "keyboardKeyEscape": "ཕྱིར་ཐོན།",
-  "keyboardKeyFn": "བྱེད་སྒོ།",
-  "keyboardKeyHome": "ཁྱིམ།",
-  "keyboardKeyInsert": "ནང་འཛུལ།",
-  "keyboardKeyMeta": "བརྗེས་སྒྱུར།",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "ཉི་ཟླ་ཟླ་བ་གཅིག་ལ་ཞལ་ཞལ་མ་ཞལ་ཞལ་རེད།",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ལོ་སྐལ་འདེམས་པ།",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "དམིགས་འཛུགས་བྱས་མེད་པའི་དུས་ཚོད།",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "དུས་ཚོད་ཀྱི་ཁྱབ་ཁོངས་དམིགས་འཛུགས་མ་བྱས་པ།",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ནང་འདྲེན་བྱས་པའི་ཚེས་གྲངས།",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "འགོ་ཚུགས་པའི་ཚེས་གྲངས།",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "མཇུག་བསྒྲིལ་བའི་ཚེས་གྲངས།",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ཚེས་གྲངས་ཀྱི་རྣམ་གཞག་ལ་ནུས་པ་མེད།",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ཚེས་གྲངས་ཀྱི་ཁྱབ་ཁོངས་རྩིས་འགྲོ་མེད།",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ཚེས་གྲངས་ཁྱབ་ཁོངས་ལས་བརྒལ་བ།",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "སྐྱོབ་ཐབས་བྱ་དགོས།",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "འདེམས་པའི་དུས་ཚོད།",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "གདམ་གསེས་བྱེད་ཁོངས།",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ཉི་མའི་ལོ་རྒྱུས་ཀྱི་དཔེ་དབྱིབས་སུ་འགྱུར་བ་བྱེད་དགོས།",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ནང་འདྲེན་བྱས་པའི་དུས་ཚོད་ཀྱི་དཔེ་དབྱིབས་སུ་འགྱུར་བ་བྱེད་དགོས།",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "དུས་ཚོད་འདེམས་པ།",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ནང་འཇུག་བྱེད་པའི་དུས་ཚོད།",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ཆུ་ཚོད་གཅིག་གི་",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "སྐར་མ་སྐར་མ་གཅིག་ཙམ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "གོ་མི་ཆོད་པའི་དུས་ཚོད།",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ཨང་གྲངས་གཏོང་བའི་དཔེ་དབྱིབས་སུ་འགྱུར་བ་བྱེད་དགོས།",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ནང་འདྲེན་དུས་ཚོད་ཀྱི་དཔེ་དབྱིབས་སུ་འགྱུར་བ་བྱེད་དགོས།",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ཐོ་འགོད་བྱས་ཟིན།",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "རྩིས་ཐོ་སྦས་སྐུང་བྱས་པ།",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ཐོ་ཁོངས་མཚོན་པ།",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ཟས་ཐོ་ཕྱོགས་སྟོན་བྱེད་པ།",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ཟས་ཐོའི་བྱང་བུ།",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ཟས་ཐོ་འཕེན་པ།",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ཁ་བརྡ་བྱེད་པ།",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ཉེན་བརྡ་གཏོང་བ།",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "འཚོལ་ཞིབ་བྱེད་པ།",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "མིག་སྔའི་ཟླ་ཚེས།",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "འདེམས་བསྐོ་བྱས་པའི་ཚེས་གྲངས།",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "འགོ་འཛུགས་སར་སྤོ་དགོས།",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "མཐར་ཐུག་གི་གནས་སུ་སྤོ་དགོས།",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ཡར་འཕགས་པ།",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "མར་སྤོས་པ།",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "གཡོན་ཕྱོགས་སུ་གནས་སྤོ་བ།",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "གཡས་ཕྱོགས་སུ་སྤོ་བ།",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "གསར་དུ་བཀྲུ་བ།",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Altཡི་མཐེབ་བཀྱག",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "མཐེབ་བཀྱག་ཕྱིར་འཐེན་",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ཟྭ་ཆེན་པོ་བརྒྱབ་ནས་གཏན་འཁེལ་བྱས་",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "བགྲོད་ལམ་སྒོ་རྒྱག་པ།",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "བགྲོད་ལམ་ཡར་ལ་འགྲོ་བ།",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ཚོད་འཛིན།",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "སུབ་དགོས།",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "མདེལ་འཕེན་པ།",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "མཇུག་བསྒྲིལ་",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "བྲོས་བྱོལ་དུ་",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ཁྱིམ་ཚང་།",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ནང་དུ་འཇུག་པ།",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ཡོན་ཡིན།",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
   "keyboardKeyMetaMacOs": "བཀའ་རྒྱ།",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
   "keyboardKeyMetaWindows": "སྒེའུ་ཁུང་།",
-  "keyboardKeyNumLock": "ཨང་གྲངས་མཐེབ་གནོན།",
-  "keyboardKeyNumpad1": "ཨང་གྲངས། 1",
-  "keyboardKeyNumpad2": "ཨང་གྲངས། 2",
-  "keyboardKeyNumpad3": "ཨང་གྲངས། 3",
-  "keyboardKeyNumpad4": "ཨང་གྲངས། 4",
-  "keyboardKeyNumpad5": "ཨང་གྲངས། 5",
-  "keyboardKeyNumpad6": "ཨང་གྲངས། 6",
-  "keyboardKeyNumpad7": "ཨང་གྲངས། 7",
-  "keyboardKeyNumpad8": "ཨང་གྲངས། 8",
-  "keyboardKeyNumpad9": "ཨང་གྲངས། 9",
-  "keyboardKeyNumpad0": "ཨང་གྲངས། 0",
-  "keyboardKeyNumpadAdd": "ཨང་གྲངས། +",
-  "keyboardKeyNumpadComma": "ཨང་གྲངས། ,",
-  "keyboardKeyNumpadDecimal": "ཨང་གྲངས། .",
-  "keyboardKeyNumpadDivide": "ཨང་གྲངས། /",
-  "keyboardKeyNumpadEnter": "ཨང་གྲངས་ནང་འཇུག",
-  "keyboardKeyNumpadEqual": "ཨང་གྲངས། =",
-  "keyboardKeyNumpadMultiply": "ཨང་གྲངས། *",
-  "keyboardKeyNumpadParenLeft": "ཨང་གྲངས། (",
-  "keyboardKeyNumpadParenRight": "ཨང་གྲངས། )",
-  "keyboardKeyNumpadSubtract": "ཨང་གྲངས། -",
-  "keyboardKeyPageDown": "ཤོག་ངོ་འོག་འགྲོ།",
-  "keyboardKeyPageUp": "ཤོག་ངོའི་སྒང་འགྲོ།",
-  "keyboardKeyPower": "གློག་སྤར།",
-  "keyboardKeyPowerOff": "གློག་གསོད།",
-  "keyboardKeyPrintScreen": "ཤོག་ངོ་བཤུས།",
-  "keyboardKeyScrollLock": "གོང་འོག་འགྲོ་བྱེད།",
-  "keyboardKeySelect": "འདེམས།",
-  "keyboardKeyShift": "བརྗེ་སྒྱུར་མཐེབ་གནོན་ཤིབ་ཊི།",
-  "keyboardKeySpace": "བར་སྟོང་།"
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞུང་ཆུང་བ།9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ།",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ་ཁ་སྣོན་བྱས",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་བཀྱག་ཆུང་བ་དགོད་ཁ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་བཀྱག་བཅུའི་ལམ་ལུགས།",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་བཀྱག་རྒྱག་སྟངས།",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ་Entreerཡིན།",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpdདང་གཅིག་མཚུངས་ཡིན།",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ཨང་ཀིའི་མཐེབ་བཀྱག་ཆུང་བའི་སྒྱུར་རྩིས།",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "ཨང་ཀིའི་མཐེབ་གཞོང་ཆུང་བའི་གཡོན་ཕྱོགས་སུ་ཡོད།",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བའི་གཡས་ཕྱོགས།།",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "གྲངས་ཀ་ཆུང་བའི་མཐེབ་གཞོང་ཆུང་བ་འཕྲི་",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ཤོག་ངོས་རྗེས་མ།",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "དབང་ཆ།",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "གློག་ཁུངས་སྒོ་རྒྱག་དགོས།",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "བརྙན་ཤེལ་དཔར་རྒྱག་པ།",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "གདམ་ག་རྒྱག་པ།",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "འགྱུར་ལྡོག་གཏོང་དགོས།",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "བར་སྟོང་།",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_brx.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_brx.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Navigation menu खौ खेव।",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "उनथिं",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "स्रां खालाम",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "बन्द'",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "खोमोर।",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "आरोबाव",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "फैगौ दानाव",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "सिगांनि दान",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "फैगौ page (पेज)",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "सिगांनि page (पेज)",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "गिबि page (पेज)",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "जोबथा बिलाइ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनुखौ दिन्थि",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "गाहायनि sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "लाइसेन्सफोर",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "मोनफ्रोमबो page (पेज) आव सारिफोर:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "दानगार",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "बन्द'",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "सोलिबाय था।",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "कपि खालाम",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "दान।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "नाय।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबखौ नागिर",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "सेयार खालाम",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "जागोन",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "गासैखौबो सायख'",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लाइसेन्सफोरखौ नाय।",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "गाहाय मन्थ्रि",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "घन्टाफोरखौ सायख'",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनितफोरखौ सायख'",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "होखार।",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनुखौ केनसेल खालाम।",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "बोसोरखौ सायख'",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "थि नङै खालार।",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "थि नङै खालारनि रेन्ज",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "खालारखौ सो",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "जागायजेननाय खालार।",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "जोबनाय खालार",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "नंखाय खालारनि फरमेट",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "नंखाय खालार रेन्ज",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "रेन्जनि बायजोआव खालार",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "रैखा खालाम।",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "खालारखौ सायख'",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "रेन्जखौ सायख'",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "केलेन्डार मडाव सोलाय।",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट खालार मडाव सोलाय।",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समखौ सायख'",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समखौ सो",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घन्टा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनिट",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "नंखाय सम",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मडाव सोलाय।",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट टाइम मडाव सोलाय।",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "साइन इन खालामबाय",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "एकाउन्टफोरखौ दोनखोमा।",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "एकाउन्टफोरखौ दिन्थि।",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनु बार",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu (पप आप मेनु)",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog (डायलग",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "एलार्ट",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "नागिर",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "सोलिफु अक्ट'",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "सायख'नाय खालार।",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "जागायजेन्नो थां।",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "जोबनायाव थां।",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "गोजौआव थां।",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "गाहायाव थां।",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "आगसिथिं थां।",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "आगदाथिं थां।",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh (रिफ्रेस खालाम)",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "खोमोर।",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "फोजोबो",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "एस्केप",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Command",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "नुमपेड Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad दाजाबदेर।",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "गोहो",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "मोब्लिब गोहो बन्द'",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "सायख'",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "सिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अख्रांमा",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ceb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ceb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Buksan ang menu sa pag-navigate",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Balik",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Malinaw",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Hapit",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Pagwagtang",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Dugang pa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Sa sunod bulan",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Milabay nga bulan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sunod nga panid",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Una nga panid",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Una nga panid",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kataposan nga panid",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ipakita ang menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ang ubos nga lapad",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisensya",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mga linya matag panid:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Pagkansela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Hapit",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Padayon",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Text scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tan-awa sa itaas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pagpangita sa Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Okay",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili sa tanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Pagtan-aw sa mga lisensya",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pilia ang mga oras",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pagpili sa mga minuto",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Pag-undang",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pag-usab sa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select Year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dili-specified nga petsa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Wala'y gipasabut nga kinatibuk-an sa petsa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "I-enter ang petsa",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ang petsa sa pagsugod",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ang Kataposan nga Dato",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Ang katapusan nga petsa $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Dili-mabatik nga format sa petsa",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Dili-mabatik nga intervalo sa petsa",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ang petsa dili naabot",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Pagluwas",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pagpili sa petsa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PILIHAN ang ranggo",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pag-usab sa mode sa kalendaryo",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pag-usab sa mode sa input date",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pagpili sa oras",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Pagsulod sa oras",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Usa ka oras",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Dili-mahuyang nga panahon",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pag-usab sa mode sa dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pag-usab sa input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Nagpirma",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ibutang ang mga kontong",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ipakita ang mga account",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu sa pag-navigate",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogue",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Pag-alabot",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Pagpangita",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Karon nga petsa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ang gipili nga petsa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Paglihok aron magsugod",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Paglihok hangtod sa kataposan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pag-uswag",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pag-adto sa ubos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pag-adto sa wala",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Paglihok sa tuo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Pagpabug-at",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Back space",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Pag-adto sa Siling",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Pagwagtang",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Pagbulag",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kataposan",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Pagkalagiw",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Balay",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ibutang",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mga bintana",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Wala",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pag-usab sa panid",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pag-uswag sa panid",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Pag-alagad",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pag-off sa Power",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pagpili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pag-usab",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ang Espesyal",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_cjk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_cjk.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu ya kutambukila yikangula",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kuhutuka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Kujingulula",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kulikata",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kuhichisa",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Kuhi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Likumbi lyakulutwe",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Likumbi lyamukuchi",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Kulikumbi lyamukuya",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Likanda lyakwalumuka",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Linanga lyakulivanga",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kuchikungulwilo chahupu",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Lwola lwakusolola",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kulemba",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Chishina cha ku chishi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Yipilo",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mapweji ha mukachi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kuhichisa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kulikata",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Twalileho",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kuzachisa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kuchima",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sanya chisoneka",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Talenu mwakwoloka",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sokola muInternet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kuhanjikanga",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Chochene",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Kukutwa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Solola yeswe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kutala mikanda ya kuhonesa",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Yipwa",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ndumbwetu",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kusakula jiola",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Kusakula maminuto",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kufumisa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kufumisa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Mwaka uze vasakwile",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Usesa wa chikupu",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Kwatwama havyuma vyakulinga",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Lingila haKukunguluka",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kuzachisa Linangulo",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kuzachisa chaKukunguluka",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Kuzachisa $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Kuzachila $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fomu ya tangwa yachikupu",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kanyiso ka makumbi",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Kuzachisa tangwa",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Kuzachisa",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Kusakula tangwa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "CHILANGU CHIHANDE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kuhinduluka kujila ya kalendala",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Kuhinduluka kujila ya tangwa lyakutambulula",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Kusakula lwola",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Lingila lwola",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Liwola",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Mzuzu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Liaka lyakukwata",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Kuhinduluka nakuzachisa jila yakusolola",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Kuhinduluka ha shimbu lia kutwala",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Kuzachisa",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kufweta mali",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Lweza mali",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ya kuzachisa",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Masalavu a menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ya ku vuluka",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kuhanjika",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kutachikiza",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kufupa",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Kuzachisa chali",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Usongo wakusakula",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Kuyile nakuzata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kuhambakana nakuheta kuhambu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nyingilililemo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Nyonga mwilu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nyonga ku chishina",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nyonga ku chishina",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kuvandulula",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Kuzachisa",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Chishina chaKulitulaho",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Kuzachisa lilimi lyakushinakaji",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapu Yakufungulula",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kuzachisa Linjila jaKukinduluka",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kuzangula",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kuyula",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kuhichisa",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kufumisa",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kuheta",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kuhona",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kuzuvo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kuzachisa",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kuyula",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mawindo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kulikanyisa cha Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kuyile",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kuchidi",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kujimba Kujimba",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kujimbulula",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Uhashi",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuhona Kuzachisa Nguvulu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Kulemba Chinene",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Kufungulula",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Kusakula",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kuzachisa milimo",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Chihela",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ckb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ckb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مێنووى ناوبراوى کراو",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "گەڕانەوە",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ڕوون",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "نزیکە",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "سڕینەوە",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "زیاتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "مانگی داهاتوو",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "مانگی پێشوو",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "پەڕەی دواتر",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "پەڕەی پێشوو",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "پەڕەی یەکەم",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "پەڕەی کۆتایی",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "مینۆی نمایش",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "شەکەک",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "پەڕەی خوارەوە",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "مۆڵەتەکان",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ڕیزەکان لە سەر پەڕەیەکدا:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "هەڵوەشاندنەوە",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "نزیکە",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "بەردەوام بن",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "تێکست پشکنین",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "سەیری بەرز بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "گەڕان لە تۆڕەکەدا",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "دابەشکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "باشه",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "پست",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەمووان هەڵبژێرە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "مۆڵەتەکان ببینە",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "سەرۆکوەزیران",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "کاتەکانی دیاری بکە",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "خولەکەکان هەڵبژێرە",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "دوورخستنەوە",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مێنووى هەڵبوەشاندن",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ساڵی دیاریکراو",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ڕێکەوتی دیاری نەکراو",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "مەودای دیاری نەکراو",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ڕۆژی تۆمارکردن",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ڕێکەوتی دەستپێکردن",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "وادەی کۆتایی",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "وادەی دەستپێک $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "وادەی کۆتایی $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "فۆرماتێکی نەقانونی ڕێکەوتی",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "مەودای وادەی هەڵوەشاندن",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ڕێکەوتی دەرەوەی مەودای",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "پاشەکشەی",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ڕێکەوتی هەڵبژێرە",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ڕیزێکی هەڵبژێرە",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "گۆڕە بۆ شێوازی ڕۆژژمێری",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "گۆڕە بۆ شێوازی وادەی هاتن",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "کات دیاری بکە",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "کاتى هاتن",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "کاتژمێرێک",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "خولەکێک",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "کاتێکی نەگونجاو",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "گۆڕە بۆ شێوازی دانانی ژمارە",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "گۆڕە بۆ شێوازی کاتی هاتن",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ئیمزا کرا",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "هەژمارەکان شاراوە",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "هەژمارەکان نیشان بدە",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "مێنووى ناوبراو",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "بارەی مێنی",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "مێنووى هەڵکێشراو",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "دیالۆگ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ئاگاداری",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "گەڕان",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ڕێکەوتی ئێستا",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ڕێکەوتی دیاریکراو",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "بزانە بۆ دەستپێک",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "بەرەو کۆتایی",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "بەرەو سەرەوە بڕۆ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "دابەزێنە خوارەوە",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "بچۆ چەپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "بگەڕێ ڕاست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "نوێبوونەوە",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ئاڵتونی",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "گرافی Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "شوێنە پشتیەکان",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قەڵەمبەسەر",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "کەناڵ بۆ خوارەوە",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "کەناڵەکە بەرز دەبێتەوە",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کۆنترۆڵ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "سڕینەوە",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "دەربکە",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "کۆتایی",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "هەڵهاتن",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ماڵ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "دانانی",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "مێتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "فەرماندەیی",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "پەنجەرەکان",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفلە",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نۆمپاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad زیاد بکە",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "کۆماى گڕ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "ژمارە دەقیی",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "دابەشکردنی نۆمپاد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "یەکسانبوون",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad زۆربکر",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren چەپ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ڕاست",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "سەندنەوەی Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "پەڕەی خوارەوە",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "پەڕەی سەرەوە",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "هێز",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "کارەبا لەکاربهێنرێت",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشەی چاپ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفلکردنی پەڕە",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "هەڵبژێرە",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "گۆڕینی",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "فەزا",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_crh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_crh.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Açılğan navigatsiya menyü",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Qaytıp kelgen",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Açıq",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Yaqınlıq",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Silüv",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Daa çoq",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kelecek ay",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Keçken ay",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nevbetteki saifede",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Önceki saifede",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Birinci saifesi",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Soñki saifede",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Menüni köster",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Çıqqama",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Alt yaprak",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Litsenziyalar",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Sayfada satırlar:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "lâğu etilmek",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Yaqınlıq",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Davam etüv",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopiyalanğan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kesilgen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Mektüpni taramaq",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Yukarğa baq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "İnternette qıdıruv",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Tamam, yahşı.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pasta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünlerini sayla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "İznlerni kör",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Baş nazir",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Saatlarnı sayla",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minuttalarnı sayla",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "İndirüv",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "İndirmek menüsi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Saylanğan yıl",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Belli olmağan tarih",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Belli olmağan tarih aralığı",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Berilgen tarih",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Başlanuv tarihı",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Soñki tarih",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Başlama tarihı $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Bitüv tarihı $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Vaqıtlı tarih formatı",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Vaqıtlı tarih aralığı",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tarmaqtan çıqqan tarih",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Qapmaq",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Saylanğan tarih",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TEKLİNİRLER",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kâlenar rejimine keç",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Berilgen tarih rejimine keç",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Vaqıtnı sayla",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Saatni kirset",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Saatnıñ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Bir daqqa",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Vaqıtsız",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Çıqqış rejimi",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Giriş vaqtı rejimine keç",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "İmzağa alınğan",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hesablarnı gizleme",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Hesablarnı köster",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigatsiya cedvelini",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menü çubuğu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Çıqqan menü",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Arama",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Şimdiki tarih",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Saylanğan tarih",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Başlamaq içün areket et",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Soñuna qadar areket et",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yüklenip çıq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Aşağıya ket",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Solğa ket",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sağğa ket",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Yañıruv",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt grafiyası",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Arqa boşluq",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps qapatıluvı",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Aşağı kanal",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Yüklenip çıqqan kanal",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Silüv",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Çıqtır",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Soñunı",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Qurtulmaq",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Evniñ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ekle",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandada",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "pencereleri",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Qapı",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad qoşmaq",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad koması",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad onluq",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad bölünüvi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad kirmek",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad teñ",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad çoqlamı",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Solğa",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Sağ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad eksikligi",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Saytnı tüşürmek",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Saytnı köter",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Güç",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Elektrik yoq etilmedi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Çaplav Ekranı",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Çıkacaq kilit",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Saylav",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Tavsiye",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Yer",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_dik.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_dik.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu de navigation open",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ku dhukkë ciëën",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Aŋic yic",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pälkë",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Thɛ̈ɛ̈k",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Këdït apɛi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ɣɔk bɛ̈n",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ɣɔk thɛɛr",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Wɛ̈t cï lɔ̈k",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Thiɛ̈ɛ̈r tueŋ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Wɛ̈t tueŋ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Wɛ̈t ciëën",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Nyuth menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pël ëak omën ompyaö",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Kä ye gäm kɔc",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lëk në page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Thɛ̈ɛ̈k",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pälkë",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Lät tueŋ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Lɔnë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Text scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ku döt nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kuen në wɛ̈t yic",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Loi käpuɔth",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Oke ye",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pël ëlök",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Päm ëbën",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lïcïn ya tïŋ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Luɔi ye kuany",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pël ëak omën pöt",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Thɛ̈ɛ̈k wei",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Thɛ̈ɛ̈c menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Yïïn cï kuany",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Të cïn kë ye lueel",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Kä cï looi në ye kën kën",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Cɔkïn cï gɔ̈t",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Käk jɔɔk",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Piny cï thök",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "jɔɔk jɔɔk $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Piny thök $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Kä cï kek looi në kë cï kek looi",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kä cï looi në ye kën kën",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Käk cï looi",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Cɔlkë",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pälkë aköl",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "LUAK KËN",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Lëk në calendar mode",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Lëk në ye rot ya tääu në ye rot ya tääu në ye rot ya tääu në ye rot",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Päm ye kuany",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Cɔl thaa",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ɣɔn cï looi",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Akäl tök",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Aköl cïï ye luui",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Lëk në mode dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Lëk në tɛ̈n ye thaa input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "A cë gɔ̈t thïn",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Cɔl kä cï looi",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Nyuɔth kä cï gɔ̈t",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu de navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Wɛ̈t cï kek ya lueel",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Wël ye kɔc yɔ̈ɔ̈k",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Wïc",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Käk ya looi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Käk cï kuany",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Lɔɔr tueŋ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Lëk në thök",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Lɔɔr nhial",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Päl piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pälkë lɔŋ cam",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yiɛ̈ɛ̈k cuëëc",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Cɔl kɔc aa puɔl",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Piny kɔ̈u",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Cäth piny",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Cäth nhial",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Luɔi de kɔc",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Thɛ̈ɛ̈k",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Thok wei",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Piny ë thök",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Luɔ̈ɔ̈i",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Piny de baai",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Add ye",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Mëthiic",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Lööŋ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Wël ë ɣön",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad split",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad ye cɔl many",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Piny ë riɛl",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Cɔl riɛl piny",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Yiɛ̈ɛ̈c",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kuɔ̈ɔ̈c",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ɣön",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_doi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_doi.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "बापस",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "साफ़-साफ़",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "कोल",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "मटाओ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "होर",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अगले म्हीने",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पिछला म्हीना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अगला पेज",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पिछला पेज",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पैह् ला पेज",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "खीरला पेज",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू दस्सो",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "खʼलकी शीट",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "लसैंस्स",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रति पेज पंक्तियां :",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द करना",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "कोल",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी रक्खो",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटोई देओ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "स्कैन टेक्स्ट",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "दिक्खो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वैब तुप्पो",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "सांझा करो",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीक ऐ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभनें दा चनाऽ करो",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लसैंस्स दिक्खो",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "प्रधानमंत्री",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "घैंटें दा चनाऽ करो",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिंटें दा चनाऽ करो",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करो",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू गी मिस करो",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "बʼरा चुनो",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अनिर्दिष्ट तरीक",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अनिर्दिष्ट तरीक सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "तरीक दर्ज करो",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "तरीक शुरू करो",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "अंत दी तरीक",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अमान्य तरीक प्रारूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अमान्य तरीक सीमा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "तरीक सीमा शा बाह् र",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "सेव करो",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "तरीक चुनो",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेंडर मोड पर स्विच करो",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट डेट मोड पर स्विच करो",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समां चुनो",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समां दर्ज करो",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घैंटा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अमान्य समां",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोड पर स्विच करो",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट टाइम मोड पर स्विच करो",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "दस्तखत कीते गे",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खातें गी छपाओ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाते दस्सो",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू बार",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोज करो",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "वर्तमान तरीक",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चुनी गेदी तरीक",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "शुरू करने आस्तै जाओ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत च जाओ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उप्पर जाओ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "खʼल्ल जाओ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "खब्बी बक्खी जाओ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "सज्जी बक्खी जाओ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "रीफ्रैश करो",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लाक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "चैनल अप",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "मटाओ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "बेदखल करो",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अंत",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "नस्सना",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घर",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Command",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नम लाक",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad बराबर",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad गुणा करो",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad घटाओ",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "बिजली",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "बिजली बंद",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रॉल लाक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चुनो",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अंतरिक्ष",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_dsb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_dsb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Nawigaciske menije wótwóriś",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Slědk",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Klar",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Zacyniś.",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Lašowaś.",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Wěcej",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Pśiducy mjasec",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Vormonat",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Pśiducy bok",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pjerwjejšny bok",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prědny bok",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Slědny bok",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Meni pokazaś",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Bałma.",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Spódny blach blacha",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licence",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Smužki na bok:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Pśetergnuś",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Zacyniś.",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Pókšacowaś",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopěrowaś",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Rězaś",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Text scannen",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Zabitki",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pśeglědajśo web web.",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Lichotne zapódaś.",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OKAY",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Kleister",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wšykne wuzwóliś.",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Inserwy licencow",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "BIN",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "WÓTPOŁDNJA",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Góźiny wubraś",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Mjeńšyny wubraś",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ze źěła pušćiś",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Meni verm",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "TT/MM/JJJJ",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Lěto wubraś.",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Njewěsty datum",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Njespecificěrowany datumowy wobłuk",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Datum zapódaś.",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Startdatum",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Enddatum",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Njepłaśiwy datumowy format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Njepłaśiwy datumowy wobłuk",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datum zwenka dowólonego wobłuka",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Wuchowaś wuchowaś",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Datum wuzwóliś",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "WOBŁUK WUBRAŚ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pśeměniśo do kalendaŕskego modusa.",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pśeměniśo do zapódawańskego modusa.",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Cas zegera wuzwóliś.",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Cas zapódaśa.",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Góźinu",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Njepłaśiwy cas",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pśeměnśo do wahlmodusa",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pśeměnśo do zapódawańskego casa.",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Pśizjawił pśizjawił",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kontenblenden",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Kontenty pokazaś.",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigationsmenü",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menüleiste",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup-Menü",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogfeld",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Wóskam",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Pytaś",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Aktualny datum",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Wuzwólony datum",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "K startoju pśesunuś.",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Na kóńc pśesunuś.",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Na kśebjati spóraś.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Dołoj pśesunuś.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nalěwo pśesunuś nalěwo.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Napšawo gibaś.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Wochłoźiś jo wótžněte.",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt (Engelski)",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt-Diagramm",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Shift-lock-tasta",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal dołoj",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal górjej",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Wóźenje",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Lašowaś.",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Wustarkowanje wustarcyś",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kóńc",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Wuběgnjenje",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Dom",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Zarědowaś.",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Pśikaz",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Wokna",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num-Taste",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Cyfrowy blok 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Cyfrowy blok 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Cyfrowy blok 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Cyfrowy blok 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Cyfrowy blok 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Cyfrowy blok 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Cyfrowy blok 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Cyfrowy blok 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Cyfrowy blok 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Cyfrowy blok 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Cyfrowy blok pśidawański blok",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Cyfrowy blok Komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Cyfrowy blok Dezimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Cyfrowy blok źěl",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Cyfrowy blok Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Cyfrowy blok ned",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplizieren",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Cyfrowy blok w spinkach nalěwo",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Cyfrowy blok Paren Rechts",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Cyfrowy blok subtrahieren",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Wobraz wót",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Wobraz górjej.",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Cyńśo",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Wušaltowaś",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Wobrazowku śišćaś.",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll-Taste",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Wubraś wubraś",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pśešaltowaś.",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Rum",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_dv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_dv.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "އޯޕަން ނެވިގޭޝަން މެނޫ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "އެނބުރި",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ސާފު",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ކައިރީގައި",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ޑިލީޓް ކުރޭ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "އިތުރު",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "އަންނަ މަހު",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "އޭގެ ކުރީ މަހު",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ދެން އޮތް ޞަފްޙާ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ކުރީ ސަފުހާ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ފުރަތަމަ ޞަފްޙާ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "އެންމެ ފަހު ސަފުހާ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "މެނޫ ދައްކާ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ތިރީ ޝީޓް",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ލައިސަންސް",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ސަފުތަކަށް ސަފުތައް:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ބާތިލު",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ކައިރީގައި",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ކުރިއަށް ގެންދިޔުން",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ކޮޕީ ކުރޭ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ކަނޑާލުން",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ލިޔުން ސްކޭން ކުރޭ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "އިސްއުފުލާ ބަލާށެވެ.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ވެބް ސާޗް ކުރޭ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ޙިއްޞާ ކުރުން",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "އެންމެ ރަނގަޅު",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "ޕޭސްޓް ކުރުން",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ހުރިހާ އެންމެން އިޚްތިޔާރު ކުރޭ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ލައިސަންސް ތައް ބަލާ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "އޭ.އެމް.",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ބޮޑުވަޒީރު ޑރ.",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ގަޑިތައް އިޚްތިޔާރު ކުރޭ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "މިނިޓްތައް އިޚްތިޔާރު ކުރޭ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "މަގާމުން ވަކިކުރުން",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "މެނޫ ބޭރުކޮށްލާ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ހޮވާ އަހަރު",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ކަނޑައެޅިފައި ނުވާ ތާރީޚެއް",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "ކަނޑައެޅިފައި ނުވާ ތާރީހު ރޭންޖް",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ތާރީޚަށް ވަންނާށެވެ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ފެށުނު ތާރީޚް",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ނިމޭ ތާރީޚް",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ބާޠިލު ތާރީޚް ފޯމެޓް",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ބާޠިލު ތާރީޚް ރޭންޖް",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ރޭންޖުން ބޭރުގެ ތާރީޚް",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ސޭވް ކުރޭ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ތާރީޚް އިޚްތިޔާރު ކުރޭ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ރޭންޖް އިޚްތިޔާރު ކުރޭ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ކަލަންޑަރު މޯޑަށް ބަދަލުވުން",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "އިންޕުޓް ޑޭޓް މޯޑަށް ބަދަލުވުން",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ވަގުތު އިޚްތިޔާރު ކުރޭ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ވަގުތަށް ވަންނާށެވެ!",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ގަޑި",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ބާޠިލު ވަގުތު",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ޑައިލް މޯޑަށް ބަދަލުވުން",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "އިންޕުޓް ޓައިމް މޯޑަށް ބަދަލުވުން",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ސޮއިކުރައްވާފައިވާ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "އެކައުންޓްތައް ފޮރުވުން",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "އެކައުންޓްތައް ދައްކާ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation މެނޫ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "މެނޫ ބާ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup މެނޫ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ޑައިލޮގް ކުރުން",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "އެލާޓް",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ހޯދުމުގެ މަސައްކަތް",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "މިހާރުގެ ތާރީޚް",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ހޮވުނު ތާރީޚް",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ފަށަން ޖެހޭ ފިޔަވަޅެއް",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ނިމުމަކަށް ގެނައުމަށް ކުރާ މަސައްކަތް",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "މައްޗަށް ދާށެވެ.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ތިރިއަށް ދާށެވެ.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ވާތް ފަރާތަށް މޫވް ކުރުން",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ކަނާތް ފަރާތަށް ދާށެވެ.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ތާޒާކަން",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "އެލްޓް ގްރާފް",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ކެޕިޓަލް އަކުރު",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ޗެނަލް ޑައުން",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ޗެނަލް އަޕް",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ކޮންޓްރޯލް ކުރުން",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ޑިލީޓް ކުރޭ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "އިޖެކްޓް",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "ނިމުން",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "ފިލައިގެން ދިއުން",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "އެފް.އެން.",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ގެއަށް",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "މެޓާ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "ކޮމާންޑް",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ނޫމްޕެޑް 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad އިކުއަލް",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ނޫމްޕެޑް ގުނަނީ",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ލެފްޓް",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ރައިޓް",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ޞަފްޙާ ޑައުން",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ޕޭޖް އަޕް",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "ބާރު",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ޕަވަރ އޮފް",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ޕްރިންޓް ސްކްރީން",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "ސްކްރޯލް ލޮކް",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "އިޚްތިޔާރު ކުރޭ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ޝިފްޓް",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ޖާގަ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_dyu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_dyu.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Nɔgɔsira gafe dayɛlɛ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "I ka segi ka na",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "A gwɛnin lo",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "I ka kan ka taga",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ka ban",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ka fara o kan",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kalo nata la",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kalo tɛmɛnin",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "A ka ɲɛɛ nata",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Ɲɛnamaya ɲɛɛ fɔlɔ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "A ka ɲɛɛ fɔlɔ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "A laban",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ka dumuni yira",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Fanga ye",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Fani min be sɔrɔ duguma",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lɛnpinanw",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lɔnnikɛyɔrɔ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ka ban",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "I ka kan ka taga",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Aw ka to ka taga",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "O sɛbɛ nin sɛbɛra",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ka tigɛ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sɛnɛ kɛ ka sɛbɛri kɛ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "I ka filɛli kɛ sanfɛ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "N'i ye mɔgɔ dɔ ye, a ɲini o yɔrɔ la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ka dɔ fara a kan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "O ka ɲi.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Fanga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Aw ye bɛɛ sugandi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lɔnniya yira",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Kɔrɔbɔli",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Jamana ɲamɔgɔ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Wagati dɔw sugandi",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minitiw sugandi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ka ban",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ka ban",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "San sugandi",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dɔn min ma fɔ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Dɔnkilila hakɛ tɛ fɔ",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ka don o loon na",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "K'a daminɛ loon",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dɔnkilila",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "K'a daminɛ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Dɔn laban $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fɛɛn min ye n'o tɛ se ka kɛ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Dɔnkilila ɲɛɛw",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dɔnkilila",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "I ka wari mara",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Aw ka datumu sugandi",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "KƐNƐW",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ka kalandɛri kɛcogo yɛlɛma",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ka yɛlɛma donyɔrɔ la",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Waati sugandi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "I ka waati ta",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Dɔn dɔ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti kelen",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Wagati min tɛ bɛn",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ka yɛlɛma ka kɛ telefɔni ye",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ka yɛlɛma don waati lacogo la",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "N' ye siginiden ye",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ka wari dogo",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ka kunnafoniw yira",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Nɔgɔdajɛcogo",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Dɔnkiliw ta",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Ka taga ɲɛ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ɲiningali",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kɔrɔbɔli",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "K'a ɲini",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dɔnkilila sisan",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dɔn min sugandi",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Aw ye taga ka baara daminɛ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ka taga a laban",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Aw ye yɛlɛ ka taga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "I ka taga duguma",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "I ka taga numan fɛ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "I ka taga kinibolo fɛ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fɛɛn kuraw",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Fɛɛn min be se ka kɛ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Fɛɛn min be se ka kɛ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Kɔnɔnajɛ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Fangaw ka kɛ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanali ka taga duguma",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanali ka yɛlɛ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kɛlɛ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ka ban",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ka bɔ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "K'a laban",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ka boli",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "N' ka soo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ka fara o kan",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Ka ɲɛsin",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kuntigiya",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fɛɛn minw be finɛtiriw kɔnɔ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad ka dɔ fara",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad ka jɛnkulu",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad ka don",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad ka kan ka kɛ kelen ye",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad ka caya",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ye numanbolo ta",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ka ɲi",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad ka bɔ",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "A ka sɛbɛri kɛ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "A ka sɛbɛri kɛ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Fanga",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Fanga ma don",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Kirinnifɛn",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Aw ka sɛbɛri kɛ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "K'a sugandi",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Fanga",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Fɛɛn minw be dan na",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_dzo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_dzo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "འགྲུལ་འཕྲིན་ཁ་ཕྱེ་ནིའི་མེ་ནུ་",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ལོག་སྟེ་ལོག་",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "གསལ་ཏོག་ཏོ་",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "སྦོ་ལོགས་ཁར་",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "བཏུབ་གཏང་",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ལྷག་མ་",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ཕྱི་ཟླ་འདི་ནང་",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ཟླ་ངོ་མཇུག་",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ཤུལ་མའི་ཤོག་ལེབ་",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "སྔོན་བྱོན་གྱི་ཤོག་ལེབ་",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "དང་པའི་ཤོག་ལེབ་",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "མཐའ་མའི་ཤོག་ལེབ་",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "སྟོན་ཐིག་",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "སྦ་ཐིག་",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "འོག་གི་ཤོག་སྒྲིལ་",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ལག་ཁྱེར་ཚུ་",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ཤོག་ལེབ་རེ་ལུ་ ཐིག་ཁྲམ་:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ཆ་མེད་གཏང་ནི་",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "སྦོ་ལོགས་ཁར་",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "འཕྲོ་མཐུད་འབད་",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ཡིག་སྣོད་",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "བཅད་བཟོ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ཡིག་ཆ་ཚུ་ ཨིས་པི་ཌི་",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ཡར་བལྟ་",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ཝིང་ནང་ལུ་འཚོལ་",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "བརྗེ་སོར་འབད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "འདི་ཡང་བཏུབ་",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "སྦྱོར་སྣོད་",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ག་ར་ གདམ་ཁ་རྐྱབས་",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "གློ་བུར་ཡིག་ཚུ་བལྟ་",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "བློན་ཆེན་",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "དུས་ཡུན་ཚུ་ གདམ་ཁ་རྐྱབས།",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "དུས་ཡུན་ཐོ་ཚུ་ གདམ་ཁ་རྐྱབས།",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "དགོངས་ཞུ་འབད་",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ཁ་གཏང་ནིའི་མེ་ལོང་",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ལོ་ངོ་བཙག་འཐུ་འབད་",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "དུས་ཚོད་མ་གསལ་བ་",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "དུས་ཚོད་ཚད་མ་ངེས་ཅན་",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ཚེས་གྲངས་བཙུགས་ནི།",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "འགོ་བཙུགས་པའི་ཚེས་གྲངས་",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "མཇུག་བསྡུ་བའི་དུས་ཚོད།",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "འགོ་བཙུགས་པའི་ཚེས་གྲངས་ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "མཇུག་བསྡུ་བའི་ཚེས་གྲངས་ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "དུས་ཡུན་མ་ཤོང་པའི་བཟོ་རྣམ་",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "དུས་ཡུན་མ་ཤོང་པའི་དུས་ཡུན་ཁྱམས་ཆོས།",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "དུས་ཡུན་ཚད་ལས་བརྒལ་",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "སྲུང་བཞག་",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "དུས་ཚེས་གྲངས་ གདམ་ཁ་རྐྱབས།",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "གདམ་ཁ་རྐྱབས་",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "དུས་ཚེས་གྲངས་གི་གནས་སྟངས་ལུ་བསྒྱུར་བཅོས་འབད་",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ནང་ཐིག་དུས་ཡུན་གནས་སྟངས་ལུ་བསྒྱུར་བཅོས་འབད་",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "དུས་ཚོད་འདི་ གདམ་ཁ་རྐྱབས་",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "དུས་ཡུན་བཙུགས་ནི་",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "དུས་ཡུན་ཆུ་ཚོད་",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "དུས་ཡུན་སྐར་མ་གཅིག་",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "དུས་ཡུན་མ་ཤོང་",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་ཨང་གྲངས་",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ནང་ཐིག་དུས་ཚོད་ལུ་བསྒྱུར་བཅོས་འབད་",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ཐོ་བཀོད་འབད་ཡོདཔ་ཨིན།",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "རྩིས་ཁྲ་སྦ་ནི་",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "རྩིས་ཁྲ་ཚུ་སྟོན་",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "འགྲུལ་འཕྲིན་གྱི་མེ་ནུ་",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ཟ་ཆས་ཀྱི་ཐིག་ཁྲ།",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup གི་མེ་ལོང་",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "གྲོས་བསྡུར་",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ཉེན་བརྡ་",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "འཚོལ་ཞིབ་",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "དུས་ཚེས་གྲངས་",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "གདམ་ཁ་རྐྱབ་མི་དུས་ཚོད།",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "འགོ་བཙུགས་ནིའི་དོན་ལུ་སྤོ་འགྱོ་",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "མཐའ་མཇུག་ལུ་འགྱོ་ནི་",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ཡར་འགྱོ་ནི་",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "མར་འགྱོ་ནི་",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "གཡག་ལུ་སྤོ་",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "གཡས་ཁ་ཐུག་ལུ་སྤོ་",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "གསར་གཏོད་འབད་",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "གཞན་ཚུ་",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt གི་རྩིས་ཁྲ་",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "རྒྱབ་ཁོར་གྱི་ས་ཁོངས།",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ཌེན་ཌ་ནེཤ་ Channel",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱང་རྒྱ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "སྲུང་སྐྱོབ་",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "བཏུབ་གཏང་",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ཕྱི་ཁར་བཏོན་གཏང་",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "མཇུག་བསྡུ་",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "བྱོག་འགྱོ་ཐབས།",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ཌི་ཨེམ་",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ཁྱིམ་ནང་ལུ་",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ནང་ཐིག་",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ཌེ་བི་ཡཱན་",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "བཀའ་རྒྱ་",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "སྒོ་སྒྲིག་ཚུ་",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad ༡",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ཤོག་ལེབ་ཨེབ་གཏང་འབད་",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad བཅུ་ཁ་",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad དབྱེ་བ་ཕྱེ་",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad ནང་འཛུལ་",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad འདི་འདྲ་མཉམ་ཨིན།",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad མང་ལྡོག་",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren བྱང་ཕྱད་",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren འདི་གཡས་",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad ཟུར་སྣོན་",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ཤོག་ལེབ་འདི་ མར་ཕབ་གཏང་",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ཤོག་ལེབ་ཡར་འཐུ་འབད།",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "གློག་ཤུགས་",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "གློག་ཤུགས་མ་བཏོན་",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ཨེབ་ཐོར་གྱི་ཐིག་ཁྲམ་",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock འདི་",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "གདམ་ཁ་རྐྱབས་",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "བསྒྱུར་བཅོས་",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ས་སྟོང་",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ee.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ee.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ʋu navigasi menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Míegbɔna",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Nu si me kɔ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Woƒo ʋɔ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ðe asi le eŋu",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Nu Geɖe",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Le ɣleti si gbɔna me",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ɣleti si va yi",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Axa si kplɔe ɖo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Axa si do ŋgɔ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Axa gbãtɔ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Axa mamlɛtɔ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Fia menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Wodoa gbe ɖa",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Akpaɖaka",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Mɔɖegbalẽwo",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Axawo ƒe ɖoɖowo:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ðe asi le eŋu",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Woƒo ʋɔ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Yi Edzi",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Woɖe wo ɖe go",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wotso",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Ŋlɔ nu siwo nègblɔ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kpɔ dzi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Di Internet dzi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wona Nuwo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ɛ̃, wòe.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Nu siwo wotsɔna doa gbe",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tia nu siwo katã",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kpɔ mɔɖeɖewo",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Dɔnunɔla",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Tia gaƒoƒo si nàzã",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Tia minitiwo",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ðe asi le eŋu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ðe asi le menu ŋu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ƒe si wotia",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ɣeyiɣi si womeka ɖe eme o",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ɣeyiɣi si womeka ɖe eme o",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ŋlɔ Ŋkeke",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ɣeyiɣi Si Me Wodze Ewɔwɔ gɔme",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ɣeyiɣi si me wowu enu",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Dzeƒeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒomeƒome",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Ɣeyiɣi si wowu enu $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ŋkeke ƒe ɖoɖo si mesɔ o",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ŋkeke ƒe didime si me womewɔe o",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ŋkeke si me womekpɔa mɔ ɖo o",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ɖo",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tia ŋkeke",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "NƆWƆNƆ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Trɔ ɖe ɣletigbalẽŋkekeŋusẽ ŋu",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Trɔ ɖe ŋkeke si dzi woade asi numame me",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Tia ɣeyiɣi si nàzã",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Fia ɣeyiɣi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ɣeyiɣi",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti ɖeka",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ɣeyiɣi si me womezãa ga o",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Zɔ ɖe numekugbalẽvi dzi",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Zɔ ɖe ɣeyiɣi si me wòɖo la dzi",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Míeŋlɔ agbalẽa ɖe eme",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ɣla nuxexlẽdzesiwo",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Fia nu siwo nèwɔna",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ŋutilãmenu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menuɖaka",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Nuɖugbalẽvi",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dzeɖoɖo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Nuxlɔ̃ame",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Di",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ɣeyiɣi si li fifia",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ŋkeke si wotia",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ʋu asi ɖo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ʋu yi nuwuwu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ʋu ɖe dzi",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ʋu ɖe anyi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi ɖusime",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ʋu ɖusime",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Nu Siwo Akɔ Na Wò",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Nu bubuwo",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Akpaɖaka",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Taɖodzinuwo",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ʋu Si Le Anyiehe",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ʋu Ʋuʋui",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ŋusẽkpɔɖeamedzi",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ðe asi le eŋu",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Wodoa asi ɖe eme",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Nuwuwua",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ɖo asi le wo ŋu",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Aƒe",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Tsɔe",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Dɔdzikpɔlawo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ɣletivi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tsɔ",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpawo ƒe Numpawo",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Ƒe Nu",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equality",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Adzi Ði",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Le Asiƒome",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ƒe Mɔme",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Ŋlɔ axa si le afisia",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Ŋlɔ Axa Dzi",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ŋusẽ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Nu Siwo Wodzudzɔ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Taɖodzinu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ʋu Ʋu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Tia",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Dɔwɔɖui",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ŋutilã",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_epo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_epo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Malfermu la manujon por navigacio",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Reiri",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Malpezo",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Proksima",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Forviŝi",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Pli",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Venontan monaton",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Antaŭa monato",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sekva paĝo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Antaŭa paĝo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Unua paĝo",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "La lasta paĝo",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Montru menuon",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "La ŝraŭbo",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Fontofolio",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencoj",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Liniojn je paĝo:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Nu, nu, nu, nu, nu!",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Proksima",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Daŭrigu",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopio",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tranĉita",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skani tekston",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Rigardu supren",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Serĉu en la reto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Dividi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Bone, bone.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pesto",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Elektu ĉiujn",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Vidu licencojn",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ĉefministro",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Elektu horaron",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Elektu minutojn",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Forĵetu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Forĵetu menuon",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Elekto de jaro",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ne precizigita dato",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ne precizigita datumbazo",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enskribi daton",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Komencita dato",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Findaton",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Komenco dato $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Findato $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Nelaŭdata datumformato",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Nelaŭdata datumintervalo",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dato ekster intervalo",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Savu",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Elektu daton",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Elektu rangon",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ŝanĝu al kalendara reĝimo",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ŝanĝu al datum-modo",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Elektu tempon",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Enigu tempon",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "horo",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Malvalida tempo",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ŝanĝu al la dialo",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ŝanĝu al eniga tempo-modo",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Subskribita",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kaŝu konton",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Montru kontojn",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigadmenuo",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menujobako",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menuo",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerto",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Serĉu",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Aktuala dato",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Elektita dato",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Moviĝas por komenci",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Movi al fino",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pli supren",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Movu malsupren",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Moviĝu maldekstren",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Movu dekstren",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Reflekso",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Grafo",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "La malantaŭa spaco",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapuŝoj Fermo",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanalo malsupren",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanalo supren",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrolado",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Forviŝi",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finon",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Eskapado",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Hejmo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Enmeti",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fenestroj",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad aldoni",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Dividi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Eniru",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Egala",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplikita",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Maldekstre",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Dekstra",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Paĝo malsupren",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Paĝo supren",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Potenco",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Malŝaltita elektro",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Ekrano",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ruliĝanta ŝlosilo",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Elektu",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Ŝanĝo",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spaco",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_fj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fj.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Dolava na menu ni navigation",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Lesu",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Vakamatatataka",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Sogota",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Bokoca",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Eso tale",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Vula mai oqo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Vula sa oti",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Tabana e tarava",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Tabana e liu",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "iMatai ni tabana",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "iOtioti ni tabana",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Vakaraitaka na menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pepa e ra",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Laiseni",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Iyatu ena dua na draunipepa:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Bokoci",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Sogota",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tomana",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Lavetaki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Musu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Vakadikeva na itukutuku",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Rai cake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Vakasaqaqara ena mataveilawa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wasea",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Vinaka",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Vakabira",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Digitaka kece",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Raica na laiseni",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Digitaka na auwa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Digitaka na miniti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Vagalalataki",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Vakasuka na menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Digitaka na yabaki",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tikinisiga sega ni vakadeitaki",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Tikinisiga sega ni vakadeitaki",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Vakacuruma na Tikinisiga",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tikinisiga ni Tekivu",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tikinisiga ni Cava",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Sega ni cala na ituvatuva ni tikinisiga",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Sega ni cala na tikinisiga",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tikinisiga e sega ni tiko kina",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Vakabula",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Digitaka na tikinisiga",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "DIGITAKA NA IWASEWASE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Veisau ki na ivakarau ni kaleda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Veisau ki na ivakarau ni tikinisiga ni vakacurumi",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Digitaka na gauna",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Vakacuruma na gauna",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Auwa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Gauna cala",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Veisau ki na ivakarau ni dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Veisau ki na ivakarau ni gauna ni vakacurumi",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sainitaki",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Vunitaka na akaude",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Vakaraitaka na akaude",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ni navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Veivosaki",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Yadrava",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Vakasaqaqara",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tikinisiga ena gauna oqo",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tikinisiga digitaki",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Toso me tekivu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Toso ki na itinitini",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Toso cake",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Toso sobu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Toso imawi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Toso imatau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Vakavouya",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Sala Sobu",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Vakatulewa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Bokoca",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Vakatalai",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kena itinitini",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Dro",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Vale",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Vakacurumi",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Vakarota",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Katubaleka",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Loka ni Num",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Kuria na Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Wasei ni Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad tautauvata",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren imawi",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Matau",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Vakalailaitaka",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Tabana e Sobu",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Tabana e cake",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kaukauwa",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Boko na livaliva",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Sikirini ni Tabaki",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Loka ni iVolavivigi",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Digitaka",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Veisau",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Maliwa lala",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_fo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Lat/latið navigatiónsvalmyndina upp",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Aftur",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Klárt",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Lat/latið vera",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Strika",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Meira",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Næsta mánað",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Undanfarna mánað",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Næsta síða",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Fyrri síða",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Fyrsta síða",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Síðsta síða",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Vís matseðilin",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Neðsta arkið",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Loyvi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Røðir á síðu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Avlýsa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Lat/latið vera",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Halda áfram",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopiera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skera",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skanna tekst",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Hygg/Hyggið upp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Leita á netinum",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ÓKEY",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Líma inn",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velja alt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Skoða loyvi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Veljið tímar",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Veljið minuttir",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Vísa burtur",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Vís matseðilin burtur",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Vel ár",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Óávís dagsetning",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Óspecificerað dagsetningarbil",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Slá inn dagfesting",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Byrjanardagur",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Endadagur",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ógilt dagsnið",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ógilt dagtíðarbil",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dagsetning uttanfyri frástøðu",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Spara",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Veljið dag",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "VELJIÐ ÚRVAL",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Skifta til kalendaramodus",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Skift/skiftið til inntøkudagmodus",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Vel tíð",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Slá inn tíð",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Tími",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuttur",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ógild tíð",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Skift/skiftið til uppringingarmáta",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Skift/skiftið til inntøkutíðarmodus",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Innritaður",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fjala kontur",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Vís frágreiðingar",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigering matseðill",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Matseðil bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup matseðill",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Samrøða",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ávaring",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Leita",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Núverandi dagsetning",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Vald dagsetning",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Flyt teg fyri at byrja",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Flyt til enda",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Flyt teg upp",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Flyt teg niður",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Flyt/Flytið teg/tykkum til vin",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Flyt/Flytið teg/tykkum til høg",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Endurnýggja",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Bakpláss",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Stórstavalás",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Rás niður",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Rás upp",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Stýring",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Strika",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Blaka út",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Endi",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Flýggja",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Heim",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Seta inn",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Leiðsla",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Vindeygu",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad leggja afturat",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad desimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad býta sundur",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad líka",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad multiplicera",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren til vinstri",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren høgra",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad draga frá",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Síða niður",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Síða upp",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kraftur",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Sløkk",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Prenta skíggja",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Rulla lás",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Veljið",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Skift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Rúmd",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_fon.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fon.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Nǔɖogbɛ̀ jí nùɖíɖó jí",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Wǔ yì",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Nǔɖé ɖ'ayǐ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Zě ɖò zɔ̀n wɛ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Zɛ́n",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Hwenɛ́nu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Azǎn jǎwe ɔ́",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "sun e jɛ nukɔn é",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Xota ɖevo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Xota e jɛ nukɔn é",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Xota nukɔntɔn ɔ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Xota gǔdo gúdo tɔn",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Nǔɖogbɛ nùɖíɖó tɔn",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Wǔvɔ́",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Xɛ́n e ɖò azinzan ɔ́ mɛ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Sɛ́nxwínmɛ lɛ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Xwe lɛ ɖò xota ɖokpo ɖokpo jí:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ÐáñÜãåé",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Zě ɖò zɔ̀n wɛ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Nɔ yì nukɔn",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Wǔxwɛ́",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wǔ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Wlǎnɖó nùxwlé",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kpɔ́n jǐ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nɔ́ xo ɖò Internet ɔ mɛ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wě nǔ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "É ɖò ganjí",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Wǔvɔ́",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi bǐ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kpɔ́n nùxwlí lɛ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Xwé e è ɖè lɛ é",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Xwé xota ɖé",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kún nǔ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kún nǔɖokpo",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Xwe e è xwixò é",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "azǎn e è ma ɖɔ ɖ'ayǐ ǎ é",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "azǎn e è ma ɖɔ ɖ'ayǐ ǎ lɛ é",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Wlǎn yì",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kúnmɛ̀ jɛ̀",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kúnmɛ̀",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Kúnmɛ̀ nùɖé $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "azǎn xota $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Wěma nùɖé ɖò azǎn ɔ jí",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "azǎn e è nɔ zán ǎ lɛ é",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "azǎn e è ɖè sín azɔ̌kpaka ɔ mɛ é",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Zě wŏ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Xwé azǎn",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "XWÉXWÉXWÉ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Zě yì gbè nùxwínxwínxwínxwínxwínxwínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínxínx",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Zě yì gbè nùxwínwá",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Xwé ɖé",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Wà hwenu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Gan ɖokpo",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Xwe ɖokpo",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Akɔ̀n e è ma ɖó ǎ é",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Zɛ̀n yì nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù nù",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Zɛ̀n yì wànɖànɖànɖàn",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "È sè gbè dó",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Xwlɛ́n nùxwlɛ́n",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ðàññêàçûâàòü ðèñû",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Nǔɖogbɛ̀ jí",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu kpò",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Nǔɖogbɛ e ɖò nùɖíɖó mɛ é",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Xó ɖɔ xó dó nùxwlé",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Xlɛ́n",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kpɔn",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "azǎn e ɖò azɔ̌ wɛ é",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Xwe e è xwetɔ́n é",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mi jɛ nukɔn",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Zɛ̀ yì yì yì",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Dàn yì nukɔn",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Zɛ̀n yì jɛ̀n",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi ɖisíxwé",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Dǒ ɖisí",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Nǔɖogbɛ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alti nùxámɛ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Xɛ́nxámɛ̀ lɛ́ɛ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kpɔnkpɔnkpɔn",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanlin e ɖò jɛ̀n wɛ é",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanlin ɖò jí",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Nǔɖokponɔ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Zɛ́n",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "È nɔ́ dɔn ɛ yì",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Xwe ɔ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Mɛ lɛ́ɛ hɔn",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Xwé",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Wlǎ kpò",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Mɛta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Nǔɖomɛ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Xwéwé",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Nú Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "nùkpá",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad lɛ́ɛ ɖò wè",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad byɔ",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equality",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad bɔ̀ é sɔ́",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ɖisí",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ɖisí",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Xwéwé dó nùxwlí",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Xwé ɖé dó jǐ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Nǔkpinkpan",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Nǔkpinkpan sín nǔ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Wlǎnsin nǔɖòɖó",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Wǔxixwɛ́ wǎ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Kpo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "azɔ̀ lɛ́ɛ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Azɔ̀n",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_fur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fur.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menù di navigazion apert",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Tornâ indaûr",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Cjargne",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Incuintri",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scjariâ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Plui di plui",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Il mês che al ven",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "mês previodût",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "La prossime pagjine",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pagjine anteriore",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prime pagjine",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ultime pagjine",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostre il menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrifâ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pagjine di basse",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenziis",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lis file par pagjine:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancelâ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Incuintri",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continuait a fâlu",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglât",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scaneâ il test",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Cjale sù",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cîr su la rêt",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Parcjâ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Va ben, alore",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezionâ ducj",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visâ lis licencis",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Prime Aministrazion",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Scelti oraris",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Selezion di minûts",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Disponsâ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dispose di menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "An di selezion",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data no specificade",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Difinît interval di date",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Date di inseriment",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data di iniziâ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data di fin",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data di inizi $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Finâl date $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format di date invalide",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Difinzion di date invalide",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fûr dal cjamp",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvâ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selezion date",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT une bande",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Passâ a mode calendari",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passâ a la date di input mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selezion di timp",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Inserî l' orari",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ore di vore",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minût",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Timp invalide",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Passâ a mode di schermâ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Passâ a la mode di timp di input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Firmât",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Classificazion di cont",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostre i contis",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu di navigazion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barc di menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menù in popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo dialogo dialogo dialogo dialogo dialogo dialogo dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alertazion",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ricercje",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data di funzionament",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dati sielzût",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Movi par scomençâ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Passi fintremai",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si movi sù",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si movi di là",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si spostin a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si movi a drete",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ressurfazion",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alts",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafic alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spazi di ret",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Capiçâ il cjâf",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canaliç Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canaliç sù",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scjariâ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ejectât",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finâl",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fugjiment",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Cjasis di cjase",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Inserî",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comantât",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Furlanis",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Comme di Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Nummar decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equalitât",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicât",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren a sinistra",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren di dreç",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Sottrazion di Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pagjine di scjampâ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagjine sù",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Puarte",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Disclusion dal energjie",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Impression di schermi",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrolâ il bloc",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selezionâ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Scjampâ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spaziâl",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_fuv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fuv.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu fuɗɗiiɗo naawirgo",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Wotaago",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Luttugo",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ɓooyɗe",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Fulide",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ɓeydi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ɗuum lewru ɓaawo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Fedde ndeen",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Winndannde yeeso",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Winndannde yeeso",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Fuɗɗoode",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Jaɓɓorgo Haalde",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skaram",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lata dow",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisensji",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lillaaji dow leggal:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Fulide",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ɓooyɗe",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ɗoɗɗii",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Koode",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ɓanngoo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sandaarol ɗemngal",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ndaaree dow",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fandita nder web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wondirde",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Okay",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Fedde",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taƴi fuu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Yiilaade liisaaji",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Suɓugo saa'i",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Taƴoode jaɓɓorgo",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Fulide",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fulii menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Taweete footi",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tawiinde nde",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ɗuum wakkati ɗon taƴa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Winndannde yeeso",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ndenndi fuɗɗam",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Sahaa ɓaawo",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Fuɗde fuɗɗam $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Fedde nde nde $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Firo taariikol ngol walaa",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Safaare taariikɗe naa' nden",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Taare nder daande",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Jaɓɓorgo Fedde",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Taƴde taariik",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "HINNAANDE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Wattuki to calnde",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Wattuki to laawol taariikol jaɓɓorgo",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Taƴo wakkati",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Weki wakkati",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Sahaa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Sahaa naa' na",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Wattita to moddi diyal",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Wattuki to wakkati wakkati naptuki",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ɗuum ko e nder",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ɓooyde konte",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Firo koode",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diiwaangal",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Wurooji",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Fuki",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Safaare hannde",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Nyannde koɓaaɗe",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ɗaɓɓo fuɗɗugo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jaɓɓorgo Fuuta",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wonduki dow",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Wonduki dow",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Taƴa haa nano",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Wonduki haa nano",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fedde ɓeydiinde",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alta",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alta Graaf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ɓaawo ɓaawo",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ɗuum ɗon ɓuwa",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Laddol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Fulide",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Fuligo",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kootol",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fuude",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Duule",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Wondondondira",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kooftaaku",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Winndannde yeeso",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad feccere",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad ɗuuɗal",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kuugal",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Woni semmbe",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Winndannde yeesoWolde",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Firo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Ɗuumɗam",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ɗuum woni",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ga.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ga.arb
@@ -1,158 +1,641 @@
 {
-  "remainingTextFieldCharacterCountFew": "$remainingCount charachtar fágtha",
-  "licensesPackageDetailTextTwo": "$licenseCount cheadúnas",
-  "licensesPackageDetailTextFew": "$licenseCount cheadúnas",
-  "licensesPackageDetailTextMany": "$licenseCount gceadúnas",
-  "selectedRowCountTitleTwo": "$selectedRowCount mhír roghnaithe",
-  "selectedRowCountTitleFew": "$selectedRowCount mhír roghnaithe",
-  "selectedRowCountTitleMany": "$selectedRowCount mír roghnaithe",
-  "remainingTextFieldCharacterCountTwo": "$remainingCount charachtar fágtha",
-  "remainingTextFieldCharacterCountMany": "$remainingCount gcarachtar fágtha",
-  "openAppDrawerTooltip": "Oscail an roghchlár nascleanúna",
-  "backButtonTooltip": "Siar",
-  "clearButtonTooltip": "Glan an téacs",
-  "closeButtonTooltip": "Dún",
-  "deleteButtonTooltip": "Scrios",
-  "moreButtonTooltip": "Tuilleadh",
-  "nextMonthTooltip": "An chéad mhí eile",
-  "previousMonthTooltip": "An mhí roimhe",
-  "nextPageTooltip": "An chéad leathanach eile",
-  "previousPageTooltip": "An leathanach roimhe seo",
-  "firstPageTooltip": "An chéad leathanach",
-  "lastPageTooltip": "An leathanach deiridh",
-  "showMenuTooltip": "Taispeáin an roghchlár",
-  "scrimLabel": "Scrioma",
   "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
   "timeOfDayFormat": "HH:mm",
-  "bottomSheetLabel": "Bileog Íochtarach",
-  "scrimOnTapHint": "Dún $modalRouteContentName",
-  "aboutListTileTitle": "Maidir le $applicationName",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Oscail roghchlár nascleanúna",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ar ais",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Glan",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Dún",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scrios",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Tuilleadh",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "An mhí seo chugainn",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "An mhí roimhe sin",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "An chéad leathanach eile",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "An leathanach roimhe seo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "An chéad leathanach",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "An leathanach deireanach",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Taispeáin roghchlár",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bileog íochtarach",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
   "licensesPageTitle": "Ceadúnais",
-  "licensesPackageDetailTextOne": "Aon cheadúnas amháin",
-  "licensesPackageDetailTextOther": "$licenseCount ceadúnas",
-  "pageRowsInfoTitle": "$firstRow-$lastRow de $rowCount",
-  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow de thuairim is $rowCount",
-  "rowsPerPageTitle": "Rónna in aghaidh an leathanaigh:",
-  "tabLabel": "Cluaisín $tabIndex de $tabCount",
-  "selectedRowCountTitleOne": "Aon mhír amháin roghnaithe",
-  "selectedRowCountTitleOther": "$selectedRowCount mír roghnaithe",
-  "cancelButtonLabel": "Cealaigh",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Sraitheanna in aghaidh an leathanaigh:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cuir ar ceal",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
   "closeButtonLabel": "Dún",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
   "continueButtonLabel": "Lean ar aghaidh",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
   "copyButtonLabel": "Cóipeáil",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
   "cutButtonLabel": "Gearr",
-  "scanTextButtonLabel": "Scan téacs",
-  "lookUpButtonLabel": "Cuardaigh",
-  "searchWebButtonLabel": "Cuardaigh an Gréasán",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scanadh téacs",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Cuardaigh suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cuardaigh ar an ngréasán",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
   "shareButtonLabel": "Comhroinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
   "okButtonLabel": "Ceart go leor",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
   "pasteButtonLabel": "Greamaigh",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
   "selectAllButtonLabel": "Roghnaigh gach rud",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
   "viewLicensesButtonLabel": "Féach ar cheadúnais",
-  "anteMeridiemAbbreviation": "R.N.",
-  "postMeridiemAbbreviation": "I.N.",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM:",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
   "timePickerHourModeAnnouncement": "Roghnaigh uaireanta",
-  "timePickerMinuteModeAnnouncement": "Roghnaigh nóiméid",
-  "modalBarrierDismissLabel": "Ruaig",
-  "menuDismissLabel": "Ruaig an roghchlár",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Roghnaigh nóiméad",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Díbhe",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Díbh roghchlár",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
   "dateSeparator": "/",
-  "dateHelpText": "ll/mm/bbbb",
-  "selectYearSemanticsLabel": "Roghnaigh bliain",
-  "unspecifiedDate": "Dáta",
-  "unspecifiedDateRange": "Raon Dátaí",
-  "dateInputLabel": "Cuir Isteach Dáta",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/bbbb",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Roghnaigh an bhliain",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dáta neamhshonraithe",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Raon dátaí neamhshonraithe",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Iontráil Dáta",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
   "dateRangeStartLabel": "Dáta Tosaigh",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
   "dateRangeEndLabel": "Dáta Deiridh",
-  "dateRangeStartDateSemanticLabel": "Dáta tosaigh $fullDate",
-  "dateRangeEndDateSemanticLabel": "Dáta deiridh $fullDate",
-  "invalidDateFormatLabel": "Formáid neamhbhailí.",
-  "invalidDateRangeLabel": "Raon neamhbhailí.",
-  "dateOutOfRangeLabel": "Lasmuigh den raon.",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formáid dáta neamhbhailí",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Raon dáta neamhbhailí",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dáta lasmuigh den raon",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
   "saveButtonLabel": "Sábháil",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
   "datePickerHelpText": "Roghnaigh dáta",
-  "dateRangePickerHelpText": "Roghnaigh raon",
-  "calendarModeButtonLabel": "Athraigh go féilire",
-  "inputDateModeButtonLabel": "Athraigh go hionchur",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ROGHNAIGH RON",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Athraigh go mód féilire",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Athraigh go mód dáta ionchuir",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
   "timePickerDialHelpText": "Roghnaigh am",
-  "timePickerInputHelpText": "Cuir isteach am",
-  "timePickerHourLabel": "Uair",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Iontráil am",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Uair an chloig",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
   "timePickerMinuteLabel": "Nóiméad",
-  "invalidTimeLabel": "Cuir isteach am bailí",
-  "dialModeButtonLabel": "Athraigh go mód roghnóra aghaidh an chloig",
-  "inputTimeModeButtonLabel": "Athraigh go mód ionchuir téacs",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Am neamhbhailí",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Athraigh go mód dhiailiú",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Athraigh go mód ama ionchuir",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
   "signedInLabel": "Sínithe isteach",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
   "hideAccountsLabel": "Folaigh cuntais",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
   "showAccountsLabel": "Taispeáin cuntais",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
   "drawerLabel": "Roghchlár nascleanúna",
-  "menuBarMenuLabel": "Roghchlár an bharra roghchláir",
-  "popupMenuLabel": "Roghchlár aníos",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barra roghchláir",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Achomh-roghchlár",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
   "dialogLabel": "Dialóg",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
   "alertDialogLabel": "Foláireamh",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
   "searchFieldLabel": "Cuardaigh",
-  "currentDateLabel": "Inniu",
-  "selectedDateLabel": "Roghnaithe",
-  "reorderItemToStart": "Bog chuig an tús",
-  "reorderItemToEnd": "Bog chuig an deireadh",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dáta reatha",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dáta roghnaithe",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Bog go tosaigh",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Bog go dtí an deireadh",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
   "reorderItemUp": "Bog suas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
   "reorderItemDown": "Bog síos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
   "reorderItemLeft": "Bog ar chlé",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
   "reorderItemRight": "Bog ar dheis",
-  "expandedIconTapHint": "Laghdaigh",
-  "collapsedIconTapHint": "Leathnaigh",
-  "expansionTileExpandedHint": "tapáil faoi dhó chun laghdú",
-  "expansionTileCollapsedHint": "tapáil faoi dhó chun leathnú",
-  "expansionTileExpandedTapHint": "Laghdaigh",
-  "expansionTileCollapsedTapHint": "Leathnaigh chun tuilleadh sonraí a fháil",
-  "expandedHint": "Laghdaithe",
-  "collapsedHint": "Leathnaithe",
-  "remainingTextFieldCharacterCountOne": "Aon charachtar amháin fágtha",
-  "remainingTextFieldCharacterCountOther": "$remainingCount carachtar fágtha",
-  "refreshIndicatorSemanticLabel": "Athnuaigh",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Athnuachan",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
   "keyboardKeyAlt": "Alt",
-  "keyboardKeyAltGraph": "AltGr",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graf Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyBackspace": "Cúlspás",
-  "keyboardKeyCapsLock": "Glas Ceannlitreacha",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Glas ceannlitreacha",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyChannelDown": "Cainéal Síos",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyChannelUp": "Cainéal Suas",
-  "keyboardKeyControl": "Ctrl",
-  "keyboardKeyDelete": "Del",
-  "keyboardKeyEject": "Caith amach",
-  "keyboardKeyEnd": "End",
-  "keyboardKeyEscape": "Esc",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Rialú",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scrios",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Díbirt",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Deireadh",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Éalú",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyHome": "Baile",
-  "keyboardKeyInsert": "Insert",
-  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ionsáigh",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "MetaCity name (optional, probably",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
   "keyboardKeyMetaMacOs": "Ordú",
-  "keyboardKeyMetaWindows": "Win",
-  "keyboardKeyNumLock": "Uimhirghlas",
-  "keyboardKeyNumpad1": "Num 1",
-  "keyboardKeyNumpad2": "Num 2",
-  "keyboardKeyNumpad3": "Num 3",
-  "keyboardKeyNumpad4": "Num 4",
-  "keyboardKeyNumpad5": "Num 5",
-  "keyboardKeyNumpad6": "Num 6",
-  "keyboardKeyNumpad7": "Num 7",
-  "keyboardKeyNumpad8": "Num 8",
-  "keyboardKeyNumpad9": "Num 9",
-  "keyboardKeyNumpad0": "Num 0",
-  "keyboardKeyNumpadAdd": "Num +",
-  "keyboardKeyNumpadComma": "Num ,",
-  "keyboardKeyNumpadDecimal": "Num .",
-  "keyboardKeyNumpadDivide": "Num /",
-  "keyboardKeyNumpadEnter": "Num Enter",
-  "keyboardKeyNumpadEqual": "Num =",
-  "keyboardKeyNumpadMultiply": "Num *",
-  "keyboardKeyNumpadParenLeft": "Num (",
-  "keyboardKeyNumpadParenRight": "Num )",
-  "keyboardKeyNumpadSubtract": "Num -",
-  "keyboardKeyPageDown": "PgDown",
-  "keyboardKeyPageUp": "PgUp",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fuinneoga",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Ainm Glas",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Uimceart 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Uimhimceap 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Uimhimchlár 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Uimleabhar 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Cuir Numpad Leis",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Camóg Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Deachúil",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Roinnt Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Iontráil Numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Comhionann",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Iolrú Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Paren Numpad ar Chlé",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Paren Numpad ar Dheis",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Dealú Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Leathanach Síos",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Leathanach Suas",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeyPower": "Cumhacht",
-  "keyboardKeyPowerOff": "Múch",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Cumhacht Múchta",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
   "keyboardKeyPrintScreen": "Priontáil Scáileán",
-  "keyboardKeyScrollLock": "Scrollghlas",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrollaigh Glas",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
   "keyboardKeySelect": "Roghnaigh",
-  "keyboardKeyShift": "Shift",
-  "keyboardKeySpace": "Space"
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Athrú",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spás",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
 }

--- a/packages/flutter_localizations/lib/src/l10n/material_gla.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gla.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu seòlaidh fosgailte",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Air ais",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Fìor-fhìor",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "A ' dol faisg",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Cuir às",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Barrachd",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "An ath mhìos",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mìos roimhe",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next duilleag",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Duilleag roimhe",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prìomh duilleag",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Duilleag Mu dheireadh",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Sealltainn menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Sgriom",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Leabhar-làimhe",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Cead-seòrsa",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rann gach duilleag:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "A dh ' ath-dhùnadh",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "A ' dol faisg",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Lean air adhart",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Còmhdach",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Gearradh",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Teacs a sganadh",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Thoir sùil suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Lorg air an lìonra",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "A ' roinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "A-mach",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tagh uile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Seallaidh cead",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Prìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh-Phrìomh",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Tagh uairean",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Tagh mionaidean",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Cùl-seachad",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Mean-làimhe a dhùnadh",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Bliadhna a thaghadh",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dàmh neo-aithnichte",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Rann-latha neo-aithnichte",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Cuir a-steach Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ceann-latha tòiseachaidh",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ceann-latha crìochnachaidh",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Ceann-latha tòiseachaidh $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Ceann-latha crìoch $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fòn-là-latha neo-dligheach",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Rann-latha neo-chruaidh",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ceann-latha a tha a ' dol a-mach às an raon",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sàbhail",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tagh-latha a thaghadh",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SCEAL an raon",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ath-ghluasad gu modh clàr",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ath-ghluasad gu modh ceann-latha inntrigidh",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Tagh ùine",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Cuir a-steach ùine",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Uaire",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Beag",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Amannan neo-chabhasach",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ath-ghluasad gu modh dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ath-ghluasad gu modh ùine inntrigidh",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Air a sonadh",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Cunntasan falaichte",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Sealltainn cunntasan",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu siubhail",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barra buidseat",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tarraing",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Rannsachadh",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ceann-latha làithreach",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ceann-latha a chaidh a thaghadh",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "A ' gluasad gus tòiseachadh",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A ' gluasad gu deireadh",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Thoir suas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Thoir sìos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "gluasad gu taobh chlì",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Thoir air làimh dheis",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ath-bheothachadh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graf Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ruim air ais",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel sìos",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel suas",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Rianachd",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Cuir às",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Críoch",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Teich air falbh",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Dachaigh",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Cuir a-steach",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comhairle",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Comma Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "No-phàis-deasail",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Nochd Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Co-ionann",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Clì",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ceart",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Cùl-a-mach Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pàirt sìos",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Leugh suas",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Cumhachd",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Cumhachd Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Clò-bhualadh",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Tagh",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Beatha",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spèis",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_gn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ménue de navegación ojepe'áva",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Jevy",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ñemomorã",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Oñemboja'o",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ñehundíke",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Hetave",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mes oúvape",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mes ohasava'ekue",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Kuatiarogue ojoajúva",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Kuatiarogue ojoajúva",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kuatiarogue peteĩha",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kuatiarogue ipaha",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Emohechauka menú",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ñembosarái",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Kuatiarogue ipýpe",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencia rehegua",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rráo página-pe:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ñemomombyry",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Oñemboja'o",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Toñepysyrõ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ojeja'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Ñemohenda kuatiarogue",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ehecha yvate",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Eipukuaa ñandutípe",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ñembojoajúva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Iporã.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Ñemohenda",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Eiporavo opaite",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ehecha umi licencia",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PÑS",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Ojeiporavo aravo",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Eiporavo kuatiarogue",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ñemboyke",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ñemohendaha",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "D/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ojeiporavo ary",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ára oje'e'ỹva",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Arandupy oje'e'ỹva",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ñemohenda ára",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tavakuéra oñepyrũva",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Aranduka ára paha",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Ta'angambyry mbohasáva $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Arareko paha $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Aranduka data noñemoguahêiva",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Arandupy'ỹ rehegua",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ára ojehecha'ỹva",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Eipuru",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Eiporavo ára",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Eiporavo pe rango",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Emoambue jehaipyre calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Emoambue jehaipyre data de entrada",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Eiporavo aravo",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Oike aravo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Aravo",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Peteî minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Arapytu'u ndojapóiva",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Emoambue mba'éichapa ojehai",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Emoambue tiempo de entrada",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Oñemohenda",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Oñemomombyry umi cuenta",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ehechauka umi cuenta",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ménue de navegación",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu barra",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menú popup rehegua",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ñe'ẽjoaju",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Jeheka",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ararandu rehegua",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ára ojeporavóva",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ñepyrũrã ñepyrũ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oguata opaite peve",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Epu'ã ha epu'ã",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Eho mombyry",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Eho tapére",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Eho oñondive",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ñembopyahu",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Ñemohenda:",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafo Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Pykue gotyo",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ñemohendaha",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ñemohenda yvate gotyo",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control rehegua",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ñehundíke",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ojejapo",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ipahápe",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Oikóva",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Hogarã",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ñemoĩ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta rehegua",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Umi ventana",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Añembohape",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad oñemboja'o",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Igual",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad multiplicación",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kuãga",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtracción",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kuatiarogue ipýpe",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kuatiarogue Yvate",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mba'epu'aka",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Mba'epu'aka'ã",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Impresión Ta'anga",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ñembohesa'ỹijo",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Eiporavo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Jehepyme'ẽ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ypytu'u",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_gom.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_gom.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ओपन नॅव्हिगेशन मेनू",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "फाटीं",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "नितळसाण",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "बंद",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "डिलीट कर",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "चड",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "फुडलो म्हयनो",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "आदलो म्हयनो",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "फुडलें पान",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "आदलें पान",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पयलें पान",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "निमाणें पान",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू दाखय",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "तळयेची पत्री",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "परवाने",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "दर पानाक पंक्ती:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द करचें",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "बंद",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "चालू दवरप",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "प्रत",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कातरप",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "मजकूर स्कॅन कर",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "देखीक",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब सोद",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "वांटप",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "बरें",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सगलें वेंचून काडप",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "परवाने पळोवप",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "एएम",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "प्रधानमंत्री",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "वेंचून काडपाची तासां",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनटां वेंचून काडप",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "बरखास्त",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Usmiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "डड्ड/म्म/यूय",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "वेंचून काडिल्लें वर्स",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अनिर्दिष्ट तारीख",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अनिर्दिष्ट तारखेची श्रेणी",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "तारीख नोंद करात",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "सुरवात तारीख",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "सोंपपाची तारीख",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध तारीख श्रेणी",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "रेंज भायर तारीख",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "सांबाळप",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "तारीख वेंचून काडप",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "रेंज वेंचून काडात",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कॅलेंडर मोडांत स्विच कर",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट तारीख मोडांत स्विच कर",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "वेळ वेंचून काडप",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "वेळ घाल",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "तास",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनिट",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अमान्य वेळ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोडांत स्विच कर",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट टायम मोडांत स्विच कर",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "तातूंत स्वाक्षरी केल्ली",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "हिशेब लिपोवन दवरप",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खातीं दाखयतात",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू बार",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "सतर्क",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "सोद",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "सद्याची तारीख",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "वेंचून काडिल्ली तारीख",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "सुरवात करपाची चाल",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "शेवटाक हालचाल",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "वयर सरप",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "सकयल सरप",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "दावे वटेन हालचाल",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "उजवे वटेन सरप",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "रिफ्रेश करप",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "आल्ट",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "आल्ट आलेख",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कॅप्स लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "चॅनल डाउन",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "चॅनल अप",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "डिलीट कर",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "भायर काडप",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "शेवट",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "पळेइयात",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "फा.",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घर",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "घालप",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "आज्ञा",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "विंडोज",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नुम ताळो",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नुंपद १",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नुंपद 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नुंपद 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नुंपद 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नुंपद ५",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नुंपद 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नुंपद 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नुंपद 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नुंपद 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नुंपद ०",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "नुंपद जोडलें",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "नुंपद अल्पविराम",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नुंपद दशांश",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नुंपद वांटप",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "नुंपद प्रविष्ट",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "नुंपद बराबर",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "नुंपद गुणाकार",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नुंपाद परें बांय",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "नुंपद परें बरोबर",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नुंपद वजा",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पान सकयल",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पेज अप",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "शक्ती",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "वीज बंद",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "छापील स्क्रीन",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रोल लॉक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "वेंचून काडप",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अंतराळ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ha.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ha.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Buɗe menu na kewayawa",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Baya",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "A bayyane",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kusa",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ƙari",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Wata mai zuwa",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Watan da ya gabata",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Shafi na gaba",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Shafin da ya gabata",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Shafi na farko",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Shafi na karshe",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Nuna menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Takardar ƙasa",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lasisi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Layuka a kowane shafi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Sokewa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kusa",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ci gaba",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kwafi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Yanke",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan rubutun",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Duba sama",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Bincika yanar gizo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Raba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "TO",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Manna",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zaɓi duka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Duba lasisi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Firayim Minista",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Zaɓi sa'o'i",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Zaɓi minti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dakatar da shi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fitar da menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd / mm / yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Zaɓi shekara",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Kwanan wata da ba a bayyana ba",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jerin kwanan wata da ba a bayyana ba",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Shigar da kwanan wata",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ranar Farawa",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kwanan wata",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Tsarin kwanan wata bai dace ba",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Tsarin kwanan wata mara inganci",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Kwanan wata daga kewayon",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ajiye",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Zaɓi kwanan wata",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ZAƁI RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Canja wurin zuwa yanayin kalanda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Canja wurin zuwa yanayin kwanan wata",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Zaɓi lokaci",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Shigar da lokaci",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Sa'a",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minti daya",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Lokaci mara inganci",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Canzawa zuwa yanayin kira",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Canja wurin zuwa yanayin lokacin shigarwa",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sanya hannu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ɓoye asusun",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Nuna asusun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu na kewayawa",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu na popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Tattaunawa",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Faɗakarwa",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Bincike",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Kwanan wata na yanzu",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Kwanan wata da aka zaɓa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Matsar don farawa",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Motsa zuwa ƙarshe",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Matsawa sama",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Matsawa ƙasa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Matsar da hagu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Matsar da dama",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Sabunta",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Manyan haruffa",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kulawa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Fitar da",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ƙarshen",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Tserewa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Gida",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Sakawa",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Umurnin",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Ƙara",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Raba",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Shigar",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad daidai",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren hagu",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Dama",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Cire",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Shafi na ƙasa",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Shafi na Sama",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ikamfani",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kashe wutar lantarki",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Buga allon",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Kulle Gungurawa",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Zaɓi",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Canji",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Sararin samaniya",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_hne.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_hne.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "खुली नेविगेशन मेनू",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "वापस",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "साफ करे",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "बंद करे",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "हटावे",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "अउ जादा",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "आने महिना म",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पिछला महीना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अगला पृष्ठ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पिछला पन्ना",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पहिली पन्ना",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "आखिरी पन्ना",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू दिखाना",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "नीचे ले शीट",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "लाइसेंस",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रति पृष्ठ पंक्तियांः",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द करे",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "बंद करे",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी रख",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "पाठ स्कैन करे",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ऊपर देख",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब म खोज",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीक हवय",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "जम्मो चुनव",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लाइसेंस देखव",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "एएम",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "पीएम",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "चुनव समय",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनट चुनें",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करे",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "डिस्पोजेबल मेनू",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "चुने गए वर्ष",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अज्ञात तिथि",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "निर्दिष्ट तिथि सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "दिनांक दर्ज करे",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "प्रारंभ तिथि",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "समाप्ति तिथि",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "प्रारंभ तिथि $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "अंत तिथि $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अवैध तिथि स्वरूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध तिथि सीमा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "तारीख सीमा ले बाहर",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "सहेजें",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "तारीख चुनव",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "चयन करे सीमा",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेंडर मोड म स्विच करे",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट तिथि मोड म स्विच करे",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय चुनव",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समय दर्ज करे",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घंटा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनट",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अमान्य समय",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोड म स्विच करे",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट समय मोड म स्विच करे",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "हस्ताक्षर करे गए",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खाता छिपावे",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाता दिखावे",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "नेविगेशन मेनू",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू बार",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "पॉपअप मेनू",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "संवाद",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोज करे",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "वर्तमान तिथि",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चुने गए तिथि",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "शुरू करे बर आगे बढ़े",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत तक ले चल",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर बढ़े",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे ले चल",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बाएं ले चल",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिन ले चल",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ताज़ा करे",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "अल्ट",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "अल्ट ग्राफ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "बैकस्पेस",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "नीचे चैनल",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ऊपर चैनल",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "हटावे",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "बाहर करे",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अंत",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "भागना",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "एएफएन",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घर म",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "डालें",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "कमांड",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "खिड़की",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नंबर लॉक",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नम्पैड 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नम्पैड 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नम्पैड 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नम्पैड 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नम्पैड 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नम्पैड 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नम्पैड 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नम्पैड 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नम्पैड 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नम्पेड 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "नम्पड जोड़ना",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "नम्पड कॉमा",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नोम्पड दशमलव",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नम्पड विभाजित करे",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad एंटर करे",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "नम्पड समान",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "नम्पड गुणा करे",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नम्पड पेरन बाएं",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "नम्पड पेरन दाएं",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नम्पड घटाव",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पृष्ठ नीचे",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पृष्ठ ऊपर",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "बिजली",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "बिजली बंद करे",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "प्रिंट स्क्रीन",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रोल लॉक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चुनव",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अंतरिक्ष",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ht.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ht.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Meni louvri navigasyon",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Do",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Klè",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Fèmen",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "efase",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Plis",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "mwa pwochen",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mwa anvan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Pwochen paj",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Paj anvan",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Premye paj",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Dènye paj",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Montre meni",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ekriti",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Anba fèy",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisans",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ranje pou chak paj:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Anile",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Fèmen",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kontinye",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Koupé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tèks eskanè",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Gade anlè/anwo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rechèch entènèt la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pataje",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OKE",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "kale",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Chwazi tout",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Gade lisans yo",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "MWEN",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "pm",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Chwazi èdtan",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Chwazi minit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Rejte",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Meni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ane chwazi",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dat ki pa espesifye",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Dat ki pa espesifye",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Dat antre",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kòmanse Dat",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dat fen",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Dat invalid",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Dat envalid ranje",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dat soti nan ranje",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sove",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Dat chwazi",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "CHWAZI RANJE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Chanje nan mòd kalandriye",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Chanje nan mòd dat opinyon",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Chwazi tan",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Antre tan",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Lè",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minit",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tan envalid",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Chanje nan mòd rele",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Chanje nan mòd tan opinyon",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "te siyen an",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kont kache",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Montre kont",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "meni navigasyon",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Ba meni",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "meni popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dyalòg",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Vijilan",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Fouye",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dat kouran",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dat chwazi",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Deplase pou kòmanse",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Deplase nan fen",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Bouje",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bouje",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Deplase agòch",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Deplase dwat",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Rafrechi",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Espas de ren",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Majiskil",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Chèn",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Chèn Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontwòl",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "efase",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Retire",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fen",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "chape",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Lakay",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kòmand",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fenèt yo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Kadinal",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Nimpade 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Nimewo 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Nimewo 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Nimewo 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Nimewo 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Nimewo 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Nimpade 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Nimewo 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Nimewo 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Nimpadjè",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Koma nimewo",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Devlopman Desimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divize",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Antre nan Nimpad Antre",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Nimewo egal-ego",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Miltipliye",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Dwa",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Soustraksyon Nimpa",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "paj desann",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "paj Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Pouvwa",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pouvwa",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ekran enprime",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Kado",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Chwazi",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Chanjman",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Plas",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ig.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ig.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Mepee menu igodoo",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Azụ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Doro anya",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Nso",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Hichaa",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "More",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ọnwa na-abịa",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ọnwa gara aga",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Peeji na-esonụ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Peeji nke gara aga",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Peeji nke mbụ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Peeji nke ikpeazụ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Gosi menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Mpempe akwụkwọ ala",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Akwụkwọ ikike",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ahịrị kwa peeji:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kagbuo",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Nso",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Gaa n'ihu",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Debata",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Bee",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Iṅomi ngwe",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Lelee elu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kwa ụbọchị WEB",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ịkekọrịta",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ọ dị mma",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Mado",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Họrọ ihe niile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Gosi ikikere",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Abụ m",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Họrọ awa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Họrọ nkeji",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Chụpụ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Hichaa menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "DD / MM / YYYY",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Họrọ afọ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ụbọchị ndị a na-akọwaghị",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ebe a na-akụrụghị ụbọchị ndị a na-akụrụghị",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tinye ụbọchị",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Mbido ụbọchị",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ọgwụgwụ ụbọchị",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ọdịdị ụbọchị na-abaghị n'aka",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Usoro ụbọchị ndị a na-abaghị uru",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ụbọchị dị n'èzí",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Chekwaa",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Họrọ ụbọchị",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "HỌRỌ NSO",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Swichie n'ọnọdụ kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Swichie ka ntinye ụbọchị mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Họrọ oge",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Banye oge",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Elekere",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Nkeji",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Oge njụụ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Gbanwee gaa na ọnọdụ ịkpọ oku",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Swinye n'ọnọdụ oge ntinye",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Bịanyere aka na ya",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Zoo akaụntụ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Gosi akaụntụ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu igodo",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Ogwe menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu mmapụta",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Mkparịta ụka",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ịdọ aka ná ntị",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Chọọ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ugbu a ụbọchị",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Họrọ ụbọchị",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Kpụgharịa ka mbido",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gaa na njedebe",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gaa n'ihu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kpụga n'ala",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kpụgharịa n'aka ekpe",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bugharịa n'aka nri",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Nweta ume ọhụrụ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt eserese",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Igodo nnukwu mkpụrụedemede",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ọwa n'okpuru",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ọwa n'elu",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Nchịkwa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Hichaa",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Chụpụ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ọgwụgwụ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Mgbapụ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ebe obibi",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Fanyenụ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Iwu",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Mkpọchi ọnụ ọgụgụ",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Ọnụ ọgụgụ 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Ọnụ ọgụgụ 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Ọnụ ọgụgụ 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Ọnụ ọgụgụ 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Ọnụ ọgụgụ 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Ọnụ ọgụgụ 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Ọnụ ọgụgụ 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Ọnụ ọgụgụ 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Ọnụ ọgụgụ 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tinye",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Nkewa Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Banye",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad hà",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad ịba ụba",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren aka ekpe",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Wepụ numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Peeji nke ala",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Peeji nke elu",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ike",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Gbanyụọ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Bipute inyogo",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Mkpọchi mpịakọta",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Họrọ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Ngbanwe",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ohere",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ikt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ikt.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Angmaumajuq",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kingumun",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Naunaittuq",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Umiktirutaa",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Piirlugu",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Amihunik",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Aipaani tatqiqhi",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kingulirmi tatqikhiutmi",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Tuklia makpiraanga",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Kingulirmi mapirvia",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Hivuliq makpirnia",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kingulliq makpiraaq",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Tautuktitilunga uvamnun",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ataaniittuq titiraq",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Laisiqaqtut",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rowsnik atauhirmi mapirvia:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Taimaaqtauyuq",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Umiktirutaa",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Aullahimmaarlutik",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Aadjiliuqhimayuq",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Aadjiliuqlugu titiraqhimayuq",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Qinirlutin",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Qinirlugu qaritauyakkut",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Atuqatigilugu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "NAAMMAKTUQ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Kinguani",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilugit tamaita",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "UBLAAMI",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "UNUAMI",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pilugit ikaangnirit",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Tikuaqlugu minitsit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Naammagijaungitun",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ikhitaanga",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Pilugu ukiuq",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Naunaiyaqhimangitut ublua",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Naunaiyaqhimangitut ublua aktilaangit",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Iliurarvikhaa Ublua",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Aulaqtirvikhaa Ublua",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Nutqarvikhaa Ublua",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid ublua aktilanga",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ublua talvanga aulangituq",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tammaqtailiniq",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pilugu ublua",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TIKUAQLUGU AKTILAAQ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Nuutlugit tatqirhiutimut",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Nuutlugu uqauhiuyumut ubluanit atuqtumi",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pilugu ubluqhiutaa",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Itirviuvikhaq",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ikaangniq",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ihuangnikkut ubluqhiutaa",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Nuutlugit naqitpaliayaagani",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Nuutlugit uqaqtatit",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sainiqhimayuq uvani",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Takupkaqtittilugit maniliqutingit",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Kukukuulat menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tuhaqtidjutit",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Qinirhianiq",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tadja Ublua",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tikuaqtauhimayuq ublua",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Hivunmuklutin aullaqtiriami",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nuutpalianigit ihulitpata",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hivunmuklutin",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hivumuuqtuq",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nuutpalianigit haumikhiani",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nuutirlugu taliqpik",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Titirangnun angiklidjut",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Qun'ngiararhat Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Qun'ngiararhat Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Munaridjutit",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Piirlugu",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Nutqarvinga",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Escape",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Aimavik",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Iluanungarlugu",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Atan'nguyaq",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Makpirnia Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Makpiqnia",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Pauwatuutit",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pauwairutikhaq",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Titirattiarlugu Piksasuuliurut",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pilugu",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Inikhaa",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ilo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ilo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Luktakan ti menu ti navigasion",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Agsubli",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Nalawag",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Umadayo",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ikkaten",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ad-adu pay",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Iti sumaruno a bulan",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Immuna a bulan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sumaruno a panid",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Sumaruno a panid",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Umuna a panid",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Maudi a panid",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ipakita ti menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ti baba a lapok",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Dagiti lisensia",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Dagiti baray iti tunggal panid:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Panagansela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Umadayo",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ituloyyo",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Panangputot",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Text a pag-isken",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kitaem ti ngato",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Agbirok iti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Agpartak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Okay, wen.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilien ti amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kitaen dagiti lisensia",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Agpili iti oras",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pilien dagiti minuto",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Panagsina",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Panagipalawag",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Selected a tawen",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Di nainaganan a petsa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Di nainaganan a petsa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ipasok ti Dati",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Dati a Panagsirugi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dati ti Panagibusen",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Dati a rugian $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Panagibusen a petsa $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid a format ti petsa",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Saan a nainkalintegan a petsa",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ti petsa a saan a nairuar",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Agsaldo",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Mangpili iti petsa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PANAGSAP",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Agbaliw iti panag-kalendar",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Agbaliw iti input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pilien ti oras",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ipasok ti oras",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Oras",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Invalid time",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Agbaliw iti dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Agbaliw iti input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Naipirma",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Aglemmeng kadagiti kontona",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ipakitam dagiti kontona",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menú ti panagnavigasion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Panagbirok",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dati a agdama",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Napili a petsa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Umayka tapno mangrugi",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Agturong iti ngudo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Umayka iti ngato",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Agpakumbaba",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Agturong iti kannigid",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Agturongka iti makannawan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Panagrang-ay",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Dagiti sumaganad a panid ket nakasilpo iti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ti backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ti Kanal iti Basbassit",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ti Kanal nga Agpangato",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ikkaten",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Panagsina",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Panagibusen",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Panagsagana",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Pagtaengan",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ipasok",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Dagiti tawa",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Nakamali",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pagina a Mababa",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Pannakabalin",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pannakapukaw ti Power",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Agpili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Panagsagana",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espaso",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_iu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_iu.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ᒪᑐᐃᙶᖅᑐᖅ ᑕᒻᒪᕇᒃᑯᑎᓄᑦ ᓂᕆᔭᒃᓴᑦ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ᑐᓄ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ᑐᑭᓯᓇᑦᑎᐊᖅᑐᖅ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ᖃᓂᑦᑐᖅ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ᐲᔭᕐᓗᒋᑦ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ᓱᓕᒃᑲᓐᓃᖅ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ᑕᖅᑭᐅᓛᖅᑐᖅ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ᑕᖅᑭᐅᓵᖅᑐᒥ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ᒪᒃᐱᕐᓗᒍ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ᒪᒃᐱᖅᑐᒐᐅᓵᖅᑐᖅ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ᓯᕗᓪᓕᖅᐹᖅ ᒪᒃᐱᖅᑐᒐᖅ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "ᑭᖑᓪᓕᖅᐹᖅ ᒪᒃᐱᖅᑐᒐᖅ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ᓂᕆᔭᒃᓴᓂᒃ ᑕᑯᑎᓪᓗᒋᑦ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "ᕿᓕᖅᓯᓇᖅ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ᐊᑖᓂ ᑎᑎᕋᖅᓯᒪᔪᑦ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ᓚᐃᓴᓐᓰᑦ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ᒪᒃᐱᖅᑐᒐᖅ ᐊᑕᐅᓯᖅ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ᓄᖅᑲᖅᑎᓪᓗᒍᑦ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ᖃᓂᑦᑐᖅ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ᑲᔪᓯᓗᒍ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ᐊᔾᔨᖓ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ᑭᐱᔭᐅᓂᖅ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ᖃᕆᑕᐅᔭᒃᑯᑦ ᑎᑎᕋᖅᓯᒪᔪᑦ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ᑕᑯᒋᐊᕐᓂᖅ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ᕿᓂᕐᓗᒍ ᐃᑭᐊᖅᑭᕕᒃ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ᐊᒥᖅᑳᖃᑎᖃᕐᓂᖅ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ᓈᒻᒪᒃᑐᖅ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "ᑭᖑᒻᖏᕐᓂᑯ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ᐃᓘᓐᓇᓯ ᓂᕈᐊᖅᑕᐃᓐᓇᕆᓗᒋᑦ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ᕿᒥᕐᕈᓗᒋᑦ ᓚᐃᓴᓐᓰᑦ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ᐅᓪᓛᒃᑯᑦ",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ᐅᓐᓄᒃᓴᒃᑯᑦ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ᓂᕈᐊᕐᓗᒋᑦ ᐃᑲᕐᕋᐃᑦ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "ᑲᑎᒪᔾᔪᑎᕕᓃᑦ ᓂᕈᐊᕐᓗᒋᑦ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ᓄᖅᑲᖅᑎᑕᐅᓂᖅ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ᖁᔭᓈᖅᑕᐅᔪᑦ ᓂᕆᔭᒃᓴᑦ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "ᐅᓪᓗᖅ/ᑕᖅᑭᖅ/ᐅᓪᓗᖅ",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ᓂᕈᐊᕐᓗᒍ ᐊᕐᕌᒍ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ᓇᓗᓇᐃᖅᓯᒪᙱᑦᑐᖅ ᐅᓪᓗᖅ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "ᓇᓗᓇᐃᖅᑕᐅᓯᒪᙱᑦᑐᖅ ᐅᓪᓗᖅ",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ᐅᓪᓗᖓ ᑎᑎᕋᖅᑕᐅᑎᓪᓗᒍ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ᐅᓪᓗᖅ ᐱᒋᐊᕐᕕᖓ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ᐃᓱᓕᕝᕕᖓᑕ ᐅᓪᓗᐊ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ᐊᑐᖏᑦᑐᖅ ᐅᓪᓗᖅ ᐋᖅᑭᒃᓯᒪᓂᖓ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ᐊᑐᖏᑦᑐᖅ ᐅᓪᓗᖅ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ᐅᓪᓗᖅ ᓇᔪᖅᑕᖓᓂ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ᑐᖅᑯᕐᓗᒍ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ᐅᓪᓗᖓ ᓂᕈᐊᕐᓗᒍ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ᓂᕈᐊᕐᓗᒍ ᐊᑯᑦᑐᓂᖓ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ᐅᓪᓗᖅᓯᐅᑎᒧᑦ ᐃᑭᑦᑕᐅᑎ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ᐃᑭᓪᓗᒍ ᐅᖃᐅᓯᒃᓴᓄᑦ ᐅᓪᓗᖓ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ᖃᖓᐅᓂᖓ ᓂᕈᐊᕐᓗᒍ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ᐱᕕᖃᖅᑎᓪᓗᖑ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ᐃᑲᕐᕋᖅ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "ᑎᑦᑕᑯᓗᐃᑦ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ᐱᕕᖃᑦᑎᐊᙱᓐᓂᖅ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ᑭᐳᒃᑎᕐᓗᒍ ᓇᕿᑦᑕᐅᑎᒧᑦ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ᐊᓯᔾᔨᕐᓗᒋᑦ ᐃᓕᐅᖅᑲᖅᑕᐅᔪᑦ ᐱᕕᒃᓴᕆᑎᑕᐅᔪᒧᑦ",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ᐊᑎᓕᐅᖅᑕᐅᓯᒪᔪᖅ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "ᐊᒥᕋᐃᑦ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ᑕᑯᒃᓴᐅᑎᓪᓗᒋᑦ ᑮᓇᐅᔭᖃᕐᕖᑦ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ᓇᕈᓇᒃᑎᑦᑎᓂᕐᒧᑦ ᓂᕆᔭᒃᓴᑦ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ᓂᕆᔭᒃᓴᑦ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ᐃᒥᒐᖅᑕᐃᓕᒪᓂᕐᒧᑦ ᓱᔾᔪᑎ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ᐅᖃᖃᑎᒌᖕᓂᖅ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ᐊᓘᑦ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ᕿᓂᕐᓂᖅ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ᒫᓐᓇ ᐅᓪᓗᖓ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ᐅᓪᓗᖓ ᓂᕈᐊᖅᑕᖅ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ᐱᒋᐊᕐᓗᑎᑦ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ᓅᓪᓗᑎᑦ ᐃᓱᐊᓄᑦ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ᖁᕝᕙᐸᓪᓕᐊᓂᖅ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ᐊᒻᒧᒋᐊᕐᓗᑎᑦ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ᓅᓪᓗᒍ ᓴᐅᒥᒃ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ᑕᓕᖅᐱᒃᑯᑦ ᓅᓪᓗᓂ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ᑕᒧᓗᒐᒃᓴᖅ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ᐋᓪᑦ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "ᑎᑎᕋᐅᔭᖅᓯᒪᔪᖅ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "ᑭᖑᑉᐱᐊᖅᑐᖅ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ᓇᖅᑭᑦᑕᐅᑎ ᑎᑎᖅᑲᖏᓐᓂᑦ ᐊᖏᔪᐃᓐᓇᐅᑎᑦᑎᔾᔪᑎᖓ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ᕿᔾᔭᓪᓗᒐᖅ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ᕿᔾᔭᓪᓗᒐᖅ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ᐊᐅᓚᑦᑎᓂᖅ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ᐲᔭᕐᓗᒋᑦ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ᑲᐱᔭᐅᓂᖅ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "ᐃᓱᐊ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Escape",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ᐊᖏᕐᕋᖅ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ᐃᓕᓗᒐ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ᒦᑕ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "ᐊᖓᔪᖅᑳᕆᔭᖅ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ᐃᒐᓛᑦ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "ᓄᒻ ᓛᒃ",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "ᓄᒻᐸᑦ 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "ᓄᒻᐸᑦ 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ᕿᓕᖅᓯᓇᖅ 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "ᓂᖀᑦ ᐃᓚᓗᒋᑦ",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "1997-2018",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "ᓂᖀᑦ ᐊᒡᒍᖅᑐᖅᑕᐅᓂᖅ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "ᓂᖀᑦ ᐃᓯᕈᑦ",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "1000000000000",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ᓴᐅᒥᐊᓂ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ᒪᒃᐱᒐᖅ ᑕᐅᓄᖓ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ᒪᒃᐱᒐᖅ −ᖑᓪᓗᑎᒃ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "ᐆᒻᒪᖅᑯᑎ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ᖃᒥᙶᖅᑎᑕᐅᓂᖅ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ᐅᓄᖅᑐᓕᐅᕐᓗᒍ ᑕᕐᕆᔭᕐᕕᒃ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "ᓯᒥᒃᑕᕐᕕᒃ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "ᓂᕈᐊᕐᓗᑎᑦ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ᓇᓪᓕᑭᑕᕐᓂᖅ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ᐃᓂᒃᓴᖅ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_jv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_jv.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigasi sing mbukak",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Bali",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Cetha",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "cedhak",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Mbusak",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Liyane",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Wulan ngarep",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Wulan sadurungé",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Kaca sabanjuré",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Kaca sadurungé",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kaca kapisan",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kaca pungkasan",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Tampilake menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lembar ngisor",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisensi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Baris saben kaca:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Mbatalake",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "cedhak",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Terusake",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Sampul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Teks scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ndeleng munggah",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Goleki ing web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bagéyan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Oke, sing apik.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih kabeh",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Deleng lisensi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pilih jam",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pilih menit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Pemberhentian",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu ora dilakoni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Taun sing dipilih",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tanggal sing ora ditemtokake",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jarak tanggal sing ora ditemtokake",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ketik Tanggal",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tanggal Wiwitan",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tanggal pungkasan",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tanggal wiwitan $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Tanggal pungkasan $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format tanggal sing ora sah",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Jarak tanggal sing ora sah",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tanggal njaba kisaran",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Simpen",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pilih tanggal",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PILIH Jangkauan",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pindhah menyang mode kalender",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pindhah menyang mode tanggal input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pilih wektu",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ketik wektu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Jam",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Menit",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Wektu ora sah",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pindhah menyang mode dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pindhah menyang mode wektu input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ditandatangani",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ndhelikaké akun",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Tampilake akun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigasi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Peringatan",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Nggoleki",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tanggal saiki",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tanggal sing dipilih",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Pindhah kanggo miwiti",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindhah nganti pungkasan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindhah munggah",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pindhah mudhun",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindhah kiwa",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindhah tengen",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafik Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ruang mburi",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Tutup tutup",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Saluran mudhun",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Saluran Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Mbusak",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Pungkasan",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Mlayu",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Omah",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ketik",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Jendela",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tambah",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kompas Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Desimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad dibagi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad padha",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren kiwa",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren tengen",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kaca ing ngisor iki",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kaca munggah",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Daya",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ngunci Gulung",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pilih",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pembagian",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ruang",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kab.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kab.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Adlis n usebtar",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Uɣal",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Yettban",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Yeqqer",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Sseffɣen",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Aṭas n",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Aseggas i d-iteddun",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Aseggas iɛeddan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Asebter i d-iteddun",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Asebter amezwaru",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tafsirt tamezwarut",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Asebter aneggaru",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Isken imennuɣ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Taɣnaḍt n usebter",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Timsiḥin",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Tamazight ɣef usebter:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ad t-tekkes",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Yeqqer",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tkemmel",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tameẓla",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tẓegger",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Imeslay n uselkim",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Muqel ɣer lqaεa",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Afed deg web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ssekni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "D ayen yelhan.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Taɣawsa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select akk",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Isebtaren n uselmed",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Isebtaren i sɛan azday",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Select minutes",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ad d-yeǧǧ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ad d-yeǧǧ adlis",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Aseggas yettwafren",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ass ur yettwasemmi",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Taɣawsa n yiseggasen ur yettwasemmi ara",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ad d-ssekcem",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Taɣmi n tebda",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Taggara n umennuɣ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Taɣra n tebda $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Taɣra n taggara $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format n useggas ur yettwaḥseb ara",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Taɣawsa n yiseggasen",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Taɣmis n usebter",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sellek",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Ad d-tefremt aseggwas",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "IWELQEN",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ssuq ɣer uselmed n uselmed",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ssuq ɣer uselmed n useggas",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Aɣmis",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ad d-yesseɣ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Taṣem",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Teddart",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Taggara n usebter",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ssuq ɣer uselmed n uselmed",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ssuq ɣer uswir n teswiεt",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Tessaweḍ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Iɣil n yiɣallen",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Isken isefra",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Adlis n usebtar",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Tabla n imeslayen",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu n usemmiḍ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ameslay",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Aḥerḍ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tawsit n useggas",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Taɣrawt yettwafren",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ad d-nebdu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ruḥ ɣer tagara",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ruḥ ɣer deffir",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ruḥ ɣer lqaεa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ruḥ ɣer tama tama tama tama tamaziɣt",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ruḥ ɣer tama n waman",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Aḥersi",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Taɣawsa n uḍar",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Tissit n tmes",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Tiddukla ɣer Da",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Yettwaḥseb ɣer lqaεa",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Aselway",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Sseffɣen",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Yettwaḥḍeb",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Taggara",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ad d-yeffeɣ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Tamdint",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Yettwasser",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Aḍebsi",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Tifranin",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Iɣelmaḍ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Asebtar ɣer Deffir",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Asebtar n Yiger",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Tazmert",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tameẓla",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Taɣna n usekru",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Sserwal n useklu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Select",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Taɣawsa",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Amḍiq",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kac.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kac.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Shiga lam hpaw menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Bai wa",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Matut nna",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Hpang de",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Matut kau u",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Grau nna",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Hpang shata hta",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Lai wa sai shata",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Hpang na laika man",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Shawng na laika man",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Shawng nnan na laika buk",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Jahtum na laika buk",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Menu madun",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Hkrunlam",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Hpang na laika buk",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Rai sa na ahkang",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Shawng lam hta lam:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Galaw kau",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Hpang de",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "matut nna galaw u",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy galaw",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kaja ai lam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Laika ka hpe scan galaw",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Yu u",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internet kaw tam u",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Hkawp",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Dai gaw kaja ai.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Hkrak",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yawng hpe lata u",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Rai sa na ahkang ni hpe yu u",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Nambat 1 hpe lata u",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minutes hpe lata u",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Jahten kau ai lam",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu hpe jahkrat kau",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "lata la ai shaning",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Matut nna n tsun da ai nhtoi",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Matut nna n chye lu ai nhtoi madang",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Matut na Matut",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Shawng na Nhtoi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Hpang jahtum nhtoi",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Shawng nnan nhtoi $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Jahtum nhtoi $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "N teng ai nhtoi hkrang",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "N teng ai nhtoi madang",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Matut nna n mai galaw ai nhtoi",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Hkrung tawn",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Matut nna masat da ai nhtoi",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "LAWNG HTAW",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kalenda mode de galai u",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Shiga dat mode de galai",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Aten hpe lata u",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Aten hpe shang",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "hkying hkum",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute langai mi",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "N teng n man ai aten",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Num jahkrat mode de galai u",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Shiga laika mode de galai",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Matut nna masat da ai",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hkaw tsun ai lam ni hpe makoi magap",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Account ni hpe madun u",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu hpe",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar hpe",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu hpe",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Hkaw tsun shaga",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Chyeju Dum",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Hpang jahtum",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ya na nhtoi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ra lata da ai nhtoi",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Hpang de shamu shamawt",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jahtum hkra hkawm sa",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Rawt u",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hpang de shamu shamawt u",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Dingdung maga de shamu shamawt",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "hkra maga de shamu shamawt u",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Hkrung rawt jat galu kaba wa na",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Hpang de na shara",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Hpang de Hpang De Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Hpang de Hpang de Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra Hkra",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "N-gun madun",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Matut kau u",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kabai kau ai",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Jahtum",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "hprawng pru wa ai lam",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Nta",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Hkrung bang",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta (n) lam",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "N-gun jaw ai lam",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Htinggaw",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add galaw",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad hpe garan kau",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad shang",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad hte maren sha",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Htam",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Hpang",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Tengman",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Shawng lam hpe yu u",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Shawng lam hpe yu u",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "N-gun atsam",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "N-gun n ja ai",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Shapoi Matut",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock galaw",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Hpaw",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Lamu ga",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kam.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kam.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ĩvathũkany'o na nzĩa sya kũvingũa",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Nĩsyasyoka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Nĩvethĩwa Ũseo",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ĩkalaa yĩ vakuvĩ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kũvetanga",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "O na ĩngĩ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mweinĩ ũatĩĩe",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mweinĩ wa mbee",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Ĩsandũkũ yĩla yĩatĩĩe",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Ĩsandũkũ yĩla yĩatĩĩe",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Ĩthangũ ya mbee",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ĩthangũ ya mũthya",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ĩka maũndũ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kũvũĩa",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ĩsese ya nthĩ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Livoti sya kũandĩka",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mĩsoa kwa ĩthangũ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kũvetanga",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ĩkalaa yĩ vakuvĩ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Endeea",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Ĩĩ, nĩ ya w'o.",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ĩvathũkany'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sisya ũvoo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Sisya ĩũlũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Mantha ũvoo ũla wĩ vo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kũĩva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Nĩ sawa.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Ĩnyunga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ũnyuve onthe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Sisya mavalũa ma kũsisya",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Mũsikalĩ Mũnene",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Ĩtambya yĩla yĩatĩĩe",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Nyuva ndatĩka",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kũeka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ĩvathũkany'a maũndũ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Mwaka ũla ũnyuvĩtwe",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Matukũ matamanyĩka",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ĩvinda yĩla ĩtaĩ ĩwetetwe",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tũmĩa Ĩsandũkũ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ĩkũlyo Ĩngĩ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Mũthenya wa Kũsilĩla",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Ĩkũlyo:",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Ĩkũlyo ya mũthya",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ndũkanatĩkw'e",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kĩsio kya matukũ kĩte vala kĩandĩkĩtwe",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ĩkũlyo yĩu yĩngĩ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ĩka ũsũvĩo",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Ĩka ũkunĩkĩli",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ŨNDŨ ŨTONYA KŨTŨMA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ĩka moalyũku maũndũnĩ ma kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ĩka moalyũku maũndũnĩ ma kũandĩka matukũ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Ĩtambya yĩla yaĩle kũatĩĩwa",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Tũmĩa ĩvinda yĩla yaĩle",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ĩsaa yĩmwe",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "O na ndatĩka nini.",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ĩvinda yĩla yĩtiele",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ĩka moalyũku maũndũnĩ ma kũkũna simũ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ĩka moalyũku maũndũnĩ ma kũlika",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Nĩnĩandĩkĩthĩtw'e",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kũvitha maũndũ ala ũtandĩthasya",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Onany'a maũndũ ala me vo",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Mĩĩ ya kũtembea",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Kĩlungu kya menyu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Mĩĩ ya Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ũneeni",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kũsiw'a",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kũthima",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ĩkũlyo yĩĩ yĩsũngĩĩtwe",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ĩkũlyo",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ĩka moalyũku",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ĩkalaa wĩ mũthyanĩ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ĩka maendeeo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ĩkalaa nthĩ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ĩkĩlya ngalĩko ya kw'oko kwa aka",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ĩkalaa ngalĩ ya kw'oko kwa aũme",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kũthesya",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Ũmwe",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Kĩlungu kya Katatũ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Kĩsio kya ĩtina",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ĩsese ya Kũtũmĩa",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ĩtambya yĩla yaĩle",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ĩtambya",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kũsiĩĩa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kũvetanga",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ĩtĩkangye",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Mũthya",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kũtia",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Nyũmba",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kũtũmĩa",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Kĩlungu kya 2",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ũvonge",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ndĩlĩsyanĩ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Kũvingũa",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Kĩlungu kya 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Kĩlungu kya 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Ĩsese ya 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Kĩlungu kya 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Ĩsese ya 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Mũio wa kũkua",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Kĩlungu kya 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Ũndũ Ũngĩ Ũtonya Kwĩka",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kĩlungu kya V,",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Ĩmwe ya namba sya ĩkũmi",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kũaany'a",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Ĩlika Kĩlungunĩ kya Numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Kĩvathũkany'o kya Numpad",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Ũmwe wa ala me na ũwau ũsu",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Aĩ Kuma Kwatũ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ũseo",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Ũkany'o wa Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Ĩsandũkũ ya Kũsyoka",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Ĩtambya",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ũtonyi",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kũvetwa kwa Nguvũ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ĩkaseti ya Kũandĩka",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ĩvingũe na Ũvingũe",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Ũnyuve",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kũvĩndũa wĩa",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Kĩsio kya Vinya",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kbp.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kbp.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Kpaɣna-ɩ nɛ ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo ŋwolo",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Pɩpɩsɩɣ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Pɩwɛɛ se ɖɩtɩlɩ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pɩɩñɔtɩ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ñɔɔzɩ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Pɩcɛyaa se ŋtɩlɩ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Pɩnaɣ ŋga kɛkɔŋ yɔ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kpɩtaʋ ŋgʋ kɩɖɛwa yɔ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Takayɩhatʋ ndʋ tɩwɛ pɩ-tɛɛ yɔ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Ñʋŋ weyi ɩɖɛwa yɔ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Takayɩhatʋ ndʋ tɩwɛ pɩ-tɛɛ yɔ tɩwɛna kpasɩ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kɩyakʋ wayɩ ñɩŋgʋ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Pɩsɩ nɛ ŋna-ɩ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kʋñɔŋ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Kɩ-tɛɛ ñɩɣlɩm",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lɩmaɣza wena awɛ kɩlɛmʋʋ yɔɔ yɔ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lɩŋgamɩŋ weyi ɩwɛ hɔɔlʋʋ ŋgʋ kɩ-taa yɔ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kʋyɩ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pɩɩñɔtɩ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ñɔɔzɩ tɔm",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Pɩsɩ takayɩhayʋʋ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pɩɩwɛɛ se pɛlɛɣzɩ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Ñʋŋ weyi ɩ-taa paɖʋʋ tɔm yɔ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kpaɣ nɛ ŋna",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ñɩnɩ intɛrnɛɛtɩ lone taa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ñɩnɩ ɖama",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Pɩlabɩ ɖeu.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ñɔɔzɩ tɔm tɩŋa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ñɩɣ niye nʋmɔʋ lɩzʋʋ waɖɛ yɔɔ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Pʊtʊ ɛnʊ",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ñʋʋdʋ sɔsɔ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hɔɔlʋʋ ŋgʋ kɩ-taa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Ñɔɔzɩ tɔm kɩkpɛlɩkɩtʋ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Lɩzɩ-ɩ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ñɔɔzɩ tɔm",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Pɩnaɣ ŋga palɩzɩ-kɛ yɔ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Kɩyakʋ ŋgʋ kɩ-taa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Pɩtɩkɛ takayɩsɩ nzɩ sɩ-taa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Lɩmaɣza wena a-yɔɔ pañɩɣ niye yɔ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kɩyakʋ ŋgʋ kɩ-taa paɖʊ-wɛ yɔ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Lɩzɩ takayaɣ ŋga ka-taa $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Pɩnaɣ tɛm wiye $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Pɩtɩkɛ takayɩsɩ nzɩ sɩ-tɔm kɩlɩ cɛyʋʋ yɔ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kɩ-tɛ lɛɣtʋ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Kɩyakʋ ŋgʋ kɩ-taa ɛyaa sakɩyɛ fɛyɩnɩ waɖɛ se pɔɖɔ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ñɔɔzɩ tɔm",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Kpaɣ kɩyakʋ ŋgʋ ŋcaɣ yɔ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ÑƆƆƆƆ TƆM",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pɩsɩ kalɩndɩlɩyʋ yɔɔ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pɩsɩ nɛ ŋpɩsɩ kɩ-taa",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Ñɔɔzɩ alɩwaatʋ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ñʋʋ alɩwaatʋ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Alɩwaatʋ ndʋ́ tɩ-taa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Pɩlakɩ pazɩ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Pɩtɩkɛ alɩwaatʋ ndʋ tɩ-yɔɔ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Kpaɣ nɛ ŋpɩsɩ num num num",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pɩsɩ nɛ ŋpɩsɩ alɩwaatʋ ndʋ tɩ-taa",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Paakpaɣ-ɩ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ñɩɣlɩm mbʋ pɩ-yɔɔ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Yele nɛ pama kɩɖaŋ nɩɩyɩ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ñʋŋ weyi ɩ-yɔɔ ŋtɩŋɩɣ yɔ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Pɩlɩʋ kpasɩ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Pɩlɩʋ kɩlɛmʋʋ yɔɔ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Tɔm yɔɔdʋʋ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tʋma wena awɛ yɔ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ñɩnɩ tɔm",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Kɩyakʋ ŋgʋ kɩ-taa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Kɩyakʋ ŋgʋ palɩzɩ-kʋ yɔ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Kpaɣ nɛ ŋpaɣzɩ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kpaɣnɩ pɩ-tɛ nɛ ŋwolo pɩ-tɛ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kpaɣ nɛ ŋwolo pɩ-yɔɔ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kpaɣ-ŋ nɛ ŋwolo pɩ-tɛɛ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kpaɣnɩnɩnɩŋ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kpaɣnɩnɩnɩnɩŋ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kɩɖaʋ kɩdɛɛka",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Pɩsɩ takayɩhayʋʋ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alɩ grafiiki",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Lɩm mbʋ pɩ-wayɩ yɔ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kʋjɔŋ weyi ɩ-yɔɔ palakɩna tʋmɩyɛ yɔ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Lɩmaɣza wena ŋwɛna yɔ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kpaɣ nɛ ŋwolo pɩ-yɔɔ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ñɩɣlɩm",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ñɔɔzɩ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Pɩlɩʋ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Pɛtɛma",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Lone nɖɩ ɖɩ-taa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ɛ-tɛ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Metaa",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Lɩzɩyʋ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fɛɛzɩ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Pɩsɩ nɛ pɩtasɩna",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad tɛyɩ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad kɩwɛna",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Pɩlɩʋ",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Lɩm",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren yɔɔ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Ñɔɔzɩ takayaɣ ŋga",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Ñʋʋ ŋgʋ kɩ-taa",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Tʋma",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pɩtɩkɛ ɖoŋ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Pɩlɩʋ kɩlɛmʋʋ yɔɔ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ñɔɔzɩ nɛ ŋɖɩɣ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Ñɔɔzɩ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ɛjaɖɛ nɖɩ ɖɩ-taa",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kea.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kea.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu di navigason abértu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Na volta",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "É klaru",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Tudu ta fika",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Diluzi",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Más",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Na mês ta ben",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "mês di anu antis",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Prósimu pájina",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pájina anterior",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prumeru pájina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ultimu pájina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Txuba di txon",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Txuba di baxu",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lísias",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rujas pa pájina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kansela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Tudu ta fika",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kontinua",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopiadu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tudu algen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skane testu",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Odja na kel lugar li",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Buska na internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Partilha",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK, N ta bai",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pásta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleksa tudu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Odja lisensas",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "N",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primi-ministradu",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleksa óra",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleksa minutu",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dispensa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu di diziginason",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Anu ki ta skodjedu",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data ki ka sta skrebedu",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Diâ di data ki ka sta skrebedu",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Entra na data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data di kumesa",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data di fin",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data di kumesa $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data di fin $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formatus di data invalidu",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Diâru di data invalidu",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data ki sta fora di rango",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Skola di livri",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selesiona data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTU di rango",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pasá pa modalidadi di kalendru",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passa pa modi di data di inpurtason",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleksa ténpu",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Tempu di ingressu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Hora ki ta dura",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tempu invalidu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Bai na modalidadi di dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pasá pa ténpu di inputu",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sinuadu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Konta pa ka da konta",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostra konta",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu di navigason",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu di bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu di pontu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diálogu",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Buska",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data di kumunidadi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data ki skodjedu",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ta muda pa kumesa",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ta bai pa fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Bai pa riba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bai pa baxu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Bai pa ladu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bai direita",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Renasku",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Altis",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafu di alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Pa di trás",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Txabi di kabésa",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Manda pa otu algen Manda pa otu algen",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Manda pa otu algen Manda pa otu algen",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrolason",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Diluzi",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "É ka ta da",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fin di kel",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Es ta fugi",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kuzas ki ta kontise na kaza",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Inseradu",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandu",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Janela",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Komu di Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad dizasimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Dividi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad entra",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad igual",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicadu",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ki sta bai",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren dretu",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtraitus di Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Paxi di baxu",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Txiga un pontu ki ta da pa el",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Povu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tudu ténpu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Téra di prenda",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Skrebe pa bu skrebedu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seleksa",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Mudansas",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espazu",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kg.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu ya navigation ya kukangula",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Na nima",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Yo Kele Pwelele",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kukatuka",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Katula",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mambu mingi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ngonda yina ke kwisa",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ngonda yina meluta",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Lutiti ya kelanda",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Lutiti ya meluta",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Lutiti ya ntete",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Lutiti ya nsuka",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Monisa menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kukatula",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lese ya nsi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Mikanda ya kupesa nswa",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Balutiti na konso lutiti:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kuzenga",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kukatuka",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Landa na kusala yo",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kubaka yo",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Katula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sadila baverse",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tala na zulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sosa na Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kabula",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Yo kele mbote.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Bima ya kutula",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pona yonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tala mikanda ya nswa",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pona bangunga",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pona minuta",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kubuya",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Katula menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ngonda ya bo me pona",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Kilumbu ya bo me tubila ve",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Kisika ya bilumbu yina bo me tubila ve",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Pesa dati",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kilumbu ya Kuyantika",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kilumbu ya Nsuka",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Kilumbu ya kuyantika $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Nsuka ya dati $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Mutindu ya dati ya me fwana ve",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kisika ya bilumbu ya me fwana ve",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Kilumbu yina bo me katuka ve na kisika yina bo ke kwenda",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Bumba",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pona dati",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "BANTU KE ZINGAKA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Katuka na mode kalandrie",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Katula na mutindu ya dati ya kukota",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pona ntangu",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Pesa ntangu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ngunga mosi",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Ntangu fioti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ntangu ya me fwana ve",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Katula na mode ya kusala dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Katula na mode ya ntangu ya kukota",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Bo me tula sinzili",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Bumba bakonti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Monisa bankenda",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ya navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu ya nkaka",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ya bo me basisa",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kulonguka",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Bangibusa",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Sosa",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Kilumbu ya beto me sala yo",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Kilumbu ya bo me pona",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Beno yantika",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kwenda tii na nsuka",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Telama na zulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Beno kwenda na nsi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kwenda na diboko ya kimama",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kwenda na diboko ya kitata",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kukatula Mambote",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Kikalulu ya nkaka",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafe ya Kuluta Nene",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Kisika ya nima",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Bima ya kukanga",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kwenda na Ntoto ya Mpa",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Tinda yo na zulu",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kukumana",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Katula",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Bo me losa yandi",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Nsuka",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kukatuka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Nzo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Tula",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Mfumu",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Bafenetre",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Yika",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kimbangu ya Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Ke Kabwana",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren na diboko ya kimama",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren na Diboko ya Kitata",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Katula lutiti",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Tula lutiti na zulu",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ngolo",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuyambula Ngudi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Kubasisa Disque",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Songa Lukanu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pona",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kisalu ya kusala",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Kisika",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_khk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_khk.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Харилцааны жагсаалт нээлттэй",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Хурд",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ухаалаг",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Тэнд нь",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Хасах",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Үүнээс илүү",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ирэх сард",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Өнгөрсөн сар",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Дараагийн хуудас",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Өмнөх хуудас",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Эхний хуудас",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Хамгийн сүүлд",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Хурлын жагсаалт",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Хүрсэл",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Дөмбөгийн хуудас",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Эрдлэм шинжилгээний",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Сураг бүр:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Халдах",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Тэнд нь",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Дахин яв",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Хөгжүүлэн",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Хөрөгдөл",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Скан текст",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Үргэлж үзээрэй",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Интернэтээр хайж үзээрэй",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Хөдөлмөр",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "- Энийг нь",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Хөгжил",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бүх сонго",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Лицензүүдийг үзнэ үү",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "АМ",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ерөнхий сайд",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Цаг хугацааг сонгох",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Утасны тэмдэглэл сонго",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Хөдөлмөрийг хая",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Хөдөлмөрийн жагсаалтыг хая",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Сонгон жилийн",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Нэгдсэн өдөр",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Нөхөн хугацааны зааваргүй",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Сургуулийн хугацаа",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Эхлэх хугацаа",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Сүүлийн хугацаа",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Барилгатын өдөр $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Датаг дууссан $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Үндсэн хуулийн дагуу",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Үүнд хүчингүй хугацааны заавар",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Датаг нь гараагүй",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Хөрөөж",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Өдөр сонгох",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ТӨРГӨН",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Цаг хугацааны мөрийн журмын",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Дагшилт мөрийн хэв маягт шилжүүлнэ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Цаг хугацааг сонгох",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Цаг хугацааг оруул",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Цагийн турш",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Нэг минут",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Үүнд хүчингүй хугацаа",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Уурхайрчтын хэв маяг руу шилжүүлнэ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Хөгжлийн цаг хугацааны хэв маягт шилжүүлнэ",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Үүнд гарын үсэг зурсан",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Санхүүгийн санг нуух",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Санхүүжилт үзнэ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Харилцааны жагсаалт",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Төлөөний хуудас",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Хаалттай жагсаалт",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Хэлэлцүүлэг",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ухаалтыг",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Танд хайх",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Одоогийн өдөр",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Сонгон авсан өдөр",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Эхлэхэд хөдөлгөөн",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Сүүлийнх хүртэл",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өрчөө",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Хурдан буурах",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Зүүн талд шилжих",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Дээр нь баруун замаар",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Улаанбаатар",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Альт",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Альт График",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Хөдөлмөрийн зайд",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Капс-ийн хаалга",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Төмөр замаар",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Өргөтгөлийн дагуу",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Хяналт",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Хасах",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Уурхай",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Сүүлийнх",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Уурч яв",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "БНХАУ-ын",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Гэртээ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Хөрөгч",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Мета",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Төмөрч",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Төмөр",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Нүм Лок",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Нэмпэд 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Нэмпэд 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Нэмпэд 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Нэмпэд 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Нэмпэд 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Нэмпэд 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Нэмпад 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Нэмпэд 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Нэмпад 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Нэмпэд 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Нөмпэд нэмнэ",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Нөмпэд Кома",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Нэмпэд Десмиал",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Нумпад хуваагдал",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Нэмпэд Энгл",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Нэмпэд тэнцвэртэй",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Нөмпэд Хоёр дахин",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Нөмпэд Парен сул",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Нөмпэд Парен Дээрх",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Нөмпэд хямрал",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Сэтгэлгээг бууруул",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Сэтгэлгээг дээшлүүлэх",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Эрчим хүч",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Цахилгаан шугам",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Шүрхүүлэгч дэлгэц",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Скрулл Лок",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Тавул",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Хөдөлмөрийн хөдөлгөөн",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Газар",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ki.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ki.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menyu ya gũteithũra",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Gũcoka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Nĩ Ũtarĩ Ũhoro",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kũhũta",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kũharũra",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Makĩria",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mweri ũroka",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mweri wa mbere",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Gĩcunjĩ kĩrĩa kĩrũmĩrĩire",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Gĩcunjĩ gĩa Mbere",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Gĩcunjĩ kĩa mbere",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ibuku rĩa mũthia",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Rora menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kũhũra",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Mũharatĩ wa mũhuro",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Marũa ma kũheana",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mĩtaratara o karatathi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kũniina",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kũhũta",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Thiĩ na mbere",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kũrita",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kũgũrũ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Rora ũhoro wa gũthoma",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Rora igũrũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rora ũhoro thĩinĩ wa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kũgayana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Nĩ wega.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Gĩthaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Thuura ciothe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Rora marũa ma kũhotithia",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ŨHORO MUONGERERE",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Mũtongoria wa bũrũri",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Thuura mathaa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Thuura mĩario",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kũrekereria wĩra",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Rora mũtaratara",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Mwaka ũrĩa ũthuurĩtwo",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Gũtigĩrũo kĩhitho",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Kĩmera gĩtaarĩirio",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Gũthondekithia",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Rĩĩrĩ nĩrĩo rĩambĩrĩirie",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Rĩĩrĩ nĩrĩo rĩathira",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Kĩambĩrĩria $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Mũico wa mũico $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ũtararĩki wa matukũ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kĩhumo gĩtarĩ kĩene",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Gũtigithĩria",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Gũtũũria",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Thuura mũthenya",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "GĨTŨRIA KĨHĨRĨRIA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Gucinyanĩra mũtaratara wa kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Gucinyanĩra mũtaratara wa mũthenya wa kũingĩra",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Thuura ihinda",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Rora ihinda",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ihinda",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "O na ndagĩka",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ihinda rĩtarĩ rĩa gũtũmĩka",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Gucinyanĩra mode ya gũcokia",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Gucinyanĩra na mũtaratara wa mahinda ma kũingĩra",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Kũhingia",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kũhitha mĩhothi",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Kuonania mĩbango",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menyu ya gũtwarithia",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Mũharatĩ wa Mĩtĩ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Mĩthenya ya kũgũrũ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ũhoro wa gũcokia",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kũmenyithia",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Gũcaria",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Rĩu nĩ rĩ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Rĩĩrĩ nĩ rĩatongoririo",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Gũthiaga na mbere",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gũthiĩ o nginya mũthia",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ũkĩrai igũrũ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ũikũrũke",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Reke ũthiĩ mwena wa ũmotho",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ĩra mwena wa ũrĩo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kũgarũra",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Ũrĩa ũngĩ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Gĩthondekithia gĩa Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Gĩthaka gĩa thutha",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Mũrango wa Kũhingũra",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kũhũrwo kwa Rũhonge",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ũkĩrai na mbere na gũtwarana",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Gũtuĩria",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kũharũra",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kũrutwo",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Mũthia",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kũrĩra",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Mũrurungano wa",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Gũkũ mũciĩ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Gũthondekithia",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Kĩmĩrũ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ũtongoria",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Matara",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Mũrango wa gũikia",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Mũromo wa Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kũgayũkania",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Ĩng'ana",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Kũingĩha",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kũrĩa Ũtarĩ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kũrĩa Kũrĩ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Ũmwe wa Ũmwe wa Ũmwe",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Rora Ibuku Rĩgathira",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Rora Kĩbungo",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ũhoti",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kũhingũra Hinya",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Gĩthondekithia",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Rora Ũhoro Ũrĩa Ũngĩhingũra",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Thuura",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kũgarũrũka",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Gĩthaka",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kmb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kmb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Jithembu ja ku jikula o mutelembe",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ku vutuka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "O ku Zukama",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ku Zukama",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kufuta",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "O milongi íii",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mu mbeji ia-nda kuíza",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mbeji ia bhiti",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "O mbandu ia kaiela",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Mbandu ia bhiti",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Mbandu ia dianga",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "O mbandu ia sukina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Jimbulula o menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "O ku zuka",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "O kijimbuete kia tokala",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Jilevita",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Milongo ia mbandu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kufuta",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ku Zukama",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kolokota",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kala ki tua mu mona",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ku batula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tanga o njimbu",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tala ku thandu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sota mu internete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ku di Bhana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Kiki kia-nda bhita.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Jimbamba",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sola ioso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kutumikisa kwakwenu Kutumikisa kwakwenu",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "O Kikalakalu",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "O P.M.",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sola o ji ola",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sola o ithangana",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ku Bhana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "O menu ia ku katula o kitadi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Selecta o ano",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ki ku moneka kizuua",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "O kizuua kia tokala",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tanga o Kizuua",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kizuua Kia Ku mateka",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "O Kizuua Kia Ku Bhua",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Fepesa ia ku mateka $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Kithangana kia disukilu $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Kijimbuete kia tokala",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "O kijimbuete kiki ki tena ku tu kuatekesa",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "O kizuua kia tokala",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ku bhaka",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sola o kizuua",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "O KIDI KIA KU DI TALA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ku lungulula o ukexilu ua kalendalu",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ku lungulula o kijimbuete kia kizuua kia ku soneka",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Sola o kithangana",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kindala o kithangana",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ola imoxi",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Mu ithangana ioso",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "O Kithangana kia ku Bhanga o Sidivisu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ku lungulula o kijimbuete",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ku lungulula o kithangana kia ku bokona",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "O kijimbuete kiki",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ku sueka o kitadi",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Londekesa o ji konda",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "O menu ia kuendesa",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Milongi ia ku di longa",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "O menu ia moneka",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kuzuela",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kikalakalu Kia ku Ngi Bhana Dilangelu",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Sota",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "O kizuua kia tokala",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Fepesa ia tokala",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Kuia ku dimatekenu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ku disukilu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Zukama",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Zukama bhoxi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ku mbandu ia kiasu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ku mbandu ia kadilu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "O ku Zolo",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "O ku kalakala ni",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Foto ia ku di longa",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "O kididi kia ku dima",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "O ku di Zangula",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "O Kikalakalu Kia ku Bhanga ku Mundu",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "O Kikalakalu Kia ku Bhongolola",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ku Langa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kufuta",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ku a kaia",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ku Bhanga o Ima Ioso",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ku lenga",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "O",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ku dibhata",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ku ta",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "O kijila kia dikota",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Jifidi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "O Kikuatekesu",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Kikuatekesu",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Kikuatekesu",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Kikuatekesu 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Kikuatekesu",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Kikuatekesu phala o ku di bunda",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Kikuatekesu",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Kikuatekesu phala o ku di bunda",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Kikuatekesu 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Kikuatekesu",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Kikuatekesu 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Ku bandekesa o Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "O Kimbundu Kia Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "O kijimbuete kia 10",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "O Kikalakalu Kia ku Bhanga o Sidivisu ia Utuminu",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Ku bokona mu kididi kia ku di longa",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "O Kimbundu Kia Difuangana",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "O Kikuatekesu",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ua xisa",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "O Kikalakalu Kia ku Bhanga ku Mundu Uoso",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "O ku katula o ima",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Ku Xisa o Milongi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "O Mulangidi ua mu Tumbula",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Nguzu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ku Xisa o Nguzu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Kutumikisa kwakwenu Kutumikisa kwakwenu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ku Zangula o Mbandu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Sola",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Ku kalakala mu ididi ia ku nhoha",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "O kididi",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_kmr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_kmr.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menuya navîgasyonê veke",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Paşve",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Jêbirin",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Bigire",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Jê bibe",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "zêdetir",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Meha bê",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mehek berê",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Rûpelê dû re",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Rûpela berê",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Rûpela pêşîn",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Rûpela dawîn",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Pêşekê nîşan bide",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skrîm",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Çarşefa jêr",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lîsans",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rêza her rûpelê:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Betal kirin",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Bigire",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "berdewam bike",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Jibergirtin",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Jê bike",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Teksta venihêre",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "binihêre",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Li torê bigere",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Parve bike",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "TEMAM",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hemûyan Hilbijêre",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lîsansên dîtinê",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Pm",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Demjimêran hilbijêre",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Xulekê hilbijêre",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ji kar dûr xistin",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menûyê ji kar dernexê",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Salê hilbijêre",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dîroka nediyar",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Navbera dîrokê ya nediyar",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Dîrokê binivîse",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Dîroka Destpêkê",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dîroka Dawîn",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formata dîrokê ya nederbasdar",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Navbera dîrokê ya nederbasdar",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tarîx ji dûr ve",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tomar bike",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Dîrokê hilbijêre",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "NAVBERÊ HILBIJÊRE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Derbasî moda salnameyê bibe",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Biguhere li moda dîroka têketinê",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Demê hilbijêre",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Dem binivîse",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Saet",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "xulek",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Dema nederbasdar",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Biguhere li moda lêgerînê",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Biguhere li moda dema têketinê",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "de imzakirî",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hesaban veşêre",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Hesaban nîşande",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menuya navîgasyonê",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Darikê pêşekê",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Pêşeka vebûnbar",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dîalog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Hişyarî",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Lê bigere",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dîroka niha",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dîroka bijartî",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ber bi destpêkirinê ve here",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ber bi dawiyê ve here",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Berjor",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Berjêr",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Berbi çepê ve here",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Berbi rastê ve here",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Nû Bike",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanala Jor",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Jê bibe",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Jê derxe",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Dawî",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Revê",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Mal",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Lêzêdekirin",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ferman",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Lê Zêde Bike",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Dabeşkirina Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Wekhev",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad pirjimar bike",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Çep",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Rast",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Rûpela Jêr",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Rûpelê Jor",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Hêz",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ekranê çap bike",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Qufilkirina Şemitandinê",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Hilbijartin",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Valahî",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ks.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ks.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "نیویگیشن مینیو کْریو اوپْن",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "واپس",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "کْلیر کْریو",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "بند کْریو",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ڈیلیٹ کْریو",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "مزید",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "بیاکھ ریتھ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "پْتیم ریتھ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "بیاکھ پیج",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "پْتیم پیج",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "گوڈنیوک پیج",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "پْتیم پیج",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "مینیو ہأیو",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "سُکریم",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "باٹم شیٹ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "لاسن",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "رو پریتھ پیجس منز:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ختم",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "بند کْریو",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "جأری تھأیو",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "کاپی کْریو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "کٹ کْریو",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "متن کْریو سیکین",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ہیور کْریو نظر",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ویب کْریو تلاش",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "شییر کْریو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ٹھیک",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "پیسٹْہ کْریو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "تمام ژأریو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "لاسن کْریو ویو",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "اے ایم",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "پی ایم",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "گھنٹہٕ ژأریو",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "منٹ ژأریو",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ڈیسمِس کْریو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مینیو کْریو ڈیسمِس",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ژأریو وْریو",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "غیر مخصوص کرنْہ آمُت تأریخ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "غیر مخصوص کرنْہ آمُت تأریخ رینج",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "تأریخ کْریو اینٹر",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "شروع تأریخ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "اند تأریخ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ناکار تأریخ فارمیٹ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ناکار تأریخ رینج",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تأریخ رینج نیبر",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "محفوظ کْریو",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "تأریخ ژأریو",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "رینج ژأریو",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "سوچ کْریو کیلنڈر موڈس کُن",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "سوچ کْریو اِنپُٹ تأریخ موڈس کُن",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ژأریو ٹایم",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "اینٹر ٹایم کْریو",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "گھنٹہٕ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "منٹ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ناکار ٹایم",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "سوچ کْریو ڈائل موڈس کُن",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "سوچ کْریو اِنپُٹ ٹایم موڈس کُن",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "سایِن اِن",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "اکاونٹ کْریو ہایِڈ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "اکاونٹ ہأیو",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "نیویگیشن مینیو",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "مینیو بار",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "پاپ اپ مینیو",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ڈایلاگ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "آگأہی کْریو",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "تلاش کْریو",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "موجود تأریخ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ژارنْہ آمُت تأریخ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "شروع کرنْہ کُن پْکیو",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "اندس کُن پْکیو",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ہیور کْریو پْکیو",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ڈاون کْریو پْکیو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "کھوفُر کْریو مو",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "دوچُھن کْریو منتقل",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ریفریش کْریو",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "بیک سُپیس",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "کیپٕس لاک",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "چنل ڈاون",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "چنل اپ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کنٹرول کْریو",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ڈیلیٹ کْریو",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ایجیکٹْہ کْریو",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "اند",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "ایسکیپ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ایف این",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ہوم",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "انسأرٹ کْریو",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "میٹا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "کمانڈ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "وینڈوز",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "نمبر پیڈ ۱",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "نمپیڈ ۲",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نمبر پیڈ ۳",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "نمبر پیڈ ۴",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "نمبر پیڈ ۵",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نمبر پیڈ ۶",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "نمپیڈ ۷",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نمبر پیڈ ۸",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نمبر پیڈ ۹",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نمبر پیڈ ۰",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad کْریو جمع",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "نمپیڈ کاما",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "نمپیڈ ڈیسیمل",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "نمپیڈ کْریو اینٹر",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نمپیڈ برابر",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "نمبر پیڈ کْریو ملٹیپْلاے",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren کھوفُر",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "نمپیڈ سب ٹریکٹ",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "پیج ڈاون",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "پیج اپ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "پاور",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "پاور آف",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "سکرین کْریو پرینٹ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "لاک کْریو سُکرال",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "ژأریو",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "شِفٹْہ کْریو",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "سُپیس",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ku.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ku.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "کردنەوەی پێڕستی ڕێنیشاندەر",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "گەڕانەوە",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "خاوێن",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "داخستن",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "سڕینەوە",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "زیاتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "مانگی داهاتوو",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "مانگی پێشوو",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "پەڕەی داهاتوو",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "پەڕەی پێشوو",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "پەڕەی یەکەم",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "پەڕەی کۆتایی",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "پێڕست نیشان بدە",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "سکریم",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "شیتی خوارەوە",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "مۆڵەتەکان",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ڕیزەکان بۆ هەر پەڕەیەک:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "هەڵوەشاندنەوه",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "داخستن",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "بەردەوام بوون",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "سکان کردنی دەق",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "سەیری سەرەوە بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "گەڕان لە وێب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "بەش پێکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "باشه",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "لکاندن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەموو دیاریبکە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "پێشاندانی مۆڵەتەکان",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "بەیانی",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "پ م",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "دەسنیشانکردنی کاتژمێرەکان",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "خولەک دەسنیشان بکە",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "دەرکردن",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "پێڕست دەربکە",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ساڵ دیاریبکە",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "بەرواری دیاری نەکراو",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "مەودای بەرواری دیاری نەکراو",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "بەروار داخڵ بکە",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "بەرواری دەستپێکردن",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "بەرواری کۆتایی هاتن",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "فۆرماتی بەروار دروست نیە",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "مەودای بەروار نادروستە",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "بەروار لەدەرەوەی مەودا",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "هەڵگرتن",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "دیاریکردنی بەروار",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "مەودا دیاریبکە",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "گۆڕین بۆ دۆخی ڕۆژژمێر",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "گۆڕین بۆ دۆخی بەرواری تێکردن",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "کات دیاریبکە",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "کاتەکە بنووسە",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "کاتژمێر",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "خولەک",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "کات نادروست",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "گۆڕین بۆ دۆخی داواکردن",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "گۆڕین بۆ دۆخی کاتی تێکردن",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "چووە ژوورەوە",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "شاردنەوەی ئەژمێرەکان",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ئەژمێرەکان نیشان بدە",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "پێڕستی ڕێنیشاندەر",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "میلی پێڕست",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "پێڕستی دەرکەوتوو",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "دیالۆگ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ئاگادارکردنەوە",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "گەڕان",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "بەرواری ئێستا",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "بەرواری دیاریکراو",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "بجوڵێ بۆ دەستپێکردن",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "بگوێزەرەوە بۆ کۆتایی",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "بجوڵێ بۆ سەرەوە",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "چوونە خوارەوە",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "بگوێزەرەوە بۆ لای چەپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "بگوێزەرەوە بۆ لای ڕاست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "نوێکردنەوە",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt گراف",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "بۆشایی پشتەوە",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "کلیلی Caps lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "کەناڵ بۆ خوارەوە",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "کەنال بۆ سەرەوە",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کۆنتڕۆڵ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "سڕینەوە",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "فڕێدان",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "کۆتایی",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "هەڵاتن",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ئێف ئێن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ماڵ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "تێکردن",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "مێتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "فەرمان",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "پەنجەرەکان",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "ژمارە پاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "ژمارە پاد 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "ژمارە پاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "ژمارە پاد 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "ژمارە پاد 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "ژمارەپاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "ژمارە پاد 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "ژمارە پاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "ژمارە پاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ژمارە پاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "زێدەکردنی Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "وێرگولی ژمارە پاد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "ژمارەی دەیی Numpad",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "دابەشکردنی ژمارە پاد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad یەکسانە",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "لێکدانی Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "پەراوێزی ژمارەیی چەپ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "پەراوێزی ژمارە پاد بەرەو ڕاست",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "لێدەرکردنی ژمارە پاد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "پەڕەیەک بۆ خوارەوە",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "پەڕەیەک بۆ سەرەوە",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "هێز",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "کوژاندنەوەی کارەبا",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "شاشەی چاپکردن",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "هەڵبژاردن",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "گۆڕین",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "بۆشایی",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lg.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Emabega",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Okumpi",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ebirala",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Omwezi ogujja",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Omwezi oguwedde",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Olupapula oluddako",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Olupapula olusooka",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Olupapula olusooka",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Olupapula olusembayo",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Layisinsi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Okusazaamu",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Okumpi",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Genda mu maaso",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tunuulira waggulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "KALE",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Londa byonna",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Laba layisinsi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "NZE",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Ssaawa ez'okulonda",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Londa eddakiika",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Okugoba",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Londa omwaka",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Olunaku olutamanyiddwa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified date range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enter Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Olunaku lw'okutandika",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "End Date",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ennaku ezitali zimu",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out of range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Okusindika",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Londa olunaku",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kyusa mu kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Londa obudde",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Okuyingira obudde",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Essaawa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Eddakiika",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Obudde obutali bumativu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Kyusa ku dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Kyusa mu Input Time Mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signed in",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Show accounts",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Emboozi",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Okulabula",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Okunoonyereza",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Current date",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Selected date",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Genda okutandikira",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Genda waggulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Genda wansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Genda ku kkono",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Genda ku ddyo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Okufuga",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Enkomerero",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Okudduka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Awaka",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ekiragiro",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Amaanyi",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Londa",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Enkyukakyuka",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Mu bbanga",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lij.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lij.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menù de navigaçion aberta",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Torna a-a mæxima",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Curiositæ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "A l'é stæta a-a fin",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scappaçión",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ciù",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "O mese do vòtto",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "L'anno precedente",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Poxiçión do comûne de Puglia",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pàgine inta categorîa ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prima pàgine",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Última pàgina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra o menù",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "scrimma",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Poxiçión do comûne de Bollin",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "License de l'autô",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Lìe pe pàgina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancelâ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "A l'é stæta a-a fin",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continuâ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copiaçión",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taggia",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scansâ o testo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Gâ â dõ alan,",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca into web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiçioin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "- Oua, o l'é ben.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleçionâ tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizzaçioìn",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "A-a primma",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primo Ministro",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleçionâ e oræ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleçionâ i minuti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dismissâ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismissâ o menù",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seleçionâ l'anno",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data scìfica",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Range de data scpecificòu",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Intrâ a data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data de comensâ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data de fin",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data de comensâ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Finâ a data $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formato de data invalido",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid date range",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fora da scistema",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvâ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Seleçionâ a data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTâ a scîa",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Passâ a-o mòddo calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passâ a-o mòddo data d'inpûsa",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleçionâ l'ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Intra o tempo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Oua",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto o l'é stæto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tempê de invalida",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Passâ a-o mòddo de dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Passâ a-o mòddo tempo de input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signòu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Nascondi contæ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostrâ i conti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menù de navigâ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barca do menù",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menù in scîto",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Cercaâ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data corrente",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data sceguiâ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mòve pe comensâ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mòve a-a fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mòve ascì",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Motta in sciâ sciâ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mòve a-a scinn-a",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mòve a drîva",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Rîfrescâ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafico alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spaçioin de scìnn-a",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canale in sciâ scêa",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canale ascì",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Controllo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scappaçión",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ejecutâ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finâ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fuggeâ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Cascia",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insertâ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comandâ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Zeneixi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numma decimâle numâle",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Dividiâ a Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicate",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren a l'é sciâ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren à drîva",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtraçion de Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pàgine inta pàgina",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pàgine inta pàgina",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Poxiçión do comûne de Puggia",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "A-a scinn-a",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Scêto de scêto",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrolloâ a sclocca",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seleçión",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Taxi de scistema",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "O spaçio",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lim.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lim.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigatie menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Achteraf",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Geklènd",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Neet te zien",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Verwijder",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Meer",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Volgende maond",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Vorige maond",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Volgende pagina",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Vorige pagina",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Eerste pagina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Laatste pagina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Vertoon menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrimming",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenties",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Reuk per pagina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Annulere",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Neet te zien",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Veurgezat",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Snij",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skandeer teks",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kiek op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Zoek op 't web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK, good.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selecteer alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Bekijk licenties",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kieske tied",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Kies de minuut",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Verkeersing",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Verwijder menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Selecteerd jaor",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Nie bepaald datum",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Onbesjreve datumbereik",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Invoerdatum",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Startdatum",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Einddatum",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Startdatum $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Einddatum $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalide datumbereik",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datum oet bereik",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sjtèlt",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selecteer datum",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT rang",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Verwissel nao kalendermodus",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Verwissel nao de ingangsdatummodus",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Kies tied",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Invoertiid",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Oere",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuttje",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Invalide tied",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Verwissel nao dialmodus",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Verwissel nao de ingangstijdmodus",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ingegreve",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Verstopt rekeningen",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Vertoon rekeningen",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigatie menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menubalk",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Waarsjlaag",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Zoek",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Opdatum",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Geselekteerde datum",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Verplaatsing veur begin",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Verplaats tot 't eind",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gao op.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gaon nao de boeg.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Verplaats nao links",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Gao rechts",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Verfrissings",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Altied",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graaf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Achterruimte",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal op",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Verwijder",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Einde",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Vluch",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Huus",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Invoeg",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Commando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Winkels",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad verdeil",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad gelijk",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren links",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Recht",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "pagina nao de pagina",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina Op",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Krach",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Stroom af",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print scherm",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Srolluusje",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selecteer",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Schifte",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ruimte",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lmo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lmo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menù de navigazion aperta",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ritorno",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "CLEAR",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "CLOSE",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scarica",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Più",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "El mes che ven",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mese precedente",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next Page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pagina precedente",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prima pagina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ultima pagina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra el menù",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrib",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "L'archivio del fondo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenzii",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Righe per pagina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancelà",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "CLOSE",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continua",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copià",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scans text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Guarda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca in web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiment",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK, OK, OK.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pesta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleziona tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizzai le licenze",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sceglie orari",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Selezion de minut",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dispensazion",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menù de scancelament",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "An de selezion",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data indeterminata",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ràzza di data non specificata",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Date di inserimento",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data de cumün",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Finale data",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data de cumün $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data de fin $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format de data invalida",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Distanza di data invalida",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fora de raggio",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvàr",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selezion de data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT LA RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Passà in modalità calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passà in modalità data di input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selezion de ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Inserit ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutt",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Temps invalidi",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Passà in modalità di taglio",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Passà in modalità temp d' input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signàda",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Cuntenzion nascossa",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostra cont",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menù de navigazion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menù in popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Avvertenza",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Cerca",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data attuale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data selezionada",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mova per cumincià",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Moved a end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mòsa sù",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Scenditi giù",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mova a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mova a destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "REFRESAGNIO",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ALT",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spazzi di schiena",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Capp Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canale giù",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canalizzà sù",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scarica",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finì",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fuga",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home - La città",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comanda",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ventrine",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren LEFT",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Dirt",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Sottrazione Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pagina giù",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina in su",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "POWER",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Off Power",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Screens de stampa",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrollo Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selezion",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Cambio",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spazzi",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ln.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ln.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu ya navigation ya polele",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Nazongi",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Emonana polele",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pembeni",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Makambo mosusu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Sanza ezali koya",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Sanza eleki",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Lokasa elandi",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Lokasa ya kala",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "LOKASA ya liboso",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Na lokasa eleki",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Lakisa menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrime",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lokasa ya nse",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisensi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Milonga pour ton page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Boya",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pembeni",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Bókoba",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Katá",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Makomi ya Scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Talá na likolo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rechercher le site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Poná bato nyonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tala ba licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "SIKA",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Bangonga ya kopona",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Poná miniti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kobengana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kobengana menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Pona mbula",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dati eyebani te",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Date eyebani te",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enter Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Date ya kobanda",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dati ya nsuka",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format ya date oyo ebongi te",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Dati ya malamu te",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out ya range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Save",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Poná date",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "CHOOSE RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Switch na mode ya calendrier",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch na mode ya date",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Poná ntango",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kokɔtaka ntango",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ngonga",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ntango oyo ebongi te",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Convert mpe mode dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Switch na mode ya input time",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signé dans",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kobomba kɔnti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Masolo ya teyatre",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Bóluka",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dati ya sikoyo",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dati eponami",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Nakei mpo na kobanda",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nakei mpo na kosuka",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Tókende liboso",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Longwá na nse",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kokende na ngámbo mosusu na lobɔkɔ ya mwasi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tókende na lobɔkɔ ya mobali",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kopemisa nzoto",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Makomi minene",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel ekiti na nse",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Nsuka",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kimá",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "MOKOLif",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Etinda",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Maninisa",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Yaka 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Yaka Mpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Yaka 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Yaka Mpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Yaka Zolo 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Bokabwani ya Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Kobotana",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren alongwaki",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Kangá - Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Lokasa na nse",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Lokasa na likolo",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Nguya",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kura ebimi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ecran imprimeri",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Roll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "CHOOSE",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espace",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ltg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ltg.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Atkluota navigacejis menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Atguoja.",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Skaista",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Tyvuok",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Izmaineit",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Vaira",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Nuokušuos mienešonas",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Pyrmais mieneš",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nuokušuo stuoste",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pyrmais stuosts",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Pyrmuo stuosta",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Pādejuo stuosta",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Izstuodeit menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skurpums",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Zemis lopys",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenciju",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rūteiti par puslītu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Atceļšona",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Tyvuok",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Vaira aizstuov",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopiejums",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skurstys",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skanej tekstus",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Pazaudēsim augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Izpieteit vītā",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pīsadaleit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Labi, nu.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pīsaceņš",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli vysus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Izstuodeit licencis",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Pīminis ministreja",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Izlaseit laiku",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Izvēli minutes",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Atlaidums",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Atlaiduma menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Izlaseitū godu",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Naatguodyta datums",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Naatīcynuots datumu intervals",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ītīņs datums",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Suokuma datums",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Beiguo datums",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Suocūtī datums $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Beiguo datums $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Navalidu datu formats",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Navaliduos datumu intervalys",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datums nu reita",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sajimt",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Izlaseit datumu",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PĪRĪVĪŠI RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pastuov iz kalendaru režimu",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pastuov iz īstuodis datuma režimu",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Izlaseit laiku",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Īeja laiks",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Stūpeibys laiks",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minūtys",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Navaļsts laiks",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pastuov iz nūruodejumu",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pastuov iz īstuodis laiku režimu",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Atsacejums",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Saceitu kontu",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Izstuodeit kontu",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigativys menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu šyunu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Izruodeituo menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialoga",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Pazaudynuojums",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Izpiete",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Vacuo datums",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Izlaseitais datums",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Izkuopūt iz suokumu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Izstuode leidz beigom",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Izstuodeit.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Izmīž iz zemis",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Izmaite iz kreisi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pa kreisi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Atdzīduošona",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Vīna nu",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt grafeja",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Aizguojuma vīta",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapuļu aizloks",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Izpiļdeituojs",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Up Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrols",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Izmaineit",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Izlīk",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Beiguos",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Izmaneiba",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Sātu",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ītīņs",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandys",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Sātys lopys",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad komā",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad īīt",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad vīnaids",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad reizynuojums",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren aizguoja",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren tīse",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Izstuodei",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Puorskaite augšā",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Vuoceiba",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Elektricejā nav",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Izpiļdeituo ekrana",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Izruodeit īrūbežuotuoju",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Izlaseit",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pīsaceiba",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Vaļsts",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ltz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ltz.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open Navigatioun Menü",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Zurück",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Kleng",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Schrëtt",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "D'Schléi",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Méi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Nächsten Mount",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Virdrun",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nächster Säit",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Fréier Säit",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Déi éischt Säit",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Déi lescht Säit",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show Menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Schrëtt",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom Sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lizenzen",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Reihen pro Säit:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Annuléiert",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Schrëtt",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "weider",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopéiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Schneiden",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scannen Text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kuckt op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sich am Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK, dat ass gutt.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "All wielt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Liwwerung Lizenzen",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Premierminister",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Auswiel vun den Stonnen",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Auswielen vun de Minutten",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Entlooss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "D' Menü gëtt ofgeschloss",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ausgewielt Joer",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Onbekannt Datum",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Net spezifizéiert Datum",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Datum an der Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Startdatum",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Enddatum",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Startdatum $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End Date $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ongültig Datumformat",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid Datumsbereich",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datum aus dem Beräich",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Erléischt",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Datum auswielen",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "D'RANGSCHLÄFT",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Schalt op Kalennermodus",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Schalt op den Date-Modus",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Zäit wielen",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Gitt Zäit",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Stonn",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutt",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Invalide Zäit",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Schalt op de Wäertmodus",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Schalt op den Input-Zäitmodus",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ënnerschriwwen",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fënnt Konten",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Fannt Konten",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigatiounsmenü",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu Bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup Menü",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alarm",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Sich",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Aktuell Datum",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ausgewielt Datum",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Schreift fir ze starten",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Verréckelt bis zum Enn",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gitt op",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gitt op d'Fënster",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Verréckelt an links",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Réck bewegen",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Erfrischung",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kappen Schloss",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal op d'Nuecht",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal op",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontroll",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "D'Schléi",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ausgeschloss",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Enn",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Flucht",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Heem",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kommando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fenster",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplikéiert",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren links",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Recht",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Säit op d'Säit",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Säit op",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kraaft",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "D'Strooss aus",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Schrëttbildschirm",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Auswielen",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Schicht",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Raum",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lua.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu wa navigation wa bukula",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Pamuapa",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Bulula",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kuvua pabuipi",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kumbusha",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Malu makuabu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mu ngondo udi ulonda",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Tshimenga tshia kumpala",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Tshibejibeji tshidi tshilonda",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Tshibejibeji tshia kumpala",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tshikandakanda tshia kumpala",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Tshikandakanda tshia ndekelu",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Leja menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Tshikandakanda",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Tshikese tshia panshi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Bipeta bia mikanda",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Muinshi mua dibeji:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kukumina",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kuvua pabuipi",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tungunuka",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Dienza mudimu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Badi bakosa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Kukeba mêyi",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tangila muulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Keba mu site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Difila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Biakenzeka bimpe",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Kanyenga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sungula bionso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tangila mikanda ya dianyisha",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sungula mêba",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sungula minite",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dibenga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kusha menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "mm/mm/mm/mm/mm/mm",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tshidimu tshia kusungula",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dituku dia dikumbana",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Tshiena tshijadika tshia matuku",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Difila Dituku",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Dituku dia kutuadija",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dituku dia ndekelu",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Dituku dia kutuadija $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Dituku dia ndekelu $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Tshisua tshia dituku tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi tshiyi",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Tshiena-kuenza tshia matuku",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dituku didi mu tshibuashibuashi",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Uteleja",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sungula dituku",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT dia muinshi",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pingana ku mushindu wa kalandriye",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pingana ku mushindu wa dituku dia difila",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Sungula dîba",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Dibueja dîba",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ndekelu wa dîba",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Tshikondo tshimue",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tshikondo tshia malu a tshianana",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pingana ku mushindu wa kuakula",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pingana ku mushindu wa dîba dia difila",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Badi badie mu mukanda",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kufiisha malu",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Leja malu adibu bafile",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu wa dienda",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu wa ku luseke",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu wa mu tshiamu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Muyuki",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Dimuija",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Dienza dipatula",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tshikondo tshia lelu",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dituku didibu basungule",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Dienda bua kutuadija",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kulekela",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ndaku kumpala",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ndaku panshi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pambuka ku tshianza tshia bakaji",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Lombola ku tshianza tshia balume",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Dishintuluka",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Tshisumbu tshia bantu",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graphe wa tshianana",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Muaba wa nyuma",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapu wa ku lukita",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Mu njila wa panshi",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Mu njila wa ku muulu",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kuenza mudimu",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kumbusha",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Dipanga",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ndekelu wa bionso",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Dibutuka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ku nzubu",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kufila",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Mukokeshi",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Matanda a ku nzubu",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Tshikondo tshia Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad udi usanka",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Tshimfuanyi",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Ku dia bakaji",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ku tshianza tshia balume",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Dipeta dia Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Mvua mulekele malu a bungi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Mbalue ku dibeji",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Bukole",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kulekela kufila bukole",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tshijengu tshia dipatula",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Lukuka lua kubula",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Sungula",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Tshisumbu tshia mudimu",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Muaba",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_luo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_luo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Meno mar wuoth",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Wuo gi",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ler",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Chiegni",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Golo",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Weche momedore",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Dwe mar auchiel mabiro",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Dwe mar adek",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Weche ma luwogi",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Weche molworo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Weche Mokwongo",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Weche mogik",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Nyis menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ng'icho",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Weche manie bwo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ratiro mag Ng'ato",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Weche molworo ite:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Golo",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Chiegni",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Dhi Nyime",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi mar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ng'ado mar ng'ado",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Nono weche",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ne malo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Many weche e Intanet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Miyo Ji",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ok ok",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yier duto",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Nonro mar laisens",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Jatelo mar piny",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Yier seche",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Yier dakika",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Golo",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Golo menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Yiero mar higa",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Odiechieng ' maok ong'ere",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Kinde ma ne ok ong'ere",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ket tarik",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Odiechienge mag Chakruok",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ndalo mar Giko",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Odiechienge mag Chakruok $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Dwe mar giko $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Weche ma ok kare",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ok ochuno ni nyaka ng'ato otim kamano",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ndalo mar wuok",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ket",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Yier tarik",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Yiero mar Ranyisi",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Lokri e yo mar kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Lokri e yo mar odiechieng ' ma idhiye",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Yier sa",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Dwok thuolo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Sa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Dakika achiel",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Kinde maok nyal tiyo",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Lokri e yo mar goyo",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Lokri e yo mar tiyo gi seche",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ne oket chik",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Pando weche",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Nyis weche",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Penjo mar wuoth",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bar mar menus",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu mar popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Weche ma Ji Wuoyoe",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Weche ma Ji Wacho",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Yud",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ndalo masani",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Dwe mar yiero",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Dhi nyime",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Dhi Nyime",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Dhi malo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Dhi piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Dhi koracham",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Dhiuru korachwich",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Medruok",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alot",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Yore mag ng'ado paro",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Dhi Nyime",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Dhi Nyime",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Riwruok",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Golo",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Golo",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Giko",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Wuok",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ot",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ket",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Chik",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Numa mar Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Pogo Nyirombe",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Donjo e Kode",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Egal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Manyiso",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ma ne ni Kanyono",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ma korachwich",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Weche Manie Websait",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Dhi Nyime",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Teko",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tiyo gi Tekono Ok Nyal Ti",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Goyo Picha",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Locho mar Scroll",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Yier",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Tije mag Lendo",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Yore mag Wuok",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lus.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Navigation menu hawn",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "A hnuai lam",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "A chiang",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "A hnai",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Chhiar",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "A tam zâwk",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Thla khat kaltaah",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Thla hmasa",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Previous page",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Hmun hmasa ber",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "A hnuhnung ber",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Menu langhter",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Hriang",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "A hnuai lam",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "License",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Page khat chhunga row:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Chhuahchhiat",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "A hnai",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "A kal zel",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "A hniam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Text scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "A chunga en rawh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Web-ah zawng",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Hlawhtling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "A ṭha e.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "A zawng zawng thlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "License en",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hun thlan",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minutes thlan",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Thlawp",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu paih",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Kum thlan",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ni sawi loh",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Hriat loh hun hunlai",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ni A Pui",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tlai ṭan ni",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Hriatna hun",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tlai ṭan ni $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Hriat hun tawp $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Hriatlohna format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Hriatloh hun hmanna",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Hmanlai chu a awm lo",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Hluang",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Ni thlan",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "HLAWNA HLAWNA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Calendar mode-ah chuan intlun rawh",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Input date mode ah chuan intlanpui rawh",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Hun thlan",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Hun chhut",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Hun",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Hun hman loh",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Hlawhtlingna lam pan",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Input time mode ah chuan intlan",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "A ziak a ni",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Account thup",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Account-te han tarlang",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogue",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Thuhrilhna",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Chhânna",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tûnlai a ni",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "A thlan ni",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Hman ṭan tûrin kal",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A tawp thlengin kal",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "A chhoh chhoh mai ang",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "A hnuai lamah chuan kal rawh",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hne lamah chuan",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hne lam pan rawh",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Chhan thar",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Hmun hnuai lam",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kap-te Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Chhiar",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Chhum chhuak",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "A tawp",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "An tlanchhiat",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "In",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "A dah",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Thuhrilna",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Window",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad-a inṭhenna",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter chu",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Hmanh",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Hne",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "A Hmun A Thlân",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Power",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power A Khah",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Screen Print",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pawisa",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Hmun hrang",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Khawvel",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lvs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lvs.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Atvērtā navigācijas menü",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Atgriežoties",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Skaista",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pieci",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Izmazgā",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Vēl vairāk",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Nākamais mēnesis",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Iepriekšējais mēnesis",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nākamajā lapā",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pirmā lapa",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Pirmais lasījums",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Pēdējā lapa",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Izskatīt menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skarbums",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Apkaimē",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licences",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rīci uz puslašu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Atcelt",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pieci",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Turpiniet",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Sārkšana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skandē tekstus",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Izskatīt augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Izmeklējiet interneta",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pievienojiet",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Labi.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli visus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Izskatīt licences",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Izvēlējiet stundas",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Izvēlējiet minūtes",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Atkāpšanās",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Atkāpjas menü",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Izvēlēts gads",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Neatzīmēta datums",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Neatzīmēts datumu diapazons",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Pielikums",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Sākuma datums",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Piepildīšanas datums",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Sākuma datums $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Galvenā datums $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Neatbilstoša datuma formāts",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Neatbilstoša datumu diapaze",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datums ārpus darbības jomas",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Saimniekot",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Izvēlējiet datumu",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "RANGĀS SELECT",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pārvietojiet kalendāra režīmā",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pārsteidzojiet ievadīšanas datuma režīmu",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Izvēli laika",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Pielikums",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Stūres",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minūtē",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Neatbilstošs laiks",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pārsteidzojiet uz numuru",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pārsteidzojiet ievadīšanas laiku režīmu",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Piezīmēta",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Aplēsties ar kontu",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Izskatīt konta",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigācijas menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu stūra",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Izplūdes menü",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialoga",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Izmeklēšana",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Aktuālā datums",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Izvēlēta diena",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Izstāde",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pieeja līdz beigām",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Izceļot",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Izkļūt uz zemumu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Izgriež uz kreisi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Izgriež uz kreisi.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Atmugurēšana",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt grafiskais",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Aizmugurējā platība",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapules lukturis",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanāls uz zemenu",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Up Channel",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrolēšana",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Izmazgā",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Izstrādā",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Galvenā",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Izvadīšana",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kādu",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Pielikt",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandā",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Pārvadījumi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad komā",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimals",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divid",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad līdzvērtīgs",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicates",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren aizstāvēts",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren tiesības",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pielikums",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagājušā daļa",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Jaudas",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Elektrības izņemšana",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Izdrukāt ekrānu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Skrāvējiet",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Izvēli",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Sastāvdaļa",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Laiks",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_lzh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_lzh.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "开导航菜单",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "返回",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "分明",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "闭之",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "除之",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "愈多",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "后月",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "前月",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "下一页",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "上一纸",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "第一纸",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "最后一页",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show 菜单",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "稀松布",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "底板",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "许可证",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "每页行数。",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "罢之",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "闭之",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "续",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "复制",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "切",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "扫一扫文本",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "𴏧",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "搜索 Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "共享",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "还",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "糊",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "全选",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "阅许可证",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "然",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "下午",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "择营业时间",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "择分钟",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "解雇",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "闭菜单",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "日/月/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "择年",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "未期",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "未定日期",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "输其日",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "始期",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "毕日",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "日格无效",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "日限无效",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "日出其限",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "救之",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "择日",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "择之",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "切换至日历模式",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "切换至输日模式",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "择时日",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "输之岁月",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "少时",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "分钟",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "无效时",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "切换至拨号式",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "切换至输时式",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "已录",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "匿账户",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "示账户",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "导航菜单",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "菜单栏",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "弹出菜单",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "对",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "警",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "搜索",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "前期",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "所选日",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "移于始",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "移之终焉",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "上升",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "下移",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "左行",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "右移",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "刷新",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt 键",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "退格键",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "大写锁定",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "道闭",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "道上",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "制之",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "除之",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "弹出",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "终",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "遁",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "家",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "插入",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "元",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "令",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "窗牖",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "数小键盘 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "数小键盘 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "数小键盘 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "数小键盘 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "数小键盘 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "数小键盘 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "数小键盘 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "数小键盘 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "数小键盘 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "数小键盘 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "数小键盘加之",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "数小键盘逗号",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "数小键盘十进制",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "数小键盘除法",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "数小键盘 Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad 也",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "数小键盘乘法",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "数小键盘括号左",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "数小键盘括号右",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "数小键盘减去",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "下一页",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "权也",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "关闭电源",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "打印屏幕",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "择",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "转",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "空中",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mag.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "नेविगेशन मेनू खोलो",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "पीछे हटके",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "साफ करे",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "बंद करे",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "हटावे",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "अधिक",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अगले महीने",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पिछला महीना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अगला पन्ना",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पिछला लेखपन्ना",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पहिला पन्ना",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "अंतिम पन्ना",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू दिखावा",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "निचला पत्रक",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "लाइसेंस",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रति पृष्ठ पंक्तिः",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द करे",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "बंद करे",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी रखल जाय",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "पाठ स्कैन करे",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ऊपर देखहो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब पर खोज करे",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीक हइ ।",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चुनल जाय",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लाइसेंस देखावल जाय",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "एएम",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "पीएम",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "चुनल जाय वाला समय",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनट के चयन करे",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "निरस्त करे",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू के छोड़ दे",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "चुनल गेल साल",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अज्ञात तिथि",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अज्ञात तिथि सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "दिनांक दर्ज करे",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "प्रारंभ तिथि",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "अंत तिथि",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "प्रारंभ तिथि $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "अंत तिथि $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अवैध तिथि प्रारूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध तिथि सीमा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "सीमा से बाहर तिथि",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "सहेजवा",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "तिथि के चयन करे",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "चुनल गेल श्रेणी",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेंडर मोड पर स्विच करे",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट तिथि मोड पर स्विच करे",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय के चयन करे",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समय दर्ज करे",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घंटा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनट में",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अवैध समय",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोड पर स्विच करे",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट समय मोड पर स्विच करे",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "हस्ताक्षरित",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खाता छिपावे",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाता दिखावा",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "नेविगेशन मेनू",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू पट्टी",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "पॉपअप मेनू",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "संवाद",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "अलर्ट",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोज करे",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "वर्तमान तिथि",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चयनित तिथि",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "शुरू करे के लेल आगे बढ़ो",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत तक जा",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर जा के चल जा",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे जा",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बाएं तरफ जा",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिना चलल जाय",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ताज़ा करे",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "अल्ट",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "अल्ट ग्राफ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "बैकस्पेस",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "नीचे के चैनल",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ऊपर चैनल",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "हटावे",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "बाहर निकलना",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अंत",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "भागलई",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घरवा में",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "डालना",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "कमांड",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "खिड़की",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नंबर लॉक",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नम्पैड 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नम्पैड 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नम्पैड 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नम्पैड 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नम्पैड 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नम्पैड 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नम्पैड 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नम्पैड 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नम्पैड 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नम्पैड 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "नम्पैड जोड़",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "नम्पैड कॉमा",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नम्पाड दशमलव",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नम्पड विभाजन",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "नम्पड समान",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "नम्पड गुणन",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नम्पड पारन बाएं",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren दाहिना",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नम्पड घटाव",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पृष्ठ नीचे",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पृष्ठ ऊपर",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "शक्ति",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "बिजली बंद हो गेलई",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "प्रिंट स्क्रीन",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रोल लॉक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चुनवा",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अंतरिक्ष",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mai.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mai.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "नेविगेशन मेनू खोलू",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "पाछाँ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "साफ करू",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "बन्न करू",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "मेटाबू",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "बेसी",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अगिला महीना",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पछिला महीना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अगिला पृष्ठ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पछिला पृष्ठ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पहिल पृष्ठ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "अंतिम पृष्ठ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू देखाबू",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "निचला शीट",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "लाइसेंस",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रति पृष्ठ पंक्ति:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द करु",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "बन्न करू",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी राखू",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "कापी करू",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "काटू",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "पाठ स्कैन करू",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "उप्पर देखू",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब खोजू",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "बेस",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "साटू",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभटा चुनू",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लाइसेंस देखू",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "भोर",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "पीएम",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "घंटा चुनू",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनट चुनू",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "बर्खास्त करू",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनू बर्खास्त करू",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "वर्ष चुनू",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अनिर्दिष्ट तिथि",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अनिर्दिष्ट दिनांक परिसर",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "दिनांक दाखिल करू",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "प्रारंभ दिनांक",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "समाप्ति तिथि",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अवैध तिथि प्रारूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध तिथि पसार",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "दिनांक परिसरसँ बाहर",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "सहेजू",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "दिनांक चुनू",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "पसार चुनू",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेंडर मोडमे स्विच करू",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट दिनांक मोडमे स्विच करू",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय चुनू",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "समय दाखिल करू",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घंटा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनट",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अवैध समय",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोडमे स्विच करू",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट समय मोडमे स्विच करू",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "एकरामे हस्ताक्षरित",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खाताकेँ नुकाऊ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाता देखाबू",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "नेविगेशन मेनू",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू पट्टी",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "पॉपअप मेनू",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "समाद",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "चेतावनी",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोजू",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "मोजुदा दिनांक",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चयनित तिथि",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "प्रारंभ करबाक लेल घसकाबू",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत मे जाउ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उप्पर जाउ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीच्चाँ जाउ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बामाँ जाउ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दहिन्ना जाउ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ताजा करू",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "आल्ट",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "आल्ट ग्राफ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "बैकस्पेस",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कैप्स लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "चैनल नीच्चाँ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "चैनल उप्पर",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "मेटाबू",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "बाहर निकालू",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अंत",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "एस्केप",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घर",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "निवेशित करू",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "कमांड",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "विंडोज",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नम लाक",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नुम्पैड 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नुम्पैड 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नुम्पैड 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नुम्पैड 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नुम्पैड 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नुम्पैड 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नुम्पैड 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नुम्पैड 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नुम्पैड 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नुम्पैड 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "न्यूमपैड जोड़ू",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "न्यूमपैड अल्पविराम",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नुम्पैड दशांश",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नुम्पैड विभाजन",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "न्यूम्पैड दाखिल करू",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "न्यूमपैड समान",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "न्यूम्पैड गुणा करू",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नुम्पैड पेरेन बम्माँ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "नुम्पैड पेरेन दहिन्ना",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नुम्पैड घटाबू",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पृष्ठ नीच्चाँ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पृष्ठ उप्पर",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "पावर",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "पावर बंद",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "स्क्रीन छापू",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रॉल लाक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चुनू",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "स्थान",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mg.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu Open navigation",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Miverina",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Akatony",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Fafao",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Bebe kokoa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Amin'ny volana ambony",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Tamin'ny volana lasa",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Pejy manaraka",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pejy teo aloha",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Pejy voalohany",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Pejy farany",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Asehoy ny karazan-tsafidy",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom taratasy",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Fahazoan-dàlana",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Andalana isaky ny pejy:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancel",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Akatony",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tohizo",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tahadika mitovy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Hetezo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan ny lahabolana",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Jereo ny tohiny",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Tadiavo ny tranonkala",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Zarao",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Apetaho",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny zava-drehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View fahazoan-dalana",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Misafidiana ora",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Misafidiana minitra",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Fandroahana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ario ny karazan-tsafidy",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Misafidiana taona",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Daty tsy voafaritra",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Daty tsy voafaritra",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ampidiro ny daty",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Daty fanombohana",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Daty farany",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Tsy mety ny datin'ny daty",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Daty tsy ekena",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Daty ivelan'ny faritra",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tehirizo",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Safidio ny daty",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ovay amin'ny fomba kalandrie",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ovay ny fomba fanoratana daty",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Safidio ny fotoana",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ampidiro ny fotoana",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minitra",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Fotoana tsy mety",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ovay amin'ny fomba dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ovay ny fomba fanoratana fotoana",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sonia ao amin'ny",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Afeno ny kaonty",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Asehoy ireo kaonty",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu Navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dinidinika",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Fanairana",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Search",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ny daty ankehitriny",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Daty voafaritra",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mandrosoa manomboka",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mifindra any amin'ny faran'ny",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mandrosoa",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Midina midina",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mifindra eo ankavia",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mihetsika tsara",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Mamelombelona",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Midina ny fantsona",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Fantsona Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Fanaraha-maso",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Fafao",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fiafarana",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fandosirana",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Baiko",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad mitovy",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren havia",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pejy midina",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pejy mirohy any amin'i ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Hery",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tapaka ny herinaratra",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Horonan-taratasy Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Safidio",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Fiovana",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Space",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mi.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Whakatuwheratia te tahua whakaterenga",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Whakamuri",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Mahea",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Katia",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Whakakore",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ētahi atu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "A tērā marama",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Marama tōmua",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Whārangi whai ake",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Whārangi o mua",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Whārangi tuatahi",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Whārangi whakamutunga",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Whakaaturia te tahua",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kiriata",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Rau o raro",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ngā Raihana",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ngā haupae mō ia whārangi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Whakakore",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Katia",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Haere tonu",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tārua",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "tapahi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Karapa kuputuhi",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tirohia ake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rapua te tukutuku",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Tohaina",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ka pai",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Whakapiri",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tīpako Katoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tirohia ngā raihana",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Tīpako hāora",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Tīpako meneti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ākiritia",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ākiritia te tahua",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tīpako Tau",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Rā kāore i whakapūtātia",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Awhe rā kāore i whakapūtātia",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tāuru Rā",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Rā tīmata",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Rā mutunga",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Hōputu rā muhu",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Awhe rā muhu",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Rā i waho i te awhe",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tiaki",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tīpako rā",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TĪPAKO AWHE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Whakawhiti ki te aratau maramataka",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Whakawhiti ki te aratau rā tāuru",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Tīpako wā",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Tāuru wā",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Haora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Meneti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Wā muhu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Whakawhiti ki te aratau waea",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Whakawhiti ki te aratau wā tāuru",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Kua takiurua",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hunaia ngā pūkete",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Whakaaturia ngā pūkete",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Tahua whakaterenga",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Pae tahua",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Tahua pakūake",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kōrero",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Matohi",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Rapua",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Rā o nāianei",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Rā kua tīpakohia",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Nuku ki te tīmata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nuku ki te mutunga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nuku whakarunga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Nuku whakararo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nuku whakatemauī",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nuku whakatematau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Whakahou",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Kauwhata Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Mokowāwhakamuri",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Pātuhi pūmatua mau",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Hongere Whakararo",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Hongere Whakarunga",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Mana",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Whakakore",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Whakaputa",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Mutunga",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "mawhiti",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kāinga",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kōkuhu",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Tohutohu",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Matapihi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Papatau 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Papatau 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Papatau 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Pūpatotau 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Papatau 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Papatau 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Papatau 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Papatau 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Papatau 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Papatau 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Tāpiri Papatau",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Piko Papatau",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Papatau Ā-Ira",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Whakawehe Papatau",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Tāuru Papatau",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Pūpatotau Ōrite",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Pūpatotau Whakarea",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Parea Pūtau Mauī",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Parea Pūtau Matau",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Tango Papatau",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Whārangi whakararo",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Whārangi whakarunga",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mana",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Whakaweto hiko",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tā Mata",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Kōwhiria",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Neke",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Mokowā",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_min.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_min.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigasi tabukak",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Babaliak",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Lampuang",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Dekek",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Hapus",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Labih banyak",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Bulan nan ka tibo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Bulan sabalumnyo",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Laman nan ka tibo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Laman sabalunnyo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Laman partamo",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Laman nan ka akienyo",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Panampilan menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scarabaeus",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lembar bawah",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisensi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Baris pado halaman:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Batalkan",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Dekek",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Lanjutkan",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tanda-tanda",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Panjang",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Teks scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Liek ateh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Barbagi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK lah",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Piliah kasadonyo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Panampilan lisensi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pamilihan jam",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Piliah minut",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Pambuek",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu indak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tahun nan dipilih",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tanggal nan indak ditantuak",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jarak tanggal nan indak ditantuakan",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tulis Tanggal",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tanggal pamulo",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tanggal panutup",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tanggal pamulo $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Tanggal akhir $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format tanggal nan indak sah",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Jarak tanggal nan indak sah",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tanggal di lua",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Saro",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tantuak tanggal",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PILIHAN RANG",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pindah ka mode kalender",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pindah ka mode tanggal masuak",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Panitia wakatu",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Masok wakatu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Jam",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minit",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Waktu nan indak sah",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pindah ka mode dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pindah ka mode wakatu input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Tanda tangan",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Panjaleh akun",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Tampilkan akun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigasi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu nan tabik",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Pantauan",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Pancarian",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tanggal ko",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tanggal nan dipilih",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Pindah untuak mulai",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindah ka akhia",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah ateh",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bajalan ka bawah",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah ka kiri",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindah ka kanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Panjang",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Langsung",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graph Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ruang ka balakang",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapas Kunci",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Saluran ka bawah",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Saluran ateh",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Hapus",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Akhirnyo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Lari dari",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Rumah",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Panambahkan",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "tingga",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tambah",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Komma Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Pambagian Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad samo",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Panambaian",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kawan",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren nan tuo",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtract Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Laman nan ka bawah",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Laman ateh",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kuasa",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Lampu mati",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tandakan Lampu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Panutup gulungan",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Piliah",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pamulihan",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ruang",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mni.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mni.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "নেভিগেসন মেন্যু হাংদোকপা",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "অমুক হন্না",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ময়েক শেংনা",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "নক্না",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "লৌথোকপা",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "হেন্না",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "মথংগী থাদা",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "মমাংগী থা",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "মথংগী পেজ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "মমাংগী পেজ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "অহানবা পেজ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "অরোইবা পেজ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "মেনু উৎ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "স্ক্রিম",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "মখাগী শীৎ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "লাইসেন্সশীং",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "পেজ অমদা রোলশীং:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "লৌথোকপা",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "নক্না",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "মখা তানা চৎকদবনি",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "কপী",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "কাৎপা",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "স্কেন তৌরবা তেক্স",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ৱাংখৎকদৌরিবশিং",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ৱেবতা থিদোকপা",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "শেল থাদবা",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ফজনা",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "পেস্ত",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "পুম্নমক খনগৎকনি",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "লাইসেন্সশিং য়েংবা",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "পি.এম.",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "মতম খনবীয়ু",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "মিনিৎশিং খনবীয়ু",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "লৌথোকপা",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "মেনু থাদোকপা",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "চহী খনবা",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "অকক্নবা তর্জ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "অকক্নবা মতমগী চাং",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "মতমদু ইনবা",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "হৌদোকপগী তাং",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "লোইশিনবগী তাং",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "হৌদোকপগী তং $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "লোইশিনবগী তং $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "মপুং ফাহল্লবা ত্রেদিট ফোর্মেৎ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "মপুং ফাহল্লবা মতমগী রেঞ্জ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "মপুং ফাহল্লবা তাং",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "সেভ তৌ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "তংখৈ খনবীয়ু",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "সিলেক্ট রেঞ্জ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "কেলেন্দর মোদতা ওনলাইন তৌ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ইনপুট দেট মোদতা ওনলাইন তৌ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "মতম খনবীয়ু",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "মতমদুদা ইন্তর তৌ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "পুং",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "মিনুত",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ইন্দিয়াগী মতম",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "দিএল মোদতা ওনশিনবা",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ইনপুট মতমগী মোদতা ওনশিনবা",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "সাইন ইন তৌখ্রে",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "একাউন্তশিং থোঙদোকপা",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "একাউন্তশিং উৎ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "নেভিগেসন মেন্যু",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "মেনু বার্",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "পোপপ মেনু",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "দিএলোক",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "এলেক্সন",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "থিদোকপা",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "হৌজিক্কী মতম",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "খনগৎলকপা তর্জা",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "হৌদোক্নবা খোঙথাং",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "লোইশিনবদা চংশিনবা",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "মথক্তা চংশিনবিয়ু",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "মখা তানা চংশিনবিয়ু",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "লেম্না চংশিনবা",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "হকথেংননা খোঙজং চঙ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "রিফ্রেশ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "অল্ট",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "অল্ট গ্রাফ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "বেকস্পেস",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "কেপস লোক",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "চেনলদা হন্থবা",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "চেনল ওফ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "কন্ত্রোল",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "লৌথোকপা",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "থাদোকপা",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "লোইশিনবা",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "লাপথোকপা",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ফন",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "য়ুমদা",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ইন্সটর তৌ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "মেটা",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "কমান্দ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ৱিন্দো",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "নম্পাদ 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "নম্পাদ ২",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "নম্পাদ 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "নম্পাদ 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "নম্পাদ ৫",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "নম্পাদ ৬",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "নম্পাদ ৭",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "নম্পাদ ৮",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "নম্পাদ 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "নম্পাদ 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "নম্পাদ এদ",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "নম্পাদ কম্মা",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "নুম্পাদ দেসিমেল",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "নম্পাদ দিভাইজ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "নম্পাদ এন্তর",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "নম্পাদ ইক্বেল",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "নম্পাদ মল্টিপ্লাই",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "নম্পাদ পেরেন লেফৎ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "নম্পাদ পেরেন হক",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "নুম্পাদ সবট্রেক্ত",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "পেজ হন্থবা",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "পেজ ওফ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "পাৱর",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "মৈ থাদোকপা",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ইন্সক্রিন প্রিন্ট তৌবা",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "রোল তৌনবগী লোল",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "সেলেক্ত তৌ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "শিফট",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "স্পেস",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mos.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mos.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ninsaal sẽn na n kẽed ne sõorã",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "D leb n kẽnga poorẽ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "B sẽn da na n maan bũmb ningã",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Sẽn pẽ-a wã",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Yɩl-y n yiis-a",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Sẽn paase",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Dẽn-kẽembeoogã",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Sẽn yɩlẽ kiuugã",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sõng-y n ges-y-yã",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Sõsg ning sẽn pʋgdã",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Pipi sebre",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Sõng-y n ges-y-yã",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Wilg-y sõorã",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Dɩt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt-yãt",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bõn-ka-toog sẽn yaa to-to wã",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Sõsg ning sẽn be Biiblã pʋgẽ wã",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Sõng-n-tɩrs ne seb-neng:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Yãk-y n da wa ye",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Sẽn pẽ-a wã",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kẽng-y n kẽng taoor",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Sõng-y n deeg-y-yã",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "B sẽn yã wã",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sõnd sẽn tar tagsgo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ges-y n gese.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Bao-y Internetã pʋgẽ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "D pʋɩ-ta ne taaba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Yaa sõma.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Dɩt-y n ges-y",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi b fãa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ges-y sɛb nins sẽn be wã",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "A D",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM wã",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Yãk wakat ning y sẽn na n yãk",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sõng-y minitã",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "B sẽn yiis-a wã",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Yãk-y n yiis-y",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Yʋʋmd ning b sẽn yãk",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Dɩta sẽn pa yetã",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "B sẽn pa wilg daarã sẽn yaa to-to wã",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Sõng-y n gʋls daarã",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Sɩngr daarã",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Dɩk-kãnga",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Sɩngr daarã $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Sɩngr daarã $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Dɩtaarã sẽn pa zems",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Dɩtaarã sẽn pa zems",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dɩta sẽn pa be sorẽ wã",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "B tall-y-la",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sõng-y daarã",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SAK-YÃNG D sẽn yãk",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Yãk-y wakatã mode",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Yãk-y n kẽng n kẽng n tɩ ges y sẽn na n wa n maan bũmb ningã",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Yãk wakat ning y sẽn datã",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Sõng n kẽ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Wakat sẽn ta",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Sõng-y n ges-y",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Wakat sẽn pa zemsã",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Yãk-y n kẽ n tool-y neda",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Yãk-y n kẽng wakat ning y sẽn na n dɩk n kẽngã",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "B sẽn gʋlsã",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Bõn-kaoodã sẽn solg",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Wilg-y sõssã",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ninsaal yel-gɛtã",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Dẽn-kãnga",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "A Zeova sẽn maan bũmb ningã",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Sõsg ning sẽn be wã",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Dɩt-yã",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Baoosgo",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Dɩta sẽn yaa sasa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Kibs nins b sẽn yãkã",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "D yik n sɩng",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kẽng n ta a baasgo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kẽng-y n kẽng n tɩ moonẽ.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kẽng-y n kẽng tẽngre.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi n kẽng goabgẽ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yi n kẽng rɩtgo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Dɩt-y n paam yam-yãkr",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "A to",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "A Graaf sẽn be",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "B sẽn da maand bũmb ningã",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Bãagrã sẽn yaa gãndg",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "D sẽn na n wa n wa n na n wa",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "D sẽn na n wa n wa",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "B sẽn get bũmb ning",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Yɩl-y n yiis-a",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "B sẽn yiisd-a wã",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Bãngr-gomdã baasgo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "B sẽn zoe wã",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "A Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "D roogã",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Add a Comment",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Metã",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "D sẽn na n wilg tɩ d yaa nin-buiidã",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Dẽnnaar",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad pʋga",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad kẽnga",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad sẽn zems",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Nambd",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren sẽn yi",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren rɩtgo",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sõng-y n wa ges-y-yã",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Sõng-y n tool-y neda",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Tʋʋmdã pãng",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "B sẽn pa tar pãng",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tãnd-y n tool-y neda",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Dɩk-y n tool-y neda",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Yi-yã",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "D sẽn maand bũmb ninsã",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Bãngrã",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mt.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Iftaħ il-menu tan-navigazzjoni",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Lura",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ċara",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Qrib",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Tħassar",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Aktar",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ix-xahar id-dieħel",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ix-xahar ta' qabel",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Il-paġna li jmiss",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Paġna preċedenti",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "L-ewwel paġna",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "L-aħħar paġna",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Uri l-menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Folja tal-qiegħ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Liċenzi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ringieli għal kull paġna:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ikkanċella",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Qrib",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tkompli",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Maqtugħa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skennja t-test",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Fittex 'il fuq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fittex fuq il-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Sehem",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Kollox sew",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Ippejstja",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Agħżel kollox",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ara l-liċenzji",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Agħżel is-sigħat",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Agħżel il-minuti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Tkeċċi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Neħħi l-menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "jj/xx/ssss",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Agħżel is-sena",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data mhux speċifikata",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Medda ta' dati mhux speċifikata",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Daħħal id-Data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data tal-Bidu",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data tat-Tmiem",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format tad-data invalidu",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Medda ta' dati invalida",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data 'l barra mill-medda",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tissejvja",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Agħżel id-data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "AGĦŻEL IL-MEDDA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Aqleb għall-modalità tal-kalendarju",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Aqleb għall-modalità tad-data tal-input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Agħżel il-ħin",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Daħħal il-ħin",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Siegħa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuta",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ħin invalidu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Aqleb għall-modalità ta' l-iddajljar",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Aqleb għall-modalità tal-ħin tal-input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Iffirmat fil",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Aħbi l-kontijiet",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Uri l-kontijiet",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu tan-navigazzjoni",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Istrixxa tal-menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Djalogu",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Twissija",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Tiftix",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Id-data kurrenti",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data magħżula",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mexxi biex tibda",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mexxi lejn it-tmiem",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Imxi 'l fuq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mexxi 'l isfel",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mexxi lejn ix-xellug",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mexxi lejn il-lemin",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Aġġorna",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graff Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spazju lura",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Għatu msakkar",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal 'l isfel",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal 'il fuq",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontroll",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Tħassar",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Toħroġ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Għan",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Salvataġġ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Dar",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Daħħal",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kmand",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Żid",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Virgola tan-numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Deċimali",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Diviżjoni tan-numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Daħħal",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Ugwali",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Multiplika tan-numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Paren tan-numpad tax-xellug",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Paren tal-Lemin tan-Numpad",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Naqqas",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Paġna 'l isfel",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Paġna 'l fuq",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Enerġija",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Itfi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ipprintja l-Iskrin",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Agħżel",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spazju",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_mww.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_mww.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Qhib navigation zaub mov",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "sab nraum qab",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ntshiab",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kaw",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ntau",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "lub hlis tom ntej",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "lub hli dhau los",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "nplooj ntawv tom ntej no ntxiv",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "nplooj ntawv yav dhau los",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "thawj nplooj ntawv",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Sab xeem",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Qhia zaub mov",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Hauv qab daim ntawv qhia txog hauv qab",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Daim LaIs Xees Uas Tau Ntawv",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows ib nplooj ntawv:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "raug muab tso tseg",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kaw",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Mus",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Luam ib daim qauv",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Hlais",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan phau ntawv",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Saib",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nrhiav lub web site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Sib qhia tawm",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ua li",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Xaiv tag nrho cov kev xaiv",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Saib daim ntawv tso cai tsav tsheb",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Xaiv cov sij hawm xaiv",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Xaiv cov feeb",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "tso tseg",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dhau los tso zaub mov",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Xaiv xyoo",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Hnub unspecified hnub",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified hnub ntau yam",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Sau Hnub Tim",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Hnub Pib",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Hnub Kawg",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid hnub format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid hnub ntau yam",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Hnub tawm ntawm ntau yam",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Tseg",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Xaiv hnub",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "XAIV NTAU YAM",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Hloov mus calendar hom",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Hloov mus rau input hnub",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Xaiv lub sij hawm",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Nkag mus rau lub sij hawm",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Teev",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Feeb",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Invalid lub sij hawm",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Hloov mus rau dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Hloov mus rau input sij hawm",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Kos npe rau hauv",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Nkaum nyiaj",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Qhia nyiaj",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation zaub mov",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Zaub mov bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup zaub mov",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ceeb toom",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "nrhiav",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "hnub tam sim no",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Xaiv hnub",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Txav mus pib",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Txav mus",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "txav mus",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "txav mus",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "txav mus",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "txav mus",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Tsiaj ntawv loj",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel tuaj",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Tswj",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kawg",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "khiav",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "FN",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Tsev",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ntxig",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "hais kom ua",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "qhov rais",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Xauv",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Ntxiv",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad nkag mus rau hauv",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Sib npaug zos",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren tshuav",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren txoj cai",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Rho",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Nplooj Ntawv Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "nplooj ntawv",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "hwj huam",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "hwj huam",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Sau Ntawv Ntsuam Xyuas",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "xaiv",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ua haujlwm",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "chaw",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_nno.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nno.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Åpne navigasjonsmenyn",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Tilbaka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Åre klar",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Nær",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Ta bort",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mer om det",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Neste månad",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Tidlegare månad",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Neste side",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Frå forrige sida",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Første sida",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Sist side",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Visa meny",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skram",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenser",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Råar per side:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Avbryt",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Nær",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Fortsette",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skjer",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skane tekst",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Sjå opp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sjå på nettet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK, det er rett.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velg alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visa lisens",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Velg tid",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Velg minuttar",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kast bort",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Avskjæring",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Velg ut år",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Utilgrepe dag",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Utilgrepe datumsområde",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Skriv inn dato",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Startdato",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Sista dag",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Startdato $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Sista dag $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Utilgjengeleg datumet",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ugyldig datumsområde",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Dato ute av rekkjeområde",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ta vare på",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Velg dato",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELKTE rangen",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Skip til kalendermodus",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Skip til inngangsdatum-modus",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Velg tid",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ta inn tid",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Stund",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutt",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Utilgjengeleg tid",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Skip til dial-modus",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Overgå til inputtidsstil",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signerte inn",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Skjul rekvister",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Visa kontoar",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigasjonsmenyn",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menynstange",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popupmenyn",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Søk etter",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ikkje aktuell",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Velde dag",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Flyt til å byrja",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Flyt til slutt",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Flyt opp",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Flyt nedover",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Flyt til venstre",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ta deg til høgre",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Forfriskning",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Bakrommet",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapper lås",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal nedover",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal opp",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrollering",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Ta bort",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Endar",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Flytta",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Heime",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Legg inn",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kommandør",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Finduar",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Komma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad deling",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad lik",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplier",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren til venstre",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren rett",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sitta ned",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Sidan opp",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Magn",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Strøm av",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Skjermprenta",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Skrule lås",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Velg",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Skift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Rettleiken",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_npi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_npi.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "खुला नेभिगेसन मेनु",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "पछाडि",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "स्पष्ट",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "नजिक",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "हटाउनु",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "थप",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अर्को महिना",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "अघिल्लो महिना",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अर्को पृष्ठ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "अघिल्लो पृष्ठ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "पहिलो पृष्ठ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "अन्तिम पृष्ठ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनु देखाउनुहोस्",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "तलको पाना",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "इजाजतपत्र",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रति पृष्ठ पङ्क्तिहरूः",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द गर्नु",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "नजिक",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "जारी राख्नुहोस्",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "प्रतिलिपि",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटौती",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "स्केन पाठ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "माथि हेर्नुहोस्",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबमा खोज्नुहोस्",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझेदारी",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीक छ ।",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सबै चयन गर्नुहोस्",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "लाइसेन्स हेर्नुहोस्",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "एएम",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "प्रधानमन्त्री",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "समय चयन गर्नुहोस्",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "मिनेट चयन गर्नुहोस्",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "खारेज",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "मेनु खारेज गर्नुहोस्",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "चयनित वर्ष",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "अनिश्चित मिति",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "अनिश्चित मिति सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "प्रविष्ट गर्ने मिति",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "सुरु हुने मिति",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "समाप्ति मिति",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "सुरु मिति $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "अन्तिम मिति $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अवैध तिथि ढाँचा",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध मिति दायरा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "समय सीमा बाहिर",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "बचत गर्नुहोस्",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "चयनित मिति",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "चयन गर्नुहोस्",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "क्यालेन्डर मोडमा स्विच गर्नुहोस्",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "इनपुट मिति मोडमा स्विच गर्नुहोस्",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय चयन गर्नुहोस्",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "प्रविष्ट समय",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घण्टा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "मिनेट",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अवैध समय",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "डायल मोडमा स्विच गर्नुहोस्",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "इनपुट समय मोडमा स्विच गर्नुहोस्",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "हस्ताक्षर गरियो",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खाताहरू लुकाउनुहोस्",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाताहरू देखाउनुहोस्",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "नेभिगेसन मेनु",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनु बार",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "पपअप मेनु",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "संवाद",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "चेतावनी",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोज",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "वर्तमान मिति",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चयनित मिति",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "सुरु गर्न सार्नुहोस्",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अन्त्यसम्मको यात्रा",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उठ्नुस्",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "तल बढ्नु",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बायाँमा हिँड",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दायाँतिर हिँड",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ताजा",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "अन्य",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "अल्ट ग्राफ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "पछाडि ठाउँ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "क्याप्स लक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "तलको च्यानल",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "च्यानल माथि",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियन्त्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "हटाउनु",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "निकासी",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अन्त्य",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "भाग्नु",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "घर",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "सम्मिलित गर्नुहोस्",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "कमाण्ड",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "विन्डोजहरू",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "नम्बर लक",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नम्पड १",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नम्पड २",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नम्पड ३",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नम्पड ४",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नम्पड ५",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नम्पड ६",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नम्पड ७",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नम्पड ८",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नम्पड ९",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नम्पड ०",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "नम्पेड कम",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नम्पाड दशमलव",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नम्पड विभाजन",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad प्रविष्ट गर्नुहोस्",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "नम्पड बराबर",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad गुणन",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नम्पड पारन बायाँ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren दायाँ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नम्पाड घटाउने",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पृष्ठ तल",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पृष्ठ माथि",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "शक्ति",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "विद्युत बन्द",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "प्रिन्ट स्क्रीन",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रोल लक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चयन गर्नुहोस्",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अन्तरिक्ष",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_nso.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nso.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ka morago",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Tše dingwe",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kgwedi ye e tlago",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kgwedi ye e fetilego",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Letlakala le le latelago",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Letlakala la pele",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Letlakala la mathomo",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Letlakala la mafelelo",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Letlakala la ka fase",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Dilaesense",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Khansela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tšwela pele",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kgaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Lebelela godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nyakišiša Websaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Go lokile",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kgetha ka moka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "KE",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Diiri tše di kgethilwego",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Kgetha metsotso",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Kgetha ngwaga",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Letšatši leo le sa tsebjego",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified date range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Letšatši la go tsenya",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Letšatši la go thoma",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Letšatši la mafelelo",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fomete ya letšatšikgwedi yeo e sa amogelegego",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid date range",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out of range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Boloka",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Kgetha letšatši",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Fetogela go mokgwa wa khalentara",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Kgetha nako",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Tsena ka nako",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Iri",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Motsotso",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nako yeo e sa amogelegego",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Switch to dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Go Go Gadget Time Mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "E saennwe",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Bontšha diakhaonte",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ya Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Poledišano",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Temošo",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Nyakišišo",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Letšatši la bjale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Letšatši leo le kgethilwego",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Move down",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Šwišetša ka go la nngele",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sepela ka go la go ja",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Sebaka sa ka morago",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kunupi ya ditlhakagolo",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Taolo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Mafelelo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Go tšhaba",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Le ge go le bjalo,",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Gae",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Tsenya",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Taelo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mafesetere",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Letlakala la Fase",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Letlakala la Godimo",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Maatla",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Kgetha",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Phetogo",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Sebaka",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_nus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_nus.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Mi̱th mi̱ ca lɛp",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Lätdɛ jɔk",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Lätdɛ jɛ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Rɛy thi̱n",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kɛnɛ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Kä ti ŋuan",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Wäl in bëë ben",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Wäl ëëdan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Gua̱a̱th in dɔ̱ŋ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Gua̱a̱th ëëdan",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Gua̱a̱th in nhiam",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Gua̱a̱th in jɔak",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Nyothni̱ menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Rɛy rɔɔdɛ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Kä mi̱ ci̱e̱kɛ jɛ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lithɛni̱",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rɛ̈ɛ̈k kɛ kui̱ pa̱a̱m:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Läkdɛ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Rɛy thi̱n",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kä ŋotdɛ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kä cuɛɛ jɛ cop",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kɛn ti̱ ca da̱a̱k",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Thekthni̱ thany",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Guic nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kuɛn rɛy webä",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ŋi̱i̱c",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Lätdɛ jɛ.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pa̱th",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kɛn diaal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Guicni̱ thëlëcni̱",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kä thɛlɛ thaak",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Kɛl mintɔni̱",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Lätdɛ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Kä cuɛɛ mi̱eth",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Rɛy runi̱ ti̱ ŋuan",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "/Ca jɛ lar ɛn ɣöö bi̱",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "/Ca jɛ lar ɛn ɣöö bi̱kɛ gua̱a̱th",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Mi̱ ci̱ wä raar",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Kä cu tok kɛ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kä gua̱a̱th in te thi̱n",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Kɛl mi̱ tok kɛ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Kä thuɔ̱kdɛ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Kä /ci̱kɛ thuɔ̱k",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Kä /ci̱kɛ thuɔ̱k",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Rɛy gua̱th mi̱ /ci̱ rɔ̱ bi̱ lɛ ben",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Kä cuɛ ji̱ luäk",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Luäkdɛ kɛ cäŋ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "KƐ LƐM IN DI̱T",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Gɛl kä kalɛndɛr mode",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Gɛ̈ɛ̈l kɛ gua̱a̱th in ci̱ wä",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Luäk gua̱th",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kä cu gua̱a̱th la̱t",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Thaŋ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minit",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "/Cä gua̱a̱th mi /ci̱ thuɔ̱k",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Gɛ̈ɛ̈l kɛ duɔ̱ɔ̱p mi̱ ca lat",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Gɛ̈ɛ̈l kɛ gua̱a̱th mi̱ ci̱ cop",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ca jɛ gɔ̱r",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ɣɔ̱ɔ̱n yio̱w",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Nyothni̱ tin ca gɔ̱r",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Kä mi̱th mi̱th",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Kä mi̱ ci̱ rɔ̱ yiath",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ŋi̱i̱c",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Lätdɛ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kuic",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Kä gua̱a̱th in te thi̱n",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Kä cua ŋar",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ji̱i̱ kɛ ɣöö ba tok",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ji̱i̱ kɛ guutdɛ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Jiɛc rɔ nhial",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Jiɛc rɔ piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Wut kä caam",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Läthɛ kä kui̱c cuëëc",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Mi̱ ca lɛy",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Rɛy",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Rɛy jɔk",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kä cuɛɛ jɛ ben piny",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kä cuɛɛ jiɛɛn",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kä luäk",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kɛnɛ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ji̱i̱ni̱",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kä guutdɛ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Rɛy raar",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Kä",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ɛn cieŋ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kuëŋ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kä cu kuäär",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ti̱e̱e̱e̱e̱",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad da̱a̱k",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad ɛ päär",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren cuɛ wä",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ɛ cuɔ̱ŋ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kä gua̱a̱th in ci̱ rɔ̱ lɛy",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kä gua̱a̱th in te nhial",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kä buɔ̱m",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kä /kenɛ buɔ̱m ben",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Thɛ̈ɛ̈k",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Rɔl Look",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Yi̱i̱c",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Rɛy gua̱th",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Rɛy gua̱th",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ny.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ny.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Tsegulani menyu yoyendetsera",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kumbuyo",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Chotsani",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pafupi",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Chotsani",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Zambiri",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mwezi wamawa",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mwezi watha",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Tsamba lotsatira",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Tsamba lapitalo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tsamba loyamba",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Tsamba lomaliza",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Onetsani menyu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Zolemba",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pepala lapansi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ziphaso",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mizere pa tsamba:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kuletsa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pafupi",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Pitirizani",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Koperani",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Dulani",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan lemba",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Yang'anani m'mwamba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fufuzani pa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Gawani",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "CHABWINO",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Phala",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani zonse",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Onani ziphaso",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sankhani maola",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sankhani mphindi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Chotsani",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Chotsani menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd / mm / yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Sankhani chaka",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tsiku losadziwika",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Mndandanda wa tsiku losatchulidwa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Lowani Tsiku",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tsiku Loyambira",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tsiku Lomaliza",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Mtundu wa deti wosagwira ntchito",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Mndandanda wa deti wosagwira ntchito",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tsiku kunja kwa osiyanasiyana",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sungani",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sankhani tsiku",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SANKHANI OSIYANASIYANA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Sinthani ku njira ya kalendala",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Sinthani ku njira yolowetsa tsiku",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Sankhani nthawi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Lowani nthawi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ola",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Mphindi",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nthawi yosagwira ntchito",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Sinthani ku njira yoyimbira",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Sinthani ku njira yolowetsa nthawi",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Adalembedwa",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Bisani maakaunti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Onetsani maakaunti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menyu yoyenda",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menyu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menyu ya Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kuyankhulana",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tcheru",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Fufuzani",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tsiku lamakono",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tsiku losankhidwa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Pitani kuti muyambe",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pitani kumapeto",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pitani m'mwamba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pitani pansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pitani kumanzere",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yendetsani kumanja",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Tsitsimutsani",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Chithunzi cha Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Malo obwerera m'mbuyo",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Malemba Akuluakulu",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Njira Pansi",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Njira Pamwamba",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kulamulira",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Chotsani",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kutulutsa",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kutha",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kuthawa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kunyumba",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Lowetsani",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Lamulo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mawindo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Loko ya Num",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Onjezani",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kugawanika kwa Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Lowani",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Yofanana",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Kuchulukitsa Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kumanzere",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kumanja",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Chotsani",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Tsamba Pansi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Tsamba Pamwamba",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mphamvu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuzimitsa Mphamvu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Sindikizani Chophimba",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Loko Mpukutu",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Sankhani",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kusintha",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Malo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_oci.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_oci.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menú de navigacion dobèrta",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Tornar",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clar",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Près",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Eliminar",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mai d'un còp",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Lo mes venent",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mes precedent",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Primièra pagina",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pagina precedenta",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Primièra pagina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Última pagina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Montar lo menú",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Escrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Foguèt",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licéncias",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Las linhas per pagina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancellar",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Près",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Seguir",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cortada",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tèxt de scanacion",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Vòli sus",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Recercar sul web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartilhar",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Òc !",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar totes",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizacion de las licéncias",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primièr ministre",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleccion de las oras",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleccionar las minutas",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dissar",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú de descart",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seleccion de l'annada",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data non especificada",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "D'intervals de data non especificats",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Date de dintrar",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data de començament",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data de fin",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data de començament $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data de fin $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format de data invalida",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Interval de data invalida",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fòra de la gama",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvar",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Seleccion de data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTAR la ràdio",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Passar al mòde calendièr",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passar al mòde data d'entrada",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleccion de l' ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Entre l' ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minut",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Temps invalid",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Passar al mòde de dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Passar al mòde de temps d'entrada",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signat",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Conti occult",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Montar de comptes",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu de navigacion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barre de menú",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menú en popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialòg",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Avís",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Recerca",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data actuala",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data seleccionada",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mòstra per començar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Passa fins a la fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "S'avança",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "S'avança cap a l'èst",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Virar a esquèrra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mòstra-te a drecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refrescar",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafic alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Espaci de darrièr",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canal en bas",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canal sus",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Contraròtle",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Eliminar",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ejeccion",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fin",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Escapa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Domèni",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insèrta",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comandacion",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Fenèstras",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Addon",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Comma de Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Divission de Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Egal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad multiplica",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren a esquèrra",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren drech",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtraccion de Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pagina de bas",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina sus",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Poténcia",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Desligat",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Imprimir l' Ecrana",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Lo blocatge de rolar",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seleccionar",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Esquèma",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espaci",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_om.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_om.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Back",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear text",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "More",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ji'a itti aanu",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ji'a darbe",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Previous page",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "First page",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Last page",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom Sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenses",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancel",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continue",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Barruu sakatta'i",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Look Up",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select all",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sa'aatii filadhu",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Select minutes",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dismiss",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "mm/dd/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Date",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Date Range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enter Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Start Date",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "End Date",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid format.",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid range.",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Out of range.",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Save",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Select date",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Select range",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Switch to calendar",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Select time",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Enter time",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Sa'aatii",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Enter a valid time",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Switch to dial picker mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Switch to text input mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signed in",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Show accounts",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Sajoo naanna'aa",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Sajoo ka'aa",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Search",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Today",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Selected",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Jalqabatti socho'i",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gara xumuraatti socho'i",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ol socho'i",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gadii socho'i",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Bitaatti socho'i",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mirgatti socho'i",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "AltGr",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "To'annoo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Del",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "End",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Esc",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Command",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Win",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Num 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Num 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Num 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Num 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Num 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Num 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Num 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Num 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Num 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Num 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Num +",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Num ,",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Num .",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Num /",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Num Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Num =",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Lakkoofsaan Baay'isi",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Num (",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Num )",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Lakkoofsa Hir'isuu",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "PgDown",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "PgUp",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Power",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Select",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Space",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_otq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_otq.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Abrir menú navegación",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Atrás",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Majwäni",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Cerrar",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Borrar",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mäs",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ar zänä Xtí",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ar zänä 'be̲t'o",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Página da ku̲hu̲",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Página 'be̲t'o",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Ndui ar página",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ngäts'i ar página",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostrar menú",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Sábana bajera",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencias",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ar filas ya página:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancelar",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Cerrar",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Da 'ño",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tu̲ki",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Escanear texto",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Honi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Honi ar web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "T'uni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ar nkohi",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pegar",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar ga̲tho",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ga licencias",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "BÍ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleccionar horario",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleccionar ya t'olo ora",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Despedir",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú Descartar",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd yá mm yá aaaa",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seleccionar ya je̲ya",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Pa hingi especificada",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Intervalo ar pa hingi especificado",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Introduzca ar pa",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Pa inicio",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Pa final",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formato ar pa hingi válido",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Intervalo ar pa hingi válido",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Pa da rango",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvar",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Seleccionar pa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECCIONAR RANGO",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Mpa̲ti modo nthuxu̲pa",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Mpa̲ti modo pa entrada",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleccionar ar ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Introducir ar ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "T'olo ora",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Pa hingi válido",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Mpa̲ti ar modo marcación",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Mpa̲ti modo pa entrada",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Iniciado sesión",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ocultar cuentas",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostrar cuentas",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menú navegación",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barra xí menú",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menú emergente",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diálogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ar nja̲pu̲",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Honi",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ar pa nu'bya",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Pa seleccionada",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mover pa 'bu̲i",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mover asta ar ngäts'i",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Desplazar nu'bu mañä",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Desplazar nu'bu abajo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mover ga ma jar izquierda",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mover ga ma jar derecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Actualizar",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Gráfico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Retroceso",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Block mayús",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canalización nu'bu abajo",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canalizar nu'bu mañä",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Borrar",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Expulsar",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ngäts'i",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Escapar",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Hogar",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insertar",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Mandar",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Bloqueo numérico",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "(Teclado numérico) 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "(Teclado numérico) 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "(Teclado numérico) 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "(Teclado numérico) 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "(Teclado numérico) 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "(Teclado numérico) 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "(Teclado numérico) 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "(Teclado numérico) 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "(Teclado numérico) 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "(Teclado numérico) 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "(Teclado numérico) Agregar",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "(Teclado numérico) Coma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "(Teclado numérico) 'ret'a",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "(Teclado numérico) gi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "(Teclado numérico) Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "(Teclado numérico) ngu",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "(Teclado numérico) Multiplicar",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "(Teclado numérico) Paren Izquierda",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "(Teclado numérico) Paren nga̲thohu̲",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "(Teclado numérico) Restar",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Av Pág",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Ndi Pág",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Nda pwede nda",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Jwiki",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Imprimir pantalla",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Bloqueo desplazamiento",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Jwahni",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Turno",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espacio",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_pag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pag.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Buksan navigasyon menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ompawil",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Malinew",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Asingger",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "I-delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mas",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Diad ontumbok ya bulan",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Nen imbeneg ya bulan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Ontumbok a pahina",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Ononan pahina",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Unonan pahina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Say unor a pahina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ipanengneng so menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Sikat",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Say walad silong",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Saray License",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Saray linya ed kada pahina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "I-cancel",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Asingger",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ituloy",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Apatalos",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pangitok",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sikanen so teksto",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Manengneng ka ed tagey",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Man-search ed web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Manpabiskegen",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Okay",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Manpili na amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "I-view iray lisensya",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Manpili na oras",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Manpili na minuton",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ibatik",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "I-dismiss so menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select Year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Agnipatnag ya petsa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Agnipatnag ya intervalo na petsa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "I-enter so Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Dati na Pangigapo",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Anggaan",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Man-start ya petsa $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Say Sampot ya petsa $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid date range",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "No Agew",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "I-save",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Manpili na petsa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PANIPILIEN NA KANSION",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Umalis ed mode na kalendaryo",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Umalis ed mode na petsa na impangawat",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Manpili na oras",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ipasen so oras",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Sakey oras",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ag-uusar ya oras",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Umalis ed mode na dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Umalis ed mode na input time",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sinali",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "I-secret accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ipanengneng iray akonta",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu na navigasyon",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogue",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Mananap",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Natan ya petsa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Say petsa ya inpili",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Manpaway",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Manpaarap ya anggad samput",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Onalis ka",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Onsi ka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Onalis ed nikawan",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Onliing ed nikawanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Pangipapaseseg",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Saray arum",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Say back space",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Man-Canale Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Manpa-Canale ed Atagey",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "I-delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "I-eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Say Anggaan",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Panapanawan",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Say abung",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ipasak",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Saray bintana",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Say Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Say Numpad a Panlalaban",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Links",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Say Pan-pa-Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Say Pampulong",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Pankakasakey",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ag-ipapainawa so Pankikimey",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Imprint Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Sulaten so Sikat",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Manpili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Say Panagpawil",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Say Espiritun",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_pap.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pap.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu di navegacion habri",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Na Kòrsou",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clare",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Propiedad",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Eliminá",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mas",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "E luna proximo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "luna anterior",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Siguiente página",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Página anterior",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Página 1",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Último página",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "E ta scurpa",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "E plaka di fondo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencianan",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Reda pa página:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Propiedad",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Sigui",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ta ta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scaneá texto",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Wak ariba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Busca riba web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiendo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Bon bon",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccioná tur",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Vea Licencianan",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleccion di oranan",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleccioná minutanan",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Descarga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dispensa menú",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seleccion di aña",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data no spesifiká",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Diario di fecha no spesifiká",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Entrega di Data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data di kuminsamentu",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data di fin",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data di kuminsamentu $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data final $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format di fecha invalido",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "E intervalo di fecha invalido",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data for di rango",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salba",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Seleccioná data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTAN di e rango",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pasá na modalidad di calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pasá na Modo Data di entrada",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleccion di ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Entre ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tempo invalido",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pasá na modo di dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pasá na e modo di tempo di entrada",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Firma",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide kontonan",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "mustra cuenta",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu di navegacion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu Bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Busca",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data di e fecha actual",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data Seleccioná",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Move pa kuminsá",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pasá pa fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pasá ariba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bai bai",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move na man robes",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Move drechi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresha",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Espacio trasero",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "E canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di e canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di canal di",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canaliá ariba",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Control",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Eliminá",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fin di e",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Escape",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ventrículo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Dividi Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Evaluacion di Numpad",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Multiplicacion Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Boso",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Derecho",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtracto Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Página Bai",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Página ariba",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Potensia",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "E Potensia a Deskonektá",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Impresion De pantalla",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Seleccioná",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Tur tur",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Espacio",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_pbt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pbt.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "د نیویګیشن مینو خلاص کړئ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "بیرته راګرځیدل",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "په روښانه ډول",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "نږدې",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "له منځه وړل",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "نورې خبرې",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "راتلونکی میاشت",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "د تېرې میاشتې",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "راتلونکې پاڼه",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "مخکینی پاڼه",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "لومړۍ پاڼه",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "وروستۍ پاڼه",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "د مینو ښودنه",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "د ګلونو د څښلو",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "د لاندې پاڼه",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "د جوازونو",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "د هرې پاڼې لپاره کرښې:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "د تادیې لغوه کول",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "نږدې",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "دوام ورکړئ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "د دې د ثبت کولو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "د ټوټې کولو لپاره",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "د متن سکین کول",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "پورته وګورئ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "په ویب کې لټون وکړئ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "د شریکولو لپاره",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ښه ده",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "د پټو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ټولې ټاکل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "د جوازونو لیدل",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "د پښتو",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "د لومړي وزیر",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "د وخت ټاکل",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "د دقیقې ټاکل",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "د ګوښه کولو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "د ډیسک مینو له منځه وړل",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "د ډي ډي / ملي متره / د",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "د انتخاب شوي کال",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "د نیټې نه مشخصه نیټه",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "د نیټې نښه نه شوې",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "د ننوتلو نېټه",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "د پیل نیټه",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "د پای نیټه",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "د پیل نیټه $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "د پای نیټه $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "د نیټې غیر معتبر بڼه",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "د نیټې د اعتبار وړ نړیواله",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "د نیټې له حد څخه بهر",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "د خوندي کولو لپاره",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "د نیټې ټاکنه",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "د انتخاباتو لړۍ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "د تقویم حالت ته لاړ شئ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "د ننوتلو نیټې حالت ته واړوي",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "د وخت ټاکل",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "د وخت د ننوتلو وخت",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "د ساعت په اړه",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقيقه",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "د وخت د اعتبار وړ نه دی",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "د ټاکلو حالت ته واړوي",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "د ننوتلو وخت حالت ته واړوي",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "لاسلیک شوی",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "د حسابونو پټول",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "د حسابونو ښودنه",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "د نیویګیشن مینو",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "د مینو بار",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "د پاپ اپ مینو",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "د خبرو اترو خبرې",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "د خبرداری",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "د لټون لپاره",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "د اوسني نیټې",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ټاکل شوې نېټه",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "د پیل لپاره حرکت وکړئ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "د پای ته رسیدو لپاره حرکت وکړئ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "پورته لاړ شئ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "لاندې حرکت وکړئ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "چپ ته لاړ شئ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "په ښي خوا حرکت وکړئ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "تازه کول",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "د نورو",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "د الټ ګراف",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "د شا ځای",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "د کڅوړې بند",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "د ښکته کیدو لړۍ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "پورته پورته کول",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "د کنترول",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "له منځه وړل",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "د تګ لپاره",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "د پای",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "د وتلو لپاره",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "د فاېن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "کور کې",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "د داخلولو لپاره",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "د میټا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "د قوماندانۍ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "د کړکۍ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "د شمېرنې قفل",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "د نيمپاد 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "د نپډ 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "د نيمپاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "د څلورمه څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څلورمې څل",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "د نيمې څلورمه",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "د شپږم پښتو",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "د نيمپاد ۷",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "د نيمپاد ۸",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "د نيمې ډلې",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "د نيمپډ 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "د نپډ اضافه کول",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "د نپډ کمې",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "د نيمه لسمه",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "د نپاد تقسیم",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "د نپډ داخل",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "د نپډ برابر",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "د نپډ ضرب",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نمپاد پارن چپ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "د نپاد پارن حق",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "د نپډ کمول",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "د پاڼې ښکته کول",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "مخ پورته کړئ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "د ځواک",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "د بریښنا بندول",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "د چاپ کولو سکرین",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "د سکرول لاک",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "د انتخاب لپاره",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "د ګمرک په اړه",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "فضا",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_pes.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_pes.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "مینیو ناوبری باز",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "برگرد",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "روشن",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "نزدیک",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "بیشتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ماه بعد",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ماه گذشته",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "صفحه بعدی",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحه قبلی",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "صفحه اول",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "آخرين صفحه",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "منو نمایش",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "کلاهک",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورق پایین",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "مجوز",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "خط ها در هر صفحه:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "لغو کردن",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "نزدیک",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ادامه بده",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "کپی شده",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "قطع",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "متن اسکن",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "نگاه کن بالا",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "در اینترنت جستجو کنید",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "باشه",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "همه را انتخاب کنید",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "مجوزهای مشاهده",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "نخست وزیر",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ساعت های انتخاب شده",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "دقیقه ها را انتخاب کنید",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "اخراج",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "منو رد کردن",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سال انتخاب شده",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاریخ مشخص نشده",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "محدوده تاریخ مشخص نشده",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "تاریخ وارد کردن",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاریخ شروع",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاریخ پایان",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "تاریخ شروع $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "تاریخ پایان $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "قالب تاریخ غیرفعال",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "محدوده تاریخ غیرفعال",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاریخ خارج از محدوده",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "نگهدار",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "تاریخ انتخاب کنید",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "دسته بندی انتخاب",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "به حالت تقویم برویم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "به حالت تاریخ ورودی تغییر دهید",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "زمان انتخاب کنید",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "زمان وارد کردن",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعت",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقیقه ای",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "زمان غیرفعال",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "به حالت شماره گذاری تغییر دهید",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "به حالت زمان ورودی تغییر دهید",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "امضا شد",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "حساب ها را پنهان کنید",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "حساب ها را نشان دهید",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "مینیو ناوبری",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "بار منو",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "مینیو پاپاپ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "دیالوگ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "هشدار",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "جستجو",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاریخ فعلی",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "تاریخ انتخاب شده",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "حرکت کن تا شروع کنم",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرکت تا آخر",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "برو بالا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "پایین برو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "به چپ حرکت کن",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "به سمت راست حرکت کن",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "تازه کردن",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "متغیر",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "نمودار آلتی",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "فضای پشت",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "قفل کلاه",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "کانال پایین",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "کانال بالا",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کنترل",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "اخراج",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "پایان",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "فرار",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "خانه",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "وارد کردن",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "متا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "فرماندهی",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "پنجره ها",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "نُمپاد 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "نُمپاد 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "نمپاد 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "نمپاد 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "نُمپاد 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad اضافه کردن",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "کمای نمپاد",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "نمپاد دسمای",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسیم نمپاد",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad وارد",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "نمپاد برابر",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ضربات نمپاد",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "نمپاد پارن چپ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "نامپاد پارن راست",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "تخفیف نمپاد",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحه پایین",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحه بالا",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قدرت",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "برق خاموش شد",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "صفحه چاپ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل رو در اسکرول کنید",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "انتخاب کنید",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "تغییر",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "فضا",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_plt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_plt.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Misokatra ny menio fitetezana",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Niverina",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Mazava",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Manakaiky",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Fandikana",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Mbola betsaka kokoa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Amin'ny volana ho avy",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Volana teo aloha",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Pejy manaraka",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pejy teo aloha",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Pejy voalohany",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Pejy farany",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Asehoy ny sakafo",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Fitaovana",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ny takelaka ambany",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Fanamarinana",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Tsipika isaky ny pejy:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Fanamarinana",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Manakaiky",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tohizo",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Fandikana",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Famoahana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Fandinihana lahatsoratra",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Jereo ny ambony",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Mitadiava ao amin'ny aterineto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Mizara",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Eny, tsara.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Fitaovana",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny rehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Fampisehoana fahazoan-dàlana",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Fomba fiasa",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Fisafidianana ora",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Safidio ny minitra",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Fandosirana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fanamarihana",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Taona voafantina",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Daty tsy voafaritra",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Famaritana tsy voafaritra",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ampidiro ny daty",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Daty fanombohana",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Daty farany",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Daty fanombohana $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Daty farany $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fomba endrika daty tsy mety",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Famaritana tsy manan-kery",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Daty tsy hita",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Vonjeo",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Fisafidianana daty",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "FANKATRAHATRA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Mifanaraka amin'ny fomba kalandrie",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Mifanaraka amin'ny fomba daty fampidirana",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Fidio ny fotoana",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ampidiro ny fotoana",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora iray",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minitra iray",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Fotoana tsy mety",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Mifanaraka amin'ny fomba fanoratana",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Mifanaraka amin'ny fomba fotoana fidirana",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Voasonia",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fitaovana tsy hita",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Asehoy ny kaonty",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Fikarohana",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Sary sakafo",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Fomba fijery",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Firesahana",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Fampitandremana",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Fikarohana",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Daty ankehitriny",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Daty voafantina",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Mihetsika mba hanombohana",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mihetsika hatrany amin'ny farany",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Miakara",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mifindrà midina",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mihetsika mankany ankavia",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mandehana ankavanana",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fanavaozana",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Fomba fiasa",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Fihirana Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Toerana ao ambadika",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Fandidiana ny fonon-doha",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Fantsona ambany",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Fantsona miakatra",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Fanaraha-maso",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Fandikana",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Fandroahana",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Farany",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Mandositra",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Trano",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ampidiro",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Fandoavana",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ny varavarankely",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Fametrahana ny laharana",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Famaritana malagasy",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Famaritana malagasy",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Fampisarahana ny Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Ampidiro ny Numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad mitovy",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Mihabetsaka",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Nambony",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Havanana",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Fampihenana ny Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sary ambany",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Miakatra ny pejy",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Hery",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tsy mandeha ny herinaratra",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Sary fanontam-pirinty",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Fandidiana ny rakitsary",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Fidio",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Fiovana",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Toerana",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_prs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_prs.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "باز کردن منوی ناوگذاری",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "بازگشت",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "پاک کردن",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "بستن",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "بیشتر",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ماه آینده",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ماه قبل",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "صفحه بعدی",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "صفحه قبل",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "صفحه اول",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "آخرین صفحه",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "نمایش فهرست",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "اسکرایم",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ورق پایین",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "مجوز",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ردیف در هر صفحه:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "لغو کردن",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "بستن",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ادامه",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "کپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "برش",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "اسکن متن",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "بالا را نگاه کنید",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "جستجو در وب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "درست است",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "خمیر کردن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "انتخاب همه",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "مشاهده مجوزها",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "ای ام",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "نخست وزیر",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ساعت ها را انتخاب کنید",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "انتخاب دقیقه",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "اخراج",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "فهرست رد",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "انتخاب سال",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "تاریخ نامشخص",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "محدوده تاریخ نامشخص",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "تاریخ را وارد کنید",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاریخ شروع",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "تاریخ پایان",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "قالب تاریخ ناموید",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "محدوده تاریخ ناموید",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "تاریخ خارج از محدوده",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ذخیره",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "تاریخ انتخاب",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "انتخاب محدوده",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "تغییر به حالت تقویم",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "تغییر به حالت تاریخ نهادن",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "انتخاب زمان",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "زمان را وارد کنید",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ساعت",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "دقیقه",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "زمان نامتناه",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "تغییر به حالت دیال",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "تغییر به حالت زمان نهاده",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ثبت نام در",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "پنهان کردن حساب ها",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "نمایش حساب ها",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "منوی ناوگذاری",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "نوار فهرست",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "منوی پاپ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "گفتگو",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "هشدار",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "جستجو",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "تاریخ جاری",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "تاریخ انتخاب شده",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "حرکت برای شروع",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرکت به پایان",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "حرکت به بالا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "حرکت به پایین",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "حرکت به سمت چپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "حرکت به سمت راست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "تازه کردن",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "دگرساز",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "نمودار دگرساز",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "فضای پشتی",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "کلید کپس لاک",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "کانال پایین",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "کانال بالا",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "کنترل",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "تخلیه",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "پایان",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "فرار",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "فن",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "صفحه اصلی",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "درج",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ماتا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "فرمان",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "پنجره ها",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "قفل به نام",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "اضافه کردن Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "کاما",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad دهدهی",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "تقسیم Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad را وارد کنید",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad برابر",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ضرب Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad پارن چپ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad پارن راست",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "زیر مجموعه Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحه پایین",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحه بالا",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "قدرت",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "برق خاموش",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "چاپ صفحه نمایش",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "قفل کردن",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "انتخاب کنید",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "تغییر",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "فضا",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_rn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_rn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Inyuma",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Hafi",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ibindi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mu kwezi gutaha",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ukwezi guheze",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Urupapuro rukurikira",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Urupapuro rwa mbere",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Urupapuro rwa mbere",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Urupapuro rwa nyuma",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Urupapuro rwo hasi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Uruhusha",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Guhagarika",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Hafi",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Bandanya",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Raba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Gusangira",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "VYIZA",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamwo vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Umushikiranganji wa mbere",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hitamwo amasaha",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Hitamwo iminota",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kwirukana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Hitamwo umwaka",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Itariki itaramenyekana",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Itariki itaramenyekana",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Kwinjira kw'itariki",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Itariki yo gutangura",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Itariki y'iherezo",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Itariki y'iherezo $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Imiterere y'itariki idahagije",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Uruzinduko rw'amatariki",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out of range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Kuzigama",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Hitamwo itariki",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Hindura uburyo bwa kalendari",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Hitamwo umwanya",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kwinjira umwanya",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Isaha",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Umunota",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Umwanya udasanzwe",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Guhindura uburyo bwo guhamagara",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Switch to input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Vyatewe umukono",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Show accounts",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ya navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ya popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ibiganiro",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Kugabisha",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Search",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Itariki y'ubu",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Itariki yatowe",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kwimuka gushika ku mpera",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Genda hejuru",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Manuka hasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Genda iburyo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Umwanya w'inyuma",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ahakurirwamwo indome nkuru",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kugenzura",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kwirukana",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Iherezo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Guhunga",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Inzu",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Gushiramwo",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Itegeko",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Amadirisha",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numerpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Ugutandukanya Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Urupapuro rwo hasi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Urupapuro rwo hejuru",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ububasha",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuzimya umuyagankuba",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Hitamwo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Guhindura",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Umwanya",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_rw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_rw.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Inyuma",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ibindi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mu kwezi gutaha",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ukwezi gushize",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Urupapuro rwa mbere",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Urupapuro rwa mbere",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Urupapuro rwa nyuma",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Urupapuro rwo hasi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Uruhushya",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Hagarika",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Gukomeza",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Reba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Shakisha urubuga",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "YEGO",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamo byose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Minisitiri w'Intebe",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Select hours",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Hitamo iminota",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kwirukana",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Hitamo umwaka",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Itariki itaramenyekana",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified date range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Itariki yo kwinjira",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Itariki yo gutangira",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Itariki y'iherezo",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Itariki y'iherezo $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid date range",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out of range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Kuzigama",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Hitamo itariki",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Hindura uburyo bwa kalendari",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Hitamo igihe",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kwinjira igihe",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Isaha",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Umunota",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Invalid time",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Switch to dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Switch to input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signed in",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Show accounts",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ya popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogue",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerte",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Search",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Itariki y'ubu",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Itariki yatoranyijwe",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Manuka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Move right",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapusiloke",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kugenzura",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kwirukana",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "End",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Guhunga",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Inzu",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Command",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Amadirisha",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Imbaraga",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Hitamo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Umwanya",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_sag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sag.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Mungo menu ti navigation",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Lo kiri na peko",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "A yeke polele",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "A yeke nduru",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "A zi ni",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ambeni ye mingi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Na nze ti peko",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Nze so ahon",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nduru tënë ti peko",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "A-article ti peko",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kozo lembeti ni",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ndangba lembeti ni",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Fa menu ni",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "A yeke sara si akeke ni aga nzoni",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "A yeke wara ni na gbe ti da",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "A yeke wara a-licence",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "A yeke wara ni na ndo ti page oko oko:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "A yeke zi ni",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "A yeke nduru",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Ala ngbâ ti sara ni",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "A-Code",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "A fâ ni",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sango ti text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Bâ ndo na nduzu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Gi na ndo ti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kangbi ni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "A yeke nzoni.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "A yeke zia ni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Soro aye kue",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Bâ a-licence",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Kota Ministre",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hinga ambeni ngbonga",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Soro ti tene",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "A bi ala na gigi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Gbu menu ni",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ngu so a soro ni",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Nduru tënë ni pëpe",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "A fa pëpe lango so a sara ni",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Lango ti gingo",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Nduru tënë ti tongo nda ni",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Nduru tënë ti fini",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Nduru tënë ti tongo nda ni $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Nduru tënë ti nda ni $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "A yeke sara tënë ti mbeni ye so ayeke na lege ni ape",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "A yeke sara si lango ni aga senge",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Nduru tënë so ayeke na yâ ti kapa ti fango tënë",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Bata ni",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Soro lango ni",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Gbian na mode ti kalandrie",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Gbian na mode ti lango ti input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Soro ngoi ni",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Lango ti gingo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ngbonga oko",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti oko",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "A yeke sara si ngoi ni aga senge",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Gbian na mode ti téléchargé",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Gbian na mode ti ngoi ti input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "A sû mbeti ni",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "A honde akonto ni",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Fa akonto",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ti navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu ti yâ ti ambeti",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ti azo",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "A yeke sara lisoro na ndo ni",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerte",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Gi ye",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Nduru tënë ti lango ni",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "A soro lango ni",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ti londo na ni",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mo gue juska na nda ni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ga na nduzu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mo gue na gbe ni",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mo gue na mbage ti mbage ti koli",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mo gue na mbage ti koli",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "A yeke sara si zo aga na ngia",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graphe ti a-Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Na peko ti zo",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "A kanga ni na ndo ti kapa",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kangbi ni Kangbi ni",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kangbi ni Kangbi ni",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kete ti fango tënë",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "A zi ni",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "A bi lo na gigi",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ndangba tënë ni",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Mbi kpe",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Da ti ala",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Mû ni",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Météo",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "A yeke commandement ti ala",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "A-fenêtre",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kâ ti bâ ndo",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "A kangbi popo ti azo ti Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Na yâ ti article so, mo yeke wara tënë ti mo",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad ayeke oko",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad multiplier",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ayeke na mbage ti mbage ti peko",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ayeke na droit",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad so a zi na ni",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Zia mbeni mbeti na gbe ni",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "A zia mbeti ni na nduzu",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ngangu ti ngangu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "A zi wâ ni",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Lango ti imprimer",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Soro ti kanga ni",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Soro",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Na yâ ti kua ti peko",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Lango",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_san.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_san.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "नेविगेशन मेनूः",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "पुनः",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "स्पष्टम्",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "निकटम्",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "हटाना",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "अधिक",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "अग्रे मासात्",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "पूर्वमासः",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "अग्रे पृष्ठम्",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "पिछला पृष्ठ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "प्रथमपृष्ठम्",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "अन्तिमपृष्ठम्",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "मेनू देखा",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "स्क्रिम",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "अधोः पत्रः",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "अनुज्ञापत्रे",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "प्रतिपृष्ठे पंक्तयः",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "रद्द",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "निकटम्",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "निरन्तरं",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "अनुच्छेदः",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटान",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "पाठ स्कैन",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "अपरं पश्य",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबं सर्च",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करना",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ठीकम् ।",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "पस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सर्वम् निवस",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "अनुज्ञां दर्शय",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "प्रधानमन्त्रिणः",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "समयं निवस",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "अनुसूचीं चयनं",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "निषेधः",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "निषेधमेनु",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "वर्षस्य चयनः",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "न निर्दिष्ट तिथि",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "न निर्दिष्ट तिथि सीमा",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "प्रविष्ट तिथि",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "आरम्भ तिथि",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "समाप्ति तिथि",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "आरम्भ तिथि $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "समाप्ति तिथि $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "अवैध तिथि प्रारूप",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "अवैध तिथि दायरा",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "तिथिः सीमाः बहिः",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "बचत",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "दिनांक चयन",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "चुनें श्रेणी",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "कैलेंडर मोडम् स्विच",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "प्रविष्ट्यादिना मोडम् स्विच",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "समय चयन",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "प्रविष्टं समयम्",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "घन्टा",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "क्षणात्",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "अवैधकालः",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "र्इवम् र्इवम्",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "प्रविष्टे समय मोडम् स्विच",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "हस्ताक्षरित",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "खाता छिपाएँ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "खाता दिखाएं",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "नेविगेशन मेनू",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "मेनू पटिका",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "पप अप मेनू",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "संवादः",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "सतर्कता",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "खोज",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "वर्तमान तिथि",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "चयनित तिथि",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "आरम्भार्थं गच्छति",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अन्ते गच्छन्ती",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उपरि गच्छ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचां गच्छ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "वामम् गच्छ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिनाम् चल",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "नवनिर्मिती",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "अन्यत्र",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "अल्ट ग्राफ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "पश्चाद्देशः",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "कप्पूल लॉक",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "नीचां चानलम्",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "उपरि च्यानलम्",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "नियंत्रण",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "हटाना",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "निष्कासितः",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "अन्तः",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "पलायनम्",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "गृहं",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "सम्मिलित",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "मेटा",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "आदेशः",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "विन्डो",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "नम्पाड १",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "नम्पाड २",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "नम्पाड ३",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "नम्पाड ४",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "नम्पाड ५",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "नम्पाड ६",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "नम्पाड ७",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "नम्पाड ८",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "नम्पाड ९",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "नम्पाड 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "नम्पाड Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "नम्पाड कम्बा",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "नम्पाड दशमलव",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "नम्पाड विभाजन",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad प्रविष्ट",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "नम्पाड सम",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "नम्पाड गुणनम्",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "नम्पड पारेन वाम",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "नम्पड पारेन राक्षस",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "नम्पाड घटादि",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "पृष्ठम् नीचां",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "पृष्ठम् उपरि",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "शक्ति",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "विद्युतः बन्द",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "प्रिन्टेशन स्क्रीन",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "स्क्रोल लॉक",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "चयनम्",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "शिफ्ट",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "अन्तरिक्षम्",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_scn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_scn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu di navigazzioni apertu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ritornu",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clari",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Cchiù vicinu",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scaricare",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Piu di piu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "U mese prossimu",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mese precedente",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Pàggina chi segue",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pàggina precedente",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prima pàggina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ultima pagina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scruci",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Fabbrica di fondo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenze",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Riggi per pagina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Annullari",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Cchiù vicinu",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "cuntinuà",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copiu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tagghiatu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scansamentu di testu",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Guarda 'n alto",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cercate in u web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Cumpartiri",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Va bè",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezziunate tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizza li licenzi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primu Ministru",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Scelta di orari",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Selezziunate minuti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Disponibili",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu di scaricatu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Selezziunatu annu",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data non specificata",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Intervallu di data non specificatu",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Introduci data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data di cummunicazione",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data di scadenza",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data di cummunicazioni $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data di fine $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formattu di data invalidu",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Intervallu di data invaludi",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fora di raggiu",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salva",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selezziunate a data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTANZA di raggiu",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Cambia a lu modu di calendariu",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Cambia a modalità data di inserimentu",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selezziunà l' ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Inserisci l' ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ora invalida",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Cambia a cuntrollu di dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Cambia a modalità di tempu di input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signatu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Cunti nascosti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostra li cunti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu di navigazzioni",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu di popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialuoghi",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Avvisu",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ricerca",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data attuale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data scegnata",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Muoviti pi cuminciari",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Muoviti finu a fini",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si muoviti supra",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si muove à a bassa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si muova a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si muove à destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ristrutturazioni",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graficu Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spaziu di u fondu",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Cappella di lucchetta",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canali Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canali Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Cuntrollu",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scaricare",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finiri",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fuggìa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "A casa",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Inserisci",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Cumanda",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Frischi",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Add Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Cumma di numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Nummarisimu decimalisimu",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Dividiri",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicate",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Sinistra",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren dritta",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Sustrazzioni di numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pàggina di scansioni",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina Avanti",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Putenza",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Disattivatu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Screnu di stampa",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrucciati a chiusura",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selezziunate",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Cumpagnu",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spaziu",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_sd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sd.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "نيويگيشن مينو کوليو",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "پوئتي",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "صاف ڪريو",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "بند ڪريو",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "حذف ڪريو",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "وڌيڪ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ايندڙ مهيني",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "گذريل مهيني",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "پويون صفحو",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "اڳيون صفحو",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "پهريون صفحو",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "آخري صفحو",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "مينيو ڏيکاريو",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "هيٺين ورق",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "لائسنس",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "هر صفحي جون قطارون:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "منسوخ ڪريو",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "بند ڪريو",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "جاري رکو",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "نقل ڪريو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ڪٽي",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "متن اسڪين ڪريو",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "مٿي ڏسو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ويب ڳوليو",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "حصيداري ڪريو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ٺيڪ آھي",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "پيسٽ ڪريو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "سڀ چونڊيو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "لائسنس ڏسو",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "اي ايم",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "وزيراعظم",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ڪلاڪ چونڊيو",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "منٽ چونڊيو",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "خارج ڪريو",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "مينيو کي رد ڪريو",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "سال چونڊيو",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "اڻ ڄاڻايل تاريخ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "اڻ ڄاڻايل تاريخ جي حد",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "تاريخ داخل ڪريو",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "تاريخ شروع ڪريو",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ختم ٿيڻ جي تاريخ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ناجائز تاريخ جي حد",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "حد کان ٻاهر تاريخ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "محفوظ ڪريو",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "تاريخ چونڊيو",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "رينج چونڊيو",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ڪئلينڊر موڊ تي سوئچ ڪريو",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ان پٽ تاريخ موڊ تي سوئچ ڪريو",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "وقت چونڊيو",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "وقت داخل ڪريو",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ڪلاڪ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "منٽ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ناجائز وقت",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ڊائل موڊ تي سوئچ ڪريو",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ان پٽ ٽائيم موڊ تي سوئچ ڪريو",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "سائن ان ڪيو",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "اڪائونٽ لڪايو",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "اڪائونٽ ڏيکاريو",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "مينيو بار",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "الرٹ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ڳولا ڪريو",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "موجوده تاريخ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "چونڊيل تاريخ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "شروع ڪرڻ لاء منتقل ڪريو",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ختم ڪرڻ لاء منتقل ڪريو",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "مٿي هلي وڃو",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "هيٺ هلي وڃو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "کاٻي پاسي منتقل ڪريو",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ساڄي پاسي هلي وڃو",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "تازو ڪريو",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "پوئتي جاء",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ڪيپس لاڪ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "چينل ڊائون",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "چينل اپ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ڪنٽرول",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "حذف ڪريو",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "آخر",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "فرار ٿي وڃو",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "گھر",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "داخل ڪريو",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ميٽا",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "حڪم",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ونڊوز",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad شامل ڪريو",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "نمپيڊ تبديل ڪريو",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "صفحو هيٺ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "صفحو مٿي",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "طاقت",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "پاور آف",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "پرنٽ اسڪرين",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "اسڪرول لاڪ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "چونڊيو",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "شفٽ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "خلا",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_shn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_shn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ၽိုၼ်လိၵ်ႈ သဵၼ်ႈတၢင်း ဢၼ်ပိုတ်ႇဝႆႉ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ၶိုၼ်းမႃး",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "လဵင်ႉလႅင်း",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ၸမ်ၸမ်",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "သုတ်ႉဢွၵ်ႇ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ပိုၼ်ႉလိူဝ်",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "လိူၼ်ၼႃႈ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "လိူၼ်ပူၼ်ႉမႃး",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ၼႃႈလိၵ်ႈၽၢႆႇလင်",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ၼႃႈလိၵ်ႈၽၢႆႇလင်",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ၼႃႈလိၵ်ႈဢွၼ်တၢင်းသုတ်း",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "ၼႃႈလိၵ်ႈလိုၼ်းသုတ်း",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ၼႄပၼ် Menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "ၶႅပ်းႁၢင်ႈ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ၽႃႈတႂ်ႈ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "လၵ်းမိူင်း",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ထႅမ်းပလဵၵ်ႉၼိုင်ႈၼႃႈလိၵ်ႈ",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ပႅတ်ႈ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ၸမ်ၸမ်",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "သိုပ်ႇၵႂႃႇ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ၶၼ်ဢဝ်",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "သဵၼ်ႈမၢႆလိၵ်ႈ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "တူၺ်းၼိူဝ်",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "လဵပ်ႈႁဵၼ်းၼႂ်းဝႅပ်ႉသၢႆႉ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ၽႄ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "လီလီ။",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "မဵတ်ႉ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "လိူၵ်ႈဢဝ် တင်းမူတ်း",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "တူၺ်းလိုင်စင်",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ၶၢဝ်းယၢမ်းဢၼ်လိူၵ်ႈ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "လိူၵ်ႈဢဝ် မၢႆတွင်း",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "လွင်ႈပႅတ်ႈ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "မႅၼ်ႇယူဝ်ႇယဵမ်ႈ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ပီဢၼ်လိူၵ်ႈဝႆႉ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ဝၼ်းဢၼ်ဢမ်ႇမၵ်းမၼ်ႈ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "မၢႆဝၼ်းဢၼ်ဢမ်ႇမၵ်းမၼ်ႈ",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ထႆႇမၢႆ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ဝၼ်းပိုတ်ႇ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ဝၼ်းလိုဝ်ႈသုတ်း",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "ဝၼ်းပိုတ်ႇ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "ၶေႃႈပိုၼ်ၽၢဝ်ႇ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ပိူင်ထၢၼ်ႈဝၼ်းဢၼ်ဢမ်ႇပၵ်း",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ၶၢဝ်းယၢမ်းဢၼ်ဢမ်ႇပႆႇတဵမ်",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ဝၼ်းဢၼ်ဢမ်ႇမီးတီႈပွင်ႇ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "သိုပ်ႇၶၢႆႉ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "လိူၵ်ႈဢဝ် ဝၼ်း",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "လိူၵ်ႈဢဝ် ၸၼ်ႉၸႄႈတွၼ်ႈ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "လၢႆႈၶဝ်ႈၸူး ပိူင်ၵၢၼ် ၵႅၼ်ႇတႃႇ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "လၢႆႈၶဝ်ႈၸူး လၢႆးသႂ်ႇ ဝၼ်း",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ၶၢဝ်းယၢမ်း လိူၵ်ႈ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ထႅမ်းပလဵၵ်ႉ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ၸူဝ်ႈမူင်း",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "မိၼိတ်ႉ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ၶၢဝ်းယၢမ်းဢၼ်ဢမ်ႇထုၵ်ႇလီႁဵတ်း",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "လၢႆႈၶဝ်ႈၸူး mode dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ၶၢႆႉၸူး ၶၢဝ်းယၢမ်း input mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "လူင်းလၢႆးမိုဝ်း",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "ႁူမ်ႇလူမ်ႈပပ်ႉ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ၼႄလွင်ႈတၢင်းတွၼ်ႈတႃႇ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "မႅၼ်ႇဝီႇၵျီႇ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ၽႃႈလၵ်းၶဝ်ႈၽိုၼ်",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ၽိုၼ်လိၵ်ႈဢၼ်ဢွၵ်ႇမႃး",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "လွင်ႈဢုပ်ႇဢူဝ်း",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "လွင်ႈသတိ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "လဵပ်ႈႁဵၼ်း",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ဝၼ်းမိူဝ်ႈၼႆႉ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ဝၼ်းဢၼ်လိူၵ်ႈဝႆႉ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ၶၢႆႉၵႂႃႇတႄႇ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ၶၢႆႉၵႂႃႇတီႈသုတ်း",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ၶၢႆႉၶိုၼ်ႈ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ၶၢႆႉလူင်းၵႂႃႇ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ၶၢႆႉၵႂႃႇၽၢႆႇသၢႆႉ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ၶၢႆႉၵႂႃႇၽၢႆႇၶႂႃ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "လွင်ႈသႂၢင်းၼမ်ႉ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ၶိူင်ႈၸႂ်ႉတိုဝ်း",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "ၼႃႈၽၢႆႇလင်",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "လွင်ႈၵုမ်းထိင်း",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "သုတ်ႉဢွၵ်ႇ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ထွၼ်ဢွၵ်ႇ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "ၶေႃႈႁတ်းသုတ်း",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "လႅၼ်ႈပၢႆႈ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ႁိူၼ်း",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ထႅမ်သႂ်ႇ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "မီႇတႃႇ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "တပ်ႉသိုၵ်းမၢၼ်ႈ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ၽူင်တူဝ်ႈ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad တွၼ်ႈၵၼ်",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad တူၺ်းၵၼ်",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad မၢႆၼမ်",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ၼႃႈလိၵ်ႈလူင်း",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ၼႃႈလိၵ်ႈၶိုၼ်ႈ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "လွင်ႈဢဵၼ်ႁႅင်း",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ၽႆးၾႃႉပိၵ်ႉ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ၽိုၼ်လိၵ်ႈၽိုၼ်လိၵ်ႈ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "လွၵ်းသဵၼ်ႈမၢႆ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "လိူၵ်ႈဢဝ်",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "လွင်ႈလႅၵ်ႈလၢႆႈ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ဢွင်ႈတီႈ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_sm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sm.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Tatala le lisi autu o le faatautaiga",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Toe foi",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Manino",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Tapuni",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Aveese",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Sili atu",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "O le masina a sau",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Masina talu ai",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Itulau e sosoo ai",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Itulau talu ai",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Itulau muamua",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Itulau mulimuli",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Fa'aali le lisi",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pepa pito i lalo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Laisene",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Laina i le itulau:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Fa'alēāogāina",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Tapuni",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Fa'aauau",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tipi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Vaai i luga",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Su'e i luga o le upega tafa'ilagi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Faasoa atu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ia lelei",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Faapipii",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Filifili uma",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Va'ai laisene",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Filifili itula",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Filifili minute",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Fa'ate'a",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Faalēaogāina le lisi autu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd / mm / yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Filifili le tausaga",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Aso e le'i fa'amaonia",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Aso e le'i fa'amaonia",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Ulufale i le Aso",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Aso amata",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Aso Fa'amutaina",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Aso fa'amutaina $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Faatulagaga o le aso e le o aoga",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "O le faasologa o aso e le aoga",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Aso i fafo atu o le lautele",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sefe",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Filifili le aso",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "FILIFILI LE TELE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Fesuia'i i le tulaga o le kalena",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Fesuia'i i le faiga o le aso e sao ai",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Filifili le taimi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Ulufale i le taimi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Itula",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minute",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Taimi e le aoga",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Sui i le dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Fesuia'i i le auala o le taimi sao",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Saini i totonu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Natia tala",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Faaali tala",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Lisi o le faatautaiga",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Pa lisi",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Talanoaga",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Mataala",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Saili",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Aso o lo'o i ai nei",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Aso filifilia",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Siitia e amata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Siitia i le faaiuga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Siitia i luga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Alu i lalo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Siitia i le agavale",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Alu i le taumatau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fa'afouina",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Kalafi",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Avanoa i tua",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Mātā'itusi lāpopo'a",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Auala i lalo",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Pulea",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Aveese",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Fa'ate'a",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fa'ai'uga",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Sola ese",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Aiga",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Fa'aopopo",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Poloaiga",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Faamalama",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Loka Numera",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Fa'aopopo le Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Vaeluaina o le Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad ulufale",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Tutusa",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Fa'ateleina le Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Tauagavale",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Taumatau",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Toesea",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Itulau i lalo",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Itulau i luga",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mana",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tape le Mana",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Lolomi le Lau",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Loka ta'ai",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Filifili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Sifi",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Avanoa",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_sn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_sn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Vhura navigation menyu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kumashure",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Pedyo",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Zvimwe",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mwedzi unouya",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mwedzi wapfuura",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Peji Rinotevera",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Peji rapfuura",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Peji rekutanga",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Peji rekupedzisira",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pazasi pepa",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Marezinesi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mitsara papeji:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kanzura",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Pedyo",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Enderera mberi",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cheka",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan chinyorwa",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tarisa kumusoro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Tsvaga iyo webhu",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Goverana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "HORAITI",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sarudza zvese",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Ona marezinesi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sarudza maawa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sarudza maminetsi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kudzinga",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dzinga menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd / mm / yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Sarudza gore",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Zuva risingazivikanwe",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified date range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Pinda Zuva",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Zuva rekutanga",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Zuva rekupera",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Chimiro chezuva chisina kukodzera",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Nzvimbo yezuva isina kukodzera",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date out of range",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Chengetedza",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sarudza zuva",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SARUDZA RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Chinja kune karenda modhi",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Chinja kune yekuisa zuva modhi",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Sarudza nguva",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Pinda nguva",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Awa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nguva isina kukodzera",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Chinja kune dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Chinja kune yekuisa nguva modhi",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Yakasainwa",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ratidza maakaundi",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menyu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menyu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menyu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Yambiro",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kutsvaga",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Zuva razvino",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Zuva rakasarudzwa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Dzvanya pano kuti utange",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Famba kusvika kumagumo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Enda kumusoro",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Enda pasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Famba kuruboshwe",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Famba kurudyi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Zorodza",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt girafu",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Mabhii makuru",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kudzora",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kupera",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kutiza",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Musha",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Kuraira",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mahwindo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Wedzera",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Pinda",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Yakaenzana",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad kuwanda",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kuruboshwe",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kurudyi",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Peji Pasi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Peji kumusoro",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Simba",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Simba Kudzima",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Dhinda Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Sarudza",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kuchinja",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Nzvimbo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_so.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_so.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigation Open",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Hore",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kuuma",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Inbadan",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Bisha soo socota",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Bisha hore",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sida xigta",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Sidan hore",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "First sida",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Last sida",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Muuji menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Sheet hoose",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenses",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per sida:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Jooji",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kuuma",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Sii wad",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Nuqul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Qoraalka Baaritaanka",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kor u eeg",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Raadi shabakadda internetka",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "HAYE",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Dalbo dhamaantood",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Eeg shatiga",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "saacadood Select",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Dooro daqiiqado",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Eryid",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Eryidda menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "mm / mm / yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "sanadka Select",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Taariikhda aan la cayimin",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Taariikhda aan la cayimin",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Taariikhda gala",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Taariikhda Bilowga",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "End Date",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Qaabka taariikhda aan saxnayn",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Taariikhda aan saxneyn",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Taariikhda oo ka baxsan firirka",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Xaree",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Dooro taariikh",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "DOORO RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ku biir si aad u hesho mode calendar",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ku biir si aad u hab taariikhda aqbasho",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "waqti Dooro",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "waqti Enter",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Saacadda",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Daqiiqo",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Waqti aan firqada ahayn",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Switch si aad u dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ku biir si aad u hesho hab waqti",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Saxiixay in",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Qari accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Tusi konton",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Liisamarka navigation",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Liisamarka Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Wada hadal",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Haku",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Taariikhda hadda la joogo",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Taariikhda la xushay",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "U dhaqaaq si aad u bilowdo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Dhaqaaq si jooji",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hore u dhaqaaq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hoos u dhaqaaq",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "U dhaqaaqo bidix",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Midig u dhaqaaq",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "cusboonaysiya",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Xaraf waaweyn",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Hore Channel",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Xakamaynta",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Dhammaad",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "baxso",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Haku",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "waaxda",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Naar 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Kaftani 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Kaftani 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Meelad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Anaalkuulid 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Anaalkuulid 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Anaalkuulid 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "8. QEEBE",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Anaalkuulid 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Anaalkuulid 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Dar Dar",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad kala qaybi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Abdisalan Khadar",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad kaar",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Power",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ku qorniin Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Dalbo",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Space",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_srd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_srd.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menù de navigatzione abertu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Torra a su tempus",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Curu chi",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Prus a unu",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Iscarrigare",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "In prus",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Su mese chi benit",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mes' anteriore",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sa pàgina a sighire",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pàgina pretzedente",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prima pàgina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "S'ùrtima pàgina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra su menù",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Iscarrigadu",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Is pàginas de suta",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licèntzias",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rùe pro pàgina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Annullare",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Prus a unu",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continua a fàghere",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copia de su nùmeru",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tagliu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scànnere su testu",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Iscuras su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Proare in sa web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartire",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "In su matessi momentu.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select all",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizare sas licenzias",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Am",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primu ministru",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "S'ora de su cursu",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Selezionare minutos",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Iscarrigare",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Discludere su menù",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "S'annu ispetzidu",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data non ispetzificada",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Cuntzessu de data non ispetzificadu",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Intrare sa data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data de cumintzu",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data de sa fine",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data de cumintzu $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data de fine $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format de data inàbile",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Cuntzessu de data inàbile",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fora de su ragadu",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvu su",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selezionare sa data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT su raghe",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Passare a su mòdulu de calendàriu",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Passare a sa modalidade data de input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selezionare s'ora",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Inserire s' ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora de sa die",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Unu minutu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tempos inàbiles",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Passare a su mòdulu de dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Passare a su mòdulu de tempus de input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Firmadu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Iscobertziare contos",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostra contos",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu de navigatzione",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu in sa pàgina",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diàlogu",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alerta",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Pro chircare",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data atuale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data ispetzificada",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Movimentu pro cumintzare",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mùvidu a sa fine",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si movet a su prus",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si movet a sa terra",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si movi a manca",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si movet a sa manu dritta",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Righentu",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graficu alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "S'ispàtziu de s'arretru",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canale a su bassu",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canali in su",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Controllu",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Iscarrigare",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ejectadu",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finidu",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fughire",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Sa domo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Inserire",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta fit",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comandu de su Comandu",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Finestras",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Comma de su nùmpadu",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicate",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren a sa manca",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren a sa die de oe",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "S'iscarbu de su nùmeru",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pàgina a sa fine",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pàgina A subra",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Potèntzia",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Iscurriadu su podere",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Impressore de iscritu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrollu de sa serratura",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selezionare",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "S'isvilupu",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "S'ispàtziu",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ss.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ss.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Vula imenyu yekuhamba",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Buyela emuva",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Kucacile",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kucedza",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Cima",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Lokunyenti",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ngenyanga letawufika",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Inyanga leyengcile",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Likhasi lelilandzelako",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Likhasi lelidzala",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Ekhasini lekucala",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Likhasi lekugcina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Bonisa imenyu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Sikhumba",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Likhasi lelisetulu",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Emalungelo eluntfu",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Imigca ngekukhombisa likhasi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kuyekela",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kucedza",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Chubeka",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Ikhophi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kugawulwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skena umbhalo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Buka etulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sesha ku-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Kulungile",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Umutsi",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetsa tonkhe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kubuka emalungelo",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "I-AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "INkhosikati",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kukhetsa emahora",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Khetsa imizuzu",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kuyekela",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Khetsa imenyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Umnyaka lokhetsiwe",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Lusuku lolungachazwanga",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Umkhawulo wesikhatsi longakachazeki",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Faka Lusuku",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Lusuku Lekucala",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Lusuku lwekuphela",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Lusuku lwekucala formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Sikhatsi sekuphela $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Likhodi lelingasebenti",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Umkhawulo wesikhatsi longasebenti",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Sikhatsi lesingaphasi kwemkhawulo",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Gcina",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Khetsa lusuku",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "KUKHETSA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Shintsani kumodi yekhalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Shintsani kumodi yemhla wekungenisa",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Khetsa sikhatsi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Faka sikhatsi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Lihora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Umzuzu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Sikhatsi lesingasebenti",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Shintsani kumodi yekubhala",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Shintsani kusimo sesikhatsi sekungena",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Sikhishiwe",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kufihla ema-akhawunti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Bonisa ema-akhawunti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Imenyu yekuhamba",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Ibhodi yemenyu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Imenyu levelako",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Umhlangano",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Sicwayiso",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kufuna",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Lusuku lolusebenta",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Lusuku lolukhetsiwe",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Hamba ucale",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Hamba uye ekugcineni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hamba uye ngetulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hamba uye phansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hamba uye ngesancele",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hamba ngesekudla",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kuvuselela",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Umsebenti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafu ye-Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Indzawo yangemuva",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Khiya Lwekuphakamisa",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Umzila Wekucala",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Umzila Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kucondziswa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Cima",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kucedza",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kuphela",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kuphunyuka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ekhaya",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Faka",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Umyalo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Emafasitelo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kuhlukaniswa kweNumpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Ngasemkhatsini",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ngekudla",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Hlola Ekhasini Leliphansi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Hlola Likhasi",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Emandla",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuphuma Emandla",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tincwadzi Letitfolakala Ku-Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Sungula Kuvala",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Khetsa",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kusebenta",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Indzawo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_st.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_st.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Bula menu ea ho sesa",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ka morao",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Hlakile",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Hlakola",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ho feta",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Khoeling e tlang",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Khoeling e fetileng",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Leqephe le latelang",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Leqephe le fetileng",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Leqephe la pele",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Leqephe la ho qetela",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lakane e ka tlase",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Laesense",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mela ka leqephe:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Hlakola",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tsoela pele",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kopitsa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Khaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan mongolo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Sheba holimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Arolelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ho lokile",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Ho beha",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha tsohle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Sheba laesense",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Lihora tse khethiloeng",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Khetha metsotso",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ho leleka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Leleka menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "DD / MM / YYYY",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Khetha selemo",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Letsatsi le sa tsejoeng",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Letsatsi le sa tsejoeng",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Letsatsi la ho kenya",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Letsatsi la ho qala",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Letsatsi la ho qetela",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Sebopeho sa letsatsi se sa sebetseng",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Letsatsi le sa sebetseng",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Letsatsi le kantle ho sebaka",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Boloka",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Khetha letsatsi",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "KHETHA RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Fetohela ho mokhoa oa khalendara",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Fetohela ho mokhoa oa letsatsi la ho kenya",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Khetha nako",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Kena nako",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Hora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Motsotso",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nako e sa sebetseng",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Fetohela ho Dial Mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Fetohela ho Input Time Mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "E saennoe",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Pata liakhaonto",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Bontša litlaleho",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu ea ho tsamaea",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu ea popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Puisano",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tlhokomeliso",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ho batla",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Letsatsi la hajoale",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Letsatsi le khethiloeng",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Fallela ho qala",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Fallela ho fihlela qetellong",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nyolohela holimo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Fallela tlase",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Fallela ka ho le letšehali",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tsamaea ka ho le letona",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Khatholla",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Sebaka sa ka morao",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ditlhaku tse kgolo",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Taolo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Hlakola",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Qetello",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ho baleha",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Ho Ho Ho",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Lehae",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kenyelletso",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Taelo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Lifensetere",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Palo ea 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Nomoro ea 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Palo ea 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Palo ea 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad eketsa",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Karohano ea Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad e lekanang",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad e atisa",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ka ho le letšehali",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Leqephe le ka tlase",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Leqephe le holimo",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Matla",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tima matla",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Printa Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Roll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Khetha",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Phetoho",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Sebaka",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_su.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_su.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigasi kabuka",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Balik deui",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Jelas",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Nyimpulkeun",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Hapuskeun",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Leuwih",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Bulan hareup",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Bulan saméméhna",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Kaca salajengna",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Kaca saméméhna",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kaca kahiji",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kaca panungtungan",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Témbongkeun menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ngaduruk",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lambaran handap",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisénsi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Baris per kaca:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ngabatalkeun",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Nyimpulkeun",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Teruskeun",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Sampel",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Téks scan",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Tingali nepi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Milarian dina wéb",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bagikeun",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Oke nu",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih sadaya",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Témbongkeun lisénsi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pilih jam",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pilih menit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ngaleungitkeun",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu pikeun nyingkahan",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Taun nu dipilih",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tanggal nu teu dicatet",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jarak tanggal anu teu ditangtukeun",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Lebetkeun Tanggal",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tanggal Dimimitian",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tanggal tungtung",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tanggal mimiti $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Tanggal tungtung $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format tanggal anu teu sah",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Jarak tanggal anu teu sah",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tanggal kaluar kisaran",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Nyimpen",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pilih tanggal",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PILIH rentang",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pindahkeun ka modeu kalénder",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pindahkeun ka mode tanggal input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pilih waktu",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Lebetkeun waktos",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Jam",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Menit nu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Waktu anu teu sah",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pindahkeun ka modeu dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pindah ka mode waktu input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ditandatanganan",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Nyumputkeun akun",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Témbongkeun akun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigasi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Perhatosan",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Milarian",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tanggal ayeuna",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tanggal nu dipilih",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Pindah pikeun ngamimitian",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindah ka tungtung",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah nepi",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pindah ka handap",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah ka kénca",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindahkeun katuhu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ngabébaskeun",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafik Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ruang tukang",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Saluran handap",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Saluran Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Hapuskeun",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Tungtungna",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ngahindarkeun",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "imah",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Nambahkeun",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Kaca",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tambahkeun",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kompas Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Décimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad ngabagi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad asupkeun",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad sarua",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren kénca",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren katuhu",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kaca handap",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kaca nu luhur",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kakuatan",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Listrik Pareum",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Téknik Téknik",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ngarobah konci",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pilih",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ruang",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_szl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_szl.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ôtworzōno menu nawigacyje",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Wrōć",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Bez przesady",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Przi bliskim",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Wymazać",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Wiyncyj",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "W nastympnym miesiōncu",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "W poprzednim miesiōncu",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Naszo strōna",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Przednio strōna",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Przowŏ strōna",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ôstatnŏ strōna",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Wyświycić menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Szczyrki",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ôpływ do kōńca",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencje",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ryski na strōnã:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Zaneckować",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Przi bliskim",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kontynuuj",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kōmprōj",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Przeciynty",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tekst skanujōncy",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Wiyź na górã",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Szukaj we internecie",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Dziel sie",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Wōm sie to niy podoba.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pasyjo",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wybierz wszyjske",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Wyświetlać licencyje",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "SI:",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Prymierny",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Wybierz godzina",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Wybierz minuty",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ôdpuszczōny",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ôdmiyniać menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Wybrany rok",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Niywypowiedziano data",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Niywykryty zakres dat",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Wpisŏ sie daty",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data zaczōncŏ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data kōńca",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data zaczōnco $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data kōniec $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Nielogowy format daty",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Nielogowy zakres dat",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Datowanie poza zasięgiem",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Utrzimać",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Wybierz data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "WYBYRZYJĄCY",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Przełącz sie na tryb kalendarza",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Przełącz sie na tryb daty wejściowej",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Wybierz czas",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Wpisŏcz czasu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Godzina",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minutka",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Czas niyprawidłowy",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Przełącz sie na tryb wyciskanio",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Przełącz sie na tryb czasu wejściowego",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Podpisane",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Skryj konta",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Wyświetlać konto",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu nawigacyje",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menus w wroczniku",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Wymŏżŏ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Szukać",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Datowarzŏ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Wybrany datum",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Przesun sie do zacznij",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Przesun do kōńca",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wstŏw sie w górã",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Przijść do dómu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Przesun sie na lewo",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Idź na prawo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Zdo sie ôtwarzanie",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Ôstatni",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafŏ Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Zdowo przestrzyństwo",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapsyniŏ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Na dole",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Wzbōj na górã",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kontrolŏ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Wymazać",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Wyjzdrzyń",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kōniec",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Uciōngnij",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Dom we ôstatnim czasie",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Wkludzić",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta ôbrozka",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandōniŏ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Okna",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Kompa z ôbrozkōm",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad rozdziela sie",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad wchodź",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Rōwno",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad mnożnik",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Lewo",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Rōwno",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Strōna do kōńca",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Strōna na górze",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Moc ôdbudowaniŏ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Wyłączōny prōb",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Drukowany ekranu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Świyrzynie zamyka",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Wybierz",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Zmiyniŏ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Przestrzeń",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_taq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_taq.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ⵎⵉⵏⵓ ⵏ ⵓⵙⵙⵓⴷⵙ ⵉⵊⵊ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ⴰⴾⴰⵍ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ⵙⵍⴰⴼⴰⵏ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ⴰⵜⵓⴰⵣⴰ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ⴰⵙⴼⵙⵔ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ⴰⴳⴳⴰⵔ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ⵉⵎⴰⵍ ⵏ ⵉⵎⴰⵍ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ⵡⴰⵢⵢⵓⵔ ⵉⵣⵔⵉⵏ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵢⵓⵛⴽⴰⵏ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵏ ⵉⵣⵔⵉⵏ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵜⴰⵎⵣⵡⴰⵔⵓⵜ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵜⴰⵎⴳⴳⴰⵔⵓⵜ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ⴰⵙⵉⵜ ⵏ ⵓⵙⵉⵜ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "ⵙⴽⵔⵎ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ⵜⴰⵍⵖⴰ ⵏ ⵓⴷⴷⴰⴷ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ⵜⵉⵍⵉⵙⵜⴰⵏ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ⵜⵉⴼⵉⵏⴰⵖ ⵙ ⵜⴰⴱⵔⴰⵜ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ⴰⵙⴼⵙⵔ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ⴰⵜⵓⴰⵣⴰ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ⴰⴾⴰⵍ ⵏⴰⵙⴰⵏ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⴰⴱⵉⵍⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ⵜⴰⵔⵔⴰⵜ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ⵜⴰⵏⵏⴰⵢⵜ ⵏ ⵓⵙⴼⵙⵔ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ⴰⴾⴰⵍ ⵉⵉⵉⴰⵏ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵡⴰⵏⵉⵜⵉⵔ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ⵜⴰⵔⴳⴰ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ⴽⵓⵍⵍⵉ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "ⵜⴰⵔⵔⴰ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⵢⵍⵜ ⴰⴽⴽⵡ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ⴰⵙⴼⵙⵔ ⵏ ⵜⵍⴰⵍⵉⵜⵉⵏ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ⴱⵉⵎⵉⵔ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ⵜⵉⵣⵉ ⵏ ⵓⵙⵜⴰⵢ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "ⵉⵙⵜⴰⵢⵏ ⵏ ⵉⵙⵍⵡⵉⵜⵏ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ⴰⵙⵏⴼⵍ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ⴰⵎⴰⴳⵔ ⵏ ⵓⵙⵏⴼⵍ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ⴰⵙⴳⴳⵡⴰⵙ ⵉⵜⵜⵓⵙⵜⴰⵢⵏ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ⴰⵙⵙⴻⵜⴻ ⵓⵔ ⵢⴻⵜⵜⴻⴼⴽⴻⵏ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "ⴰⴱⴰⵔⴰⵣ ⵏ ⵡⴰⵙⵙ ⵓⵔ ⵉⵜⵜⵓⵙⵏⵎⴰⵍⴰ",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ⴰⵙⵙⴻⴽⵜⵉ ⵏ ⵡⴰⵙⵙ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ⴰⵙⵉⵜ ⵏ ⵓⵙⵏⵜⵉ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ⴰⵙⵉⵔⴰ ⵏ ⵜⵉⴼⵉⵏⴰⵖ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "ⵟⴰⵙⵙⵓⵜ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "ⵟⴰⴳⴷⵓⴷⴰ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ⵜⴰⵍⵖⴰ ⵏ ⵡⴰⵙⵙ ⵓⵔ ⵉⵣⴷⵖⵏ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ⵜⴰⴳⵓⵜ ⵏ ⵡⴰⵙⵙⵏ ⵓⵔ ⵉⵣⴷⵖⵏ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ⴰⵙⵙ ⵏ ⵓⴽⵕⴰⵙ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ⵙⴻⴼⵔⴻⴼ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵡⴰⵙⵙ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵜⴰⵍⵖⴰ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ⵙⵡⵉⵟ ⵖⵔ ⵡⴰⴷⴷⴰⴷ ⵏ ⵓⴽⴰⵍⴹⴰⵕ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ⵙⵡⵉⵟ ⵖⵔ ⵡⴰⴷⴷⴰⴷ ⵏ ⵡⴰⵙⵙ ⵏ ⵓⵙⵙⴽⵛⵎ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵜⵉⵣⵉ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ⵜⵉⵣⵉ ⵏ ⵓⵙⵙⴽⵛⵎ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ⵜⵉⵣⵉ ⵏ ⵜⵉⵣⵉ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "ⴷⴷⵓ ⵏ ⵖⵉⴽⴰⵏⵏ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ⵜⵉⵣⵉ ⵓⵔ ⵉⵣⴷⵖⵏ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ⵙⵡⵉⵟ ⵙ ⵓⴷⵔⵉⵙ ⵏ ⵓⵙⵙⵉⴼⵍ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ⵙⵡⵉⵟ ⵖⵔ ⵓⵏⴳⵔⴰⵡ ⵏ ⵜⵉⵣⵉ ⵏ ⵓⵙⵙⴽⵛⵎ",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ⴰⵙⴳⵔⴰⵡ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "ⴰⵙⵏⴼⵍ ⵏ ⵉⵎⵓⵣⴰⵣⴰⵢⵏ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ⴰⵙⴼⵙⵔ ⵏ ⵉⵎⵓⵣⴰⵢⵏ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ⵎⵉⵏⵓ ⵏ ⵏⵉⴼⵉⵊⵉⵛ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ⵜⴰⴱⴰⵔⴰ ⵏ ⵉⵎⵓⵜⵜⴳⵏ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ⵎⵉⵏⵓ ⴱⵓⴱⴱ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ⴰⵎⵙⴰⵡⴰⵍ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ⴰⵏⴳⴰⵍ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ⴰⵙⴰⴼⵓ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ⴰⵙⵙⴰ ⵏ ⵓⴽⴰⵜⴰⵔ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ⴰⵙⵙⴻⵜⴻⴼⵙⴻⵜ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ⵙⴽⵔ ⵙ ⵓⵙⵙⵉⵅⴼ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ⴰⵜⵓⴰⵣⴰⵔ ⵉ ⵢⴷⴰⴶ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ⴰⵜⵓⴰⵣⴰⵔ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ⴰⵜⵓⴰⵣⴰⵍ ⵓⴰ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ⴰⴾⴰⵍ ⵙ ⴰⴾⴰⵍ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ⴰⴾⴰⵍ ⵙ ⴰⵣⵓⴾ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ⴰⵙⵏⴼⵍ ⵏ ⵓⵙⵙⴰⵏ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ⴰⵍⵜ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "ⴰⵜ ⴶⵔⴰⴼ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "ⵜⴰⵣⵓⵎⵎⴰ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ⵍⴽⵙ ⵛⴰⴱⵙ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ⴰⴱⵔⵉⴷ ⵏ ⵓⴷⵔⴰⵔ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ⴰⴱⵔⵉⴷ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ⴰⵙⵉⵔⴰ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ⴰⵙⴼⵙⵔ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ⴰⵙⵏⴼⵍ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "ⵜⴰⵡⵉⵔⴰⵜ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "ⴰⵙⵏⴼⵍ ⵏ ⵓⵙⵙⴼⵍⴷ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ⴼⵏ",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ⵜⴰⴷⴷⴰⵔⵜ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ⵙⵙⵓⴳⴳⵔ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ⵎⵉⵜⴰ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "ⵜⴰⵍⵍⵉⵜ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ⵉⵏⵊⵉⴷⵢⵓ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "ⵜⴰⴽⵓⵎⵎⴰ ⵏⵓⵎⴱⴰⴷ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "ⵏⵓⵎⴱⴰⴷ ⵙⴱⵉⴷ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equality",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "ⵏⵓⵎⴱⴰⴷ ⴱⴰⵔⵉⵏ ⵉⴹⴼⴼⴰⵕⵏ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ⴰⵣⴳⵣⴰⵡ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ⵜⴰⴱⵔⴰⵜ ⵏ ⵓⴷⴷⴰⴷ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ⵜⴰⴱⵔⴰⵜ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "ⵜⴰⵣⵓⵣⵔⵜ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ⵜⴰⴳⵏⵉⵜ ⵏ ⵜⵣⵓⵣⵔⵜ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ⵉⴾⵔⴰⵜ ⵏ ⵢⴾⵔⴰⵜ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "ⵔⵓⵍⵍ ⵍⵓⴽ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "ⵙⵜⵢⵍⵜ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ⵜⴰⵍⵍⵉⵜ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ⴰⵎⴰⵏ ⵏ ⵓⴽⴰⴱⴰⵕ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tg.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Менюи навигасияи кушода",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Бозгашт",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Тафсилоти муайян",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Дар наздики",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Таъхир кардан",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Бештар",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Моҳи оянда",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Моҳи гузашта",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Саҳифаи навбатӣ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Саҳифаи гузашта",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Саҳифаи аввал",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Саҳифаи охирин",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Менюи намоиш",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Скрим",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Саҳифаи поёнӣ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Иҷозатномаҳо",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Сатрҳо дар саҳифа:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Таълиф кардан",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Дар наздики",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Идома диҳед",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Нусхаи муаллифӣ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Тақсим",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Матнро санҷед",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Ба боло нигаред",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Дар интернет ҷустуҷӯ кунед",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Мубодила",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ОК, хуб аст.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ҳамаро интихоб кунед",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Иҷозатномаҳои тамошо",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Сарвазири давлат",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Вақтҳои интихобшуда",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Дақиқаи интихобкунӣ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Барканор кардан",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Менюи радкунӣ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Соли интихобшуда",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Соати номуайян",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Дарози таърихии номуайян",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Таърихи воридкунӣ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Давраи оғоз",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Соати охири",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Санаи оғоз $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Соати охири $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Формати беэътибор",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Дарораи санаи беэътибор",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Давраи берун аз дастрас",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Ҳифз кунед",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Санаи интихобкунӣ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "МАРҲАБОИ интихоб кунед",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Ба режими тақвими гузаред",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Ба режими санаи воридкунӣ гузаред",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Вақти интихобкунӣ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Вақти воридкунӣ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Соат",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Дақиқа",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Вақти беэътибор",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Ба режими санҷиш гузаред",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Ба режими вақти воридкунӣ гузаред",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Имзо гузошта шуд",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ҳисобҳоро пинҳон кунед",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ҳисобҳоро нишон диҳед",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Менюи навигатсия",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Барги меню",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Менюи папка",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Муколама",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Огоҳинома",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ҷустуҷӯ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Санаи амалкунанда",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Санаи интихобшуда",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Ба оғоз ҳаракат кунед",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ба охир ҳаракат кунед",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ба боло равед",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ба поён равед",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ба чап ҳаракат кунед",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ба рост ҳаракат кунед",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Таъминот",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Барномаи дигар",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Графи Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Фазои пушти",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Қувваи баста",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ба поён равона кунед",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ба боло равона кунед",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Танзим",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Таъхир кардан",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Партофта шавад",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Охири",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Гурехтан",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Фн",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Хона",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Банд кунед",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Мета",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Фармондиҳанда",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Очаҳо",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Нум Лок",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Нумпад 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Нумпад 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Нумпад 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Нумпад 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Нумпад илова кунед",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Комаи номпад",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Номпади даҳумӣ",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Нишондиҳандаҳои нома",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Ба воридшавӣ дохил шавед",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad баробар",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Нумпад муштаракун",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ба тарафи чап",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren рост",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Нумпад истисно",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Саҳифаи поён",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Саҳифаро боло кунед",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Қувваи барқ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Барқ аз кор",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Шабакаи чоп",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Скрул-Лок",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Интихоб кунед",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Қисми нав",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Фазои",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ti.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ti.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ኣንፈቱ ዚፈልጠሉ ሰሌዳ ኽፉት",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ንድሕሪት ተመለስኩ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ንጹር",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ቀሪብካ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ኣወግድ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ተወሳኺ ነገራት",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ኣብ እትቕጽል ወርሒ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ናይ ዝሓለፈ ወርሒ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ዚቕጽል ገጽ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ናይ ቀደም ገጽ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ቀዳማይ ገጽ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "ናይ መወዳእታ ገጽ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ሜኑ ኣርኢ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "ስክሪም",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ታሕተዋይ ቈጽሊ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ፍቓድ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ኣብ ነፍሲ ወከፍ ገጽ መስርዕ፦",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ደምስስ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ቀሪብካ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ቀጽል",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ቅዳሕ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ቍረጽ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ጽሑፍ ስካን",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ናብ ላዕሊ ጠምት",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ነቲ መርበብ ሓበሬታ ድለዮ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ንኻልኦት ኣካፍሎም",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ሐራይ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "መቐመጢ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ንዅሉ ምረጽ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ፍቓድ ርአ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ምሸት",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ሰዓታት ምረጽ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "ደቓይቕ ምረጽ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ካብ ቤት ካባና ተሰጐ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ዝርዝር ኣወጻጽኣ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ዓመት ምረጽ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ዘይተገልጸ ዕለት",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "ዘይተገልጸ ሰንሰለት ዕለት",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ዕለት ኣእቱ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ዕለት ምጅማር",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ዕለት መወዳእታ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ዘይግቡእ ቅርጺ ዕለት",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ዘይግቡእ ስፍሓት ዕለት",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ካብ ቦታ ናብ ቦታ እትወጽእ ዕለት",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ኣድሕን",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ዕለት ምረጽ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ስፍሓት ምረጽ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ናብ ኣገባብ ዓውደ-ኣዋርሕ ምቕያር",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ናብ ኣገባብ ኣተኣታትያ ምቕያር",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ግዜ ምረጽ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ግዜ ኣእቱ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ሰዓት",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "ደቒቕ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ዘይግቡእ ግዜ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ናብ መደወሊ ተቐያየር",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ናብ ናይ ግዜ ሰሌዳ ምቕያር",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ክታም ዘንበረ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "ሕቡእ ጸብጻባት",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ጸብጻባት ኣርኢ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ኣንፈቱ ዚፈልጠሉ ሰሌዳ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ባር ሜኑ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "መቝነን ፖፕ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ዝርርብ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "መጠንቀቕታ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ድለ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "እዋናዊ ዕለት",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "እተመርጸ ዕለት",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ንምጅማር ግዓዝ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ናብ መወዳእታ ግዓዝ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ናብ ላዕሊ ግዓዝ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ናብ ታሕቲ ግዒዝካ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ናብ ጸጋም ግዓዝ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ናብ የማን ግዓዝ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ዕረፍቲ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ኣልት",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "ኣልት ግራፍ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "ባክስፔስ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ካፕ ሎክ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ታሕተዋይ መትረብ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ናብ ላዕሊ ዘሎ መትረብ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ቍጽጽር",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ኣወግድ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ምውጻእ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "መወዳእታ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "ምህዳም",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ቤት",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ኣእቱ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ሜታ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "ትእዛዝ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "መሸጐር",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "ኑምፓድ 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "ኑምፓድ 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "ኑምፓድ 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "ኑምፓድ 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "ኑምፓድ 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "ኑምፓድ 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "ኑምፓድ 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "ኑምፓድ 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "ኑምፓድ 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ኑምፓድ 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "ኑምፓድ መወሰኽታ",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "ኑምፓድ ኮምማ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "ናይ ኑምፓድ ዲሲማል",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "ኑምፓድ ምክፍፋል",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "ኑምፓድ ኣእቱ",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "ኑምፓድ ማዕረ",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "ኑምፓድ ምብዝሑ",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "ኑምፓድ ፓረን ጸጋም",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "ኑምፓድ ፓረን የማን",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "ንኡስ ኣርእስቲ ኑምፓድ",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ገጽ ታሕቲ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ገጽ ናብ ላዕሊ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "ሓይሊ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ሓይሊ ምጥፋእ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ስክሪን ሕትመት",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "መሸጐር ጠቕልል",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "ሕረ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ለውጢ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ቦታ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tk.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Navigasyon menýusyny aç",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "arkanlykkan",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ýüze çykarmak",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "golaý",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Poz",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Köpräk",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Indiki aý",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Geçen aý",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Indiki sahypa",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Öňki sahypa",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Birinji sahypa",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Soňky sahypa",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Menýany görkez",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "gygyrmak",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Aşaky kagyz",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisenziýalar",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Her sahypada setir sany:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ýatyrmak",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "golaý",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "dowam etmek",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "nusgala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "gyrkmak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Metin skan et",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "seretmek",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Webi Ahtar",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "paýlaşmak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "BOR",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "ýelmemek",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ehlisini Saýla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lisenziýalary gör",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Saýlanan sagat",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Saýla",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "işden aýyrmak",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menýuny ýapmak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Saýlan ýyly",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "_",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "_",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Taryhy Gir",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Başlangyç Senesi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Gutaryş Senesi",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "_",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "_",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Sahypa",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "halas etmek",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Senajy Saýla",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ARALYGY SAÝLA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kalendar moduna geç",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Giriş taryhy moduna geç",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Wagty saýla",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Wagty gir",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ölçeg",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "jikme-jik",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nädogry wagt",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Dil moduna geç",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Wagt moduna geç",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "gol çekildi",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ýazgylary Gizle",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ýazgylary görkez",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigasiýa menýusy",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menýu zolaky",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Açylan menü",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "hüşgär",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "derňemek",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Häzirki taryh",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Saýlanan senesi",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Başlamak üçin göç",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Soňuna göç",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ýokaryk galmak",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "aşak süýşür",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Çepe süýşür",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Saga süýşür",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "täzelemek",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "alt-format",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt-Graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Yza",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Gapak gulpy",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kanal Aşak",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kanal Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "kontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Poz",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "çykarmak",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "aýak ujy",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "gaçyp gutulmak",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "öý",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Arasyna Süýşür",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "buýurmak",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "aýnalar",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Sim Gulpy",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Ekle",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Virgül",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Onluk Tama",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Deň",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Köpeltmek",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Sol",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren sag",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Sayı Aýyrmak",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sahypa Aşak",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Sahypa Ýok",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "häkimiýet",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Öçürmek",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ekran Çap",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Tebylyş Bagla",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "saýlamak",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "smena",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "meýdança",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Open navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Back",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Clear",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Close",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Delete",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Tse dingwe",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kgwedi e e tlang",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kgwedi e e fetileng",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Previous page",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tsebe ya ntlha",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Tsebe ya bofelo",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Bottom sheet",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Dilaesense",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows per page:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Phimola",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Close",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tswelela",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan text",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Leba kwa godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "EE",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tlhopha sengwe le sengwe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "View licenses",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Diura tse di tlhophilweng",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Tlhopha metsotso",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Tlosa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Dismiss menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tlhopha ngwaga",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Letlha le le sa tlhalosiwang",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Unspecified date range",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Letlha la go tsena",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Letlha la Tshimologo",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Letlha la bokhutlo",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Invalid date format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Invalid date range",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Date Out of Range ke gane",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Boloka",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Tlhopha letlha",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECT RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Go Go Gadget Calendar Mode",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Switch to input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Tlhopha nako",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Go tsena ka nako",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ura",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Motsotso",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nako e e sa siamang",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Switch to dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Go Go Gadget Input Time Mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Signed in",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hide accounts",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Show accounts",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tlhagiso",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Phuruphutso",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Letlha la ga jaana",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Letlha le le tlhophilweng",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to End ke gane",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Move down",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tsamaya ka fa mojeng",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Refresh",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ditlhaka tse di tona",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Taolo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Delete",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Bokhutlo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Tshabela",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Le fa go ntse jalo,",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Gae",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Tsenya",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Taelo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Difensetere",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Maatla",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Power Off",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Tlhopha",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Phetogo",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Space",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_to.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_to.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Fakaava ʻa e navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Foki",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Mahino",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Tapuni",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Tamateʻi",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Lahi ange",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mahina kahaʻu",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mahina kimuʻa",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Peesi hono hoko",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Peesi kimuʻa",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Peesi ʻuluaki",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Peesi fakaʻosi",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Fakaʻaliʻali ʻa e menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Laʻipepa ki lalo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ngaahi laiseni",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ʻOtu ki he pesi:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kaniseli",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Tapuni",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Hoko atu",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tatau",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tuʻusi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scan ʻa e fakamatala",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Sio hake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fekumi ʻi he uepisaiti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Vahevahe",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Sai pe",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Fili kotoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Vakai ki he ngaahi laiseni",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Fili ʻa e ngaahi houa",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Fili ʻa e miniti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Tukuange",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tukuange ʻa e menu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Fili ʻa e taʻu",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ʻAho ʻoku ʻikai fakamahinoʻi",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Vahaʻa ʻo e ʻaho ʻoku ʻikai fakamahinoʻi",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Fakahu ʻa e ʻAho",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ʻAho Kamata",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ʻAho ʻOsi",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Founga hala ʻo e ʻaho",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ʻOku hala ʻa e vahaʻa ʻo e ʻaho",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ʻAho ʻoku mavahe mei he tuʻunga",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Seivi",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Fili ʻa e ʻaho",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "FILI ʻA E RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Liliu ki he tuʻunga ʻo e tohi mahina",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Liliu ki he input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Fili ʻa e taimi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Fakahu ʻa e taimi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Houa",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Miniti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Taimi taʻeʻaonga",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Liliu ki he dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Liliu ki he input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Hu ki he",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fufuuʻi ʻa e ngaahi ʻakauni",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Fakaʻaliʻali ʻa e ngaahi ʻakaun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigation menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Pa menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Talanoa",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Fakatokanga",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Fekumi",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ʻAho lolotonga",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ʻAho kuo fili",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Hiki ke kamata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ʻUnu ki he ngataʻanga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hiki ki ʻolunga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ʻUnu ki lalo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hiki ki toʻohema",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ʻUnu ki toʻomataʻu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fakafoʻou",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Puleʻi",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Tamateʻi",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Tuli",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fakaʻosinga",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Hola",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ʻApi",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Fakahu",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Fekau",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ngaahi matapa sioʻata",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Loka Fika",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Tanaki atu ʻa e Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Vahevahe ʻo e Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Fakalahi ʻa e Numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Toʻohema",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Toʻomataʻu",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Toʻo ʻa e Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Peesi ki lalo",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Peesi ki ʻolunga",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Malohi",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Tamateʻi ʻa e ʻuhila",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Paaki ʻa e screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Loka ʻo e Scroll",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Fili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Liliu",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ʻAtaa",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tpi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tpi.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Opim navigation menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kisim bek",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ol samting i klia",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Klostu",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Slipim",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Planti moa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Long mun bihain",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mês i kamap paslain",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Stori bilong bipo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Namba wan pes",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Laip bilong laspela pes",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Spela menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ol samting bilong mekim wok",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ol samting bilong wokim graun",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ol Laisen",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Ol lain long wanpela pes:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kisim bek",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Klostu",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kisim bek",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Tok bilong en",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kisim ol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skenaim tok",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Lukim antap",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ritim long web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ol i save kisim ol samting",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ol i orait.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pas",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Putim olgeta",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lukim ol laisens",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Kisim ol haptaim",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Kisim ol minit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Tok i No Kisim",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Toksave long ol samting",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select Year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "No save makim taim",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ol i no makim taim bilong en",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Enter Date",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Statim De",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Taim bilong pinis",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Klostu long pinis $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ol tok bilong dispela tok i no stret",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ol yia bilong en i no stret",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Taim bilong mekim wok",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Saveim",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Kisim de",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELEKTI",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kisim kalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Kisim rot long taim bilong putim",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selektim taim",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Enter taim",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Taim",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minut",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Taim i no stret",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Kisim rot long rot bilong makim",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Kisim taim bilong putim",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Mi bin raitim nem",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Haitim ol rekod",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Lukim ol rekord",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ol man bilong navigim",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Ol menu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Toktok",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Tok lukaut",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Wok bilong painim",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Klostu",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ol i makim de",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Kisim rot long stat",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kisim ol samting i go inap long pinis",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kisim bek",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kisim ol samting i go daun",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kisim han kais",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kisim han sut",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Wok bilong givim nupela strong",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Ol narapela",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graf",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ol samting bilong baksait",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ol Kap Tok",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kam daun",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kisim Tok Long Ol Man",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ol samting bilong bosim",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Slipim",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Paitim",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Klostu",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kisim Bek",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Haus",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Pasim",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Ol samting bilong wokim piksa",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Koman",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Ol windo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Ol Numpad i Divim",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Ol i wankain olsem ol",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren i go",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Long Rogat",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pait i Go daun",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Tok Pisin i Go antap",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ol samting bilong mekim wok",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ol i no save mekim wok",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Lukim Ol Tok",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selektim",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Wok senis",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Hap bilong graun",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ts.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ts.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Pfula menyu ya ku famba",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ku Tlhelela eNdzhaku",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ku Hlula",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ku Pfala",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Susa",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Ku tlula kwalaho",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "N'hweti leyi taka",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "N'hweti leyi hundzeke",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Tluka leri landzelaka",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Tluka leri hundzeke",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tluka ro sungula",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Tluka ro hetelela",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Kombisa menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Ku tsindziyela",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Xiphephana xa le hansi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Maphepha-mfanelo",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Tilayini hi tluka:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Ku Tsema",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ku Pfala",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Hambeta",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Ku kopa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ku tsemiwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Tsala rungula",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Languta ehenhla",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Lavisisa eka Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ku Avelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Swi lulamile.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Xitlhoma-ndzeni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hlawula Hinkwaswo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tiphasi ra ku hlalela",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "Xitirhisiwa",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Nkulukumba wa tiko",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hlawula tiawara",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Hlawula minete",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ku Lahliwa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tsala ehansi",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Lembe leri hlawuriweke",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Siku leri nga hlamuseriwangiki",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ku nga tiveki nkarhi lowu faneleke",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tsala Siku",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Siku Ro Sungula",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Siku Ra Ku Hela Ka Ntirho",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Siku ro sungula $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Siku ro hela $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fomo ya siku leri nga tirhiwiki",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ku nga tirhi ka masiku",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Siku leri nga riki kona",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Pfuna",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Hlawula siku",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "HLAYA XIPHEMU",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Famba eka fambiselo ra khalendara",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Famba eka fambiselo ra siku ra ku nghenisa",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Hlawula nkarhi",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Nghena hi nkarhi",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Nkarhi",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minete",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nkarhi lowu nga riki enawini",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Famba hi ndlela ya ku hlawula",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Famba eka fambiselo ra nkarhi wa ku nghenisa",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ku sayiniwa",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Ku tumbeta tiakhawunti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Kombisa tiakhawunti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Xibukwana xa ku famba",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Xitirhisiwa xa swakudya",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Xibukwana Xa Xitsonga",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ku Vulavurisana",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Xitsundzuxo",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ku Lavisisa",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Siku ra sweswi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Siku leri hlawuriweke",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Famba u ya sungula",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ku ya fika emakumu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Tlakuka",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Tsutsuma ehansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Famba hi le ximatsini",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Famba hi ku ya exineneni",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ku Titsakisa",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Tindlela tin'wana",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafu ya Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Xiyimo xa le ndzhaku",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ku Pfala",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Ku Rhurha",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Ku Tlakusa Xitichi",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ku Lawula",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Susa",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ku cukumetiwa",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ku Hela",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ku Baleka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Kaya",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Nghenisa",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Xitsonga",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ku Rhangela",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Tifasitere",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Xitirhisiwa xa ku rhunga",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Ku Engetela Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Xitsotswana Xa Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Ku Avana Ka Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Nghena Hi Numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren U Sile",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren U Le Kusuhi",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Tluka Ra Le hansi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Tluka Ra Le Henhla",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Matimba",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ku Pfumaleka Ka Matimba",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Ku Printa Xirha-ndhawu",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ku Pfala",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Hlawula",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Ku Cinca",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ndhawu",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tt.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Навигация менюсын ачу",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Артка",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Чиста",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ябу",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Бетерү",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Күбрәк",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Киләсе ай",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Узган ай",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Киләсе бит",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Алдагы бит",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Беренче бит",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Соңгы бит",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Меню күрсәтү",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Скрим",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Аскы бит",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Лицензияләр",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Бер биттәге юллар:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Баш тарту",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ябу",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Дәвам итү",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Күчермә",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Кисү",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Текстны сканлау",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Югарыга карагыз",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Интернетта эзләү",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Уртаклашу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ЯХШЫ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Паста",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Барысын да сайлап алу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Лицензияләрне карау",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "АМ",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Кичке сәгать",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Сәгатьләрне сайлап алу",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Сайлау минутлары",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Эштән чыгару",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Меню ябылу",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "дд/мм/гггг",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Сайлау елы",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Датасы билгеләнмәгән",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Даталар диапазоны билгеләнмәгән",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Дата кертү",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Башлану датасы",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Тәмамлану датасы",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Дата форматы дөрес түгел",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Дөрес булмаган дата диапазоны",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Дата диапазоннан тыш",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Саклау",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Датаны сайлау",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ДИАПАЗОННЫ САЙЛАУ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Календарь режимына күчү",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Кертү датасы режимына күчү",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Вакытны сайлау",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Вакытны кертү",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Сәгать",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Минут",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Дөрес булмаган вакыт",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Шалтырату режимына күчү",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Кертү вакыты режимына күчү",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Кергән",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Аккаунтларны яшерү",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Аккаунтларны күрсәтү",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Навигация меню",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Меню панеле",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Диалог",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ачыклык",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Эзләү",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Хәзерге дата",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Сайланган дата",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Башлангыч өчен күчерү",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ахырына күчерү",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өскә күтәрелеш",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Түбәнгә күчерү",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Сулга күчерү",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Уңга күчерү",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Яңарту",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Альт",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Альт-граф",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Баш хареф",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Канал түбәнгә төшү",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Канал өскә күтәрелү",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Контроль",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Бетерү",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Чыгару",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ахыры",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Качу",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Фн",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Өй",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Өстәмә",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Мета",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Команда",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Тәрәзәләр",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "1 нче чәчәк",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "3 нче чәчәк",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "4 нче чәчәк",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "5 нче чәчәк",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "6 нчы чәчәк",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "7 нче чәчәк",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "8 нче чәчәк",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "9 нчы чәчәк",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Цифр өстәү",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Цифр тамгасы өчен өчәк",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Унарлы цифралар",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Сан-Пад Бүленеше",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Кабатлау",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Парен сул",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren уң",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Төшерү",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Бит түбәнгә",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Бит өскә",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Көч",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Электр сүндерү",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Басма экраны",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Төргәкләү йозагы",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Сайлау",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Смена",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Космос",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tum.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tum.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Mndandanda wa navigation",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kuwelera",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Kuŵa Ŵakufikapo",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Kuŵa pafupi",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Kufumiska",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Vinyake",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Mwezi wakulondezgapo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Mwezi wapitawo",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Nkhani yakulondezgapo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Tsamba Lakumapeto",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Tsamba loyamba",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Tsamba Laposachedwa",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Wonani menyu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Kupopera",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Chidindo cha pasi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Maluso",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mzere pa peji:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Kulekeska",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Kuŵa pafupi",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Lutilirani",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Kupokera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kupalasa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skani malemba",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Wukani",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Penjani pa Intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kugaŵana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Chabwino",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Kupaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Wonani ziphaso",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "M.",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Nduna Yaikulu",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Sankhani nyengo",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sankhani mphindi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Kulekerathu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Chinthu chinyake",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Chaka chakusankhira",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Zuŵa lambura kuwoneka",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Nyengo iyo ŵakagwiranga ntchito yayi",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Lembani Dazi",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Zuŵa Lakwamba",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Zuŵa Lakumalizgira",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Zuŵa lakwamba $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Zuŵa laumaliro $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Mtundu wa deti",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Vyakupambana na vinyake",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Zuŵa lakwamba",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sungani",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sankhani deti",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Sankhani Vyakupambanapambana",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Sinthani ku kalendala",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Sinthani ku ndondomeko ya deti",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Sankhani nyengo",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Wikani nyengo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Mphindi",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Nyengo ya kulekerera",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Sinthani ku dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Sinthani ku mode ya time input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ŵakalembeska",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Kubisa nkhani",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Wonani nkhani",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Mndandanda wa maulendo",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Mzere wa Mndandanda",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Mndandanda wa Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Kuyowoya",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Chenjezo",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kupenja",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Zuŵa lakwamba",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Zuŵa Lakusankhika",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Yambani",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Lutilirani kwenda",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wukani",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Welerani pasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yenda kumazere",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yenda kumalyero",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Kusanguluska",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Vyakusankha",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafu ya Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Malo gha kumanyuma",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kujalira",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Kuwukira",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Kwerani",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kuwongolera",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Kufumiska",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Kufumiska",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Umaliro",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Kuchimbira",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ku Nyumba",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kuŵikamo",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Mtundu wa Mtundu",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ŵalongozgi",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mawindo",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Kujalira",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Kuphatikiza Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Kugaŵikana kwa Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Kwerani Numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Wakukhala Kumazere",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kumene",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Kutaya kwa Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kuŵikapo Mtima",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Kuwuska",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mphamvu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Kuleka Kugwira Ntchito",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Kusindikizira",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Kulemba Kulemba",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Sankhani",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Kusintha",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Malo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tw.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Nantew a wobɛtumi akɔfa",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Yɛsan kɔ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Hyɛ no nsow",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Ɛbɛn",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Sɛe",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Nea Ɛsen Saa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Bosome a edi hɔ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Bosome a etwaam",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Kratafa a Edi hɔ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "N'asɛmti",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kratafa a edi kan",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kratafa a etwa to",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Yi menua no kyerɛ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Nsonsonoe",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Asase no ase nhoma",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Ahyehyɛde",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Nsraban a ɛwɔ kratafa biara mu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Sɛe",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Ɛbɛn",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Kɔ so",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Wɔahyehyɛ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wodi mu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Nhwɛso a wohwehwɛ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Hwehwɛ soro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Hwehwɛ Intanɛt so",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Fa no",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ɛhɛe!",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Nkyene",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Paw nyinaa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Hwɛ tumi krataa",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ɔmampanyin",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Hwɛ nnɔnhwerew a wɔde yɛ adwuma",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Paw nnɔnhwerew",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "W'ayi",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Fa no kɔ baabiara",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Afe a wɔpaw no",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Da a wɔnkyerɛw",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Da a wɔammɔ ho asɛm",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Fa Da no hyɛ mu",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Da a Wɔfi Ase",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Awiei Da",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Mfiase da $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Awiei Da $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Da a enni nnyinaso",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Da a enni hɔ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Da a wɔrentumi nyɛ adwuma",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Fa no",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Fa da a wɔpaw no",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SƐ WƆHWƐ ƆWƐN",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Fa wo ho kɔ kalenda so",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Fa kɔfa da a wɔde hyɛ mu no mu",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Paw bere",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Fa bere no hyɛ mu",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Dɔnhwerew",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Da koro",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Bere a enni mu",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Fa wo ho kɔ fon so",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Fa no kɔ input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Wɔhyɛ ase",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hintaw akonta",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Kyerɛw akontaabu",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Nnansa a wɔde kɔ hɔ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menua bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ɔkasa",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ɛbɔ a Ɛbɔ no Hyɛ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Hwehwɛ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Da a edi kan",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Da a wɔpaw no",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Yɛkɔyɛ adwuma",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kɔ awiei",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Monkɔ soro",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kɔ fam",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kɔ benkum",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Fa wo nsa nifa",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Nnansa",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Nkyinkyin",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Nkyena",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kapu Ahyehyɛde",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Fa Wo Ho To Asase So",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Fa no Kɔ Ɔfasu So",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Adesoa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Sɛe",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "W'ayi",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Awiei",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Wɔdwane",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Fie",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Fa hyɛ mu",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ahyɛde",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Nkyɛnkyɛm",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Nkyekyɛ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Abusuakuw",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren N'anim",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kɔfa W'asɛmti no",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Hwɛ Nsɛm a Ɛwɔ Wiase Yi So",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Tumi",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ɔde Nsuo no Betu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Wode W'anim Nsɛm",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Fa Nhoma no Kyekye",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Paw",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Adwuma",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Amansan",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ty.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ty.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Iriti i te tabula ohipa no te tere",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "I muri",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Maramarama",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Opani",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Tumâ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Te tahi atu â mau mea",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "I te ava'e i muri nei",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Ava'e na mua'tu",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Api i muri mai",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Api na mua'tu",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Api matamua",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Api hopea",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Faaite i te tapura ohipa",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Api i raro i te api",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Te pato'iraa i te $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "No ni'a i te $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licenses",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Rows i te api:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Faaoreraa hapa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Opani",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "A tamau noa",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Hoho'a",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tapu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Hi'opo'a i te parau papa'i",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Hi'o i ni'a",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ma'imi i ni'a i te Itenati",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Faaite",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ok",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Te mau nota",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ma'iti i te taatoaraa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Hi'o i te mau parau faati'a",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Ma'iti i te hora",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Ma'iti i te mau minuti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Te faarueraa i te haapiiraa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Tabula ohipa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Ma'iti i te matahiti",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tai'o mahana faataa-ore-hia",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Tai'o mahana faataa-ore-hia",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tai'o mahana i papa'i",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tai'o mahana haamataraa",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tai'o mahana hopea",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tai'o mahana haamataraa $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Tai'o mahana hopea $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Faito tai'o mahana tano ore",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Tai'o mahana tano ore",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tai'o mahana i faataahia",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Faaora",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Ma'iti i te tai'o mahana",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TE MAU PARAU APÎ O TE EKALESIA",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "A taui i te huru o te tarena",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Taui no te huru tai'o mahana",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Ma'iti i te taime",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "A tomo i roto i te hora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Hora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuti",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Taime tano ore",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Te niuniu afa'ifa'i",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Taui no te faanahoraa i te taime no te tuuraa i te mana'o",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Tuurimahia i roto",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Huna i te mau aamu",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Faaite i te mau aamu",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Tabula ohipa no te tereraa na ni'a i",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Tabula ohipa",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Te mau mana'o tauturu no te",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ma'imi",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tai'o mahana i teie nei",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tai'o mahana i ma'itihia",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Haere i mua no te haamata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A haere i mua e tae atu i te hopea",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "A haere i ni'a",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "A haere i raro",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Haere i te pae aui",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Haere i te pae atau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Te tamǎr",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Te mau mana'o tauturu no te haapiiraa",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "A ti'a i ni'a",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Hi'opo'araa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Tumâ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Hopea",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Te hororaa",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Te fare",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Insert",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Faaueraa",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Te mau haamaramarama",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren i te pae aui",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Right",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Numpad I raro a'e i te mana",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Api i raro",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Api i ni'a",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Mana",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Te mana i tupohehia",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Nene'i i te paruai",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ponao o te otaro",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Ma'iti",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Shift",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Te reva teitei",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_tzm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_tzm.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "ⴰⵙⴳⵓⵎ ⵏ ⵓⵙⵏⴼⵍ ⵏ ⵓⵙⵙⵓⴷⵙ",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "ⵙⵙⵓⵜⵍ",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "ⴰⵙⴼⵍⴷ",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "ⵜⴰⵎⴰ ⵏⵉⵖ",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "ⴰⵙⴼⵙⵔ",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "ⵓⴳⴰⵔ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "ⴰⵙⴰⵢⵙ ⴰⴷ ⵢⵓⵛⴽⴰⵏ",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "ⵡⴰⵢⵢⵓⵔ ⵉⵣⵔⵉⵏ",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ⵜⴰⵡⴰⵍⴰ ⵢⵓⵛⴽⴰⵏ",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "ⵜⴰⵡⵍⴰⴼⵜ ⵉⵣⵔⵉⵏ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵜⴰⵎⵣⵡⴰⵔⵓⵜ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "ⵜⴰⴱⵔⴰⵜ ⵜⴰⵎⴳⴳⴰⵔⵓⵜ",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ⴰⵙⴼⵙⵔ ⵏ ⵓⵙⵉⵜ",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "ⵙⴽⵔⵎ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "ⵜⴰⴱⵔⵣⴰ ⵏ ⵓⴷⵔⴰⵔ",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "ⵜⵉⵥⴹⴰⵕⵉⵏ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "ⵉⵙⴽⴽⵉⵍⵏ ⵙ ⵜⴱⵔⴰⵜ:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "ⴰⵙⴼⵙⵔ",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "ⵜⴰⵎⴰ ⵏⵉⵖ",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "ⵙⵓⵍ",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⵓⴱⵉⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ⴰⵖⵔⴼ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "ⵜⴰⵏⵎⵎⵉⵔⵜ ⵏ ⵓⵙⴼⵙⵔ",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "ⴰⵥⵕ ⵙ ⵓⵍⵍⴰⵙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵓⵙⵉⵜ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ⴰⵙⵎⴹⴰⵍ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "ⴽⴽⵓ ⴽⴽⵓ",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "ⵜⴰⴱⵔⴰⵜ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⴰⵢ ⴽⵓⵍⵍⵓ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ⴰⵙⴼⵙⵔ ⵏ ⵜⵍⴽⴰⵎⵉⵏ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "ⴰⵏⵙⵙⵉⵅⴼ ⵏ ⵜⵏⴱⴰⴹⵜ",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "ⴰⵙⵜⴰⵢ ⵏ ⵜⵉⵣⵉ",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "ⴰⵙⵜⴰⵢ ⵏ ⵉⵙⴽⴽⵉⵍⵏ",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "ⴰⵙⵏⴼⵍ",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "ⴰⵙⴳⵓⵎ ⵏ ⵓⵙⵙⵓⴼⵖ",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "ⴰⵙⴳⴳⵡⴰⵙ ⵉⵜⵜⵓⵙⵜⴰⵢⵏ",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "ⴰⵙⵏⵜⵉ ⵓⵔ ⵉⵜⵜⵓⵙⵏⵎⴰⵍⴰ",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "ⴰⵙⴰⵢⵔⴰⵔ ⵏ ⵡⴰⵙⵙ ⵓⵔ ⵉⵜⵜⵓⵙⵏⵎⴰⵍⴰⵏ",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "ⴰⵙⴽⵜⵉ ⵏ ⵡⴰⵙⵙ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "ⴰⵙⵏⵜⵉ ⵏ ⵓⵙⵏⵜⵉ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "ⴰⵙⵉⵔⴰ ⵏ ⵓⵣⵎⵣ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "ⴰⵙⵏⵜⵉ $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "ⴰⵙⵉⵔⴰ ⵏ ⵡⴰⵙⵙ $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ⵜⴰⵖⴰⵡⵙⴰ ⵏ ⵡⴰⵙⵙ ⵓⵔ ⵉⵣⴷⵉⵏ",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ⴰⵙⴰⵢⵔⴰⵔ ⵏ ⵡⴰⵙⵙ ⵓⵔ ⵉⵣⴷⵉⵏ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "ⴰⵙⵉⵜ ⵏ ⵓⴱⵔⵉⴷ",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "ⴰⵙⵏⴼⵍ",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵡⴰⵙⵙ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵓⵙⵡⵉⵔ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "ⵙⴽⵍ ⵙ ⵡⴰⴷⴷⴰⴷ ⵏ ⵓⴽⴰⵍⴹⴰⵕ",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "ⵙⴽⵍ ⵙ ⵓⵙⵍⴳⵏ ⵏ ⵡⴰⵙⵙ ⵏ ⵓⵙⵙⴽⵛⵎ",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "ⴰⵙⵜⴰⵢ ⵏ ⵡⴰⴽⵓⴷ",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "ⴰⵙⴽⵛⵎ ⵏ ⵜⵉⵣⵉ",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "ⵜⵉⵣⵉ ⵏ ⵜⴷⴳⴳⵡⴰⵜ",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "ⴷⴳ ⵡⴰⵔⵔⴰⵜ",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ⵜⵉⵣⵉ ⵓⵔ ⵉⵣⴷⵖⵏ",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "ⵙⴽⵍ ⵙ ⵓⴷⵔⵉⵙ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "ⵙⴽⵍ ⵙ ⵓⵏⴳⴰⵙ ⵏ ⵜⵉⵣⵉ ⵏ ⵓⵙⵙⴽⵛⵎ",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "ⴰⵙⴳⵎⴹ",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "ⴰⵙⴼⵓⴳⵍⵓ ⵙ ⵜⵍⴰⵍⵉⵜ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ⴰⵙⴼⵙⵔ ⵏ ⵉⵎⵓⵣⴰⵢⵏ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "ⴰⵎⴰⴳⵔ ⵏ ⵓⵙⵏⴼⵍ",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "ⵜⴰⴱⵔⵓⵜ ⵏ ⵉⵎⵓⵙⵙⵓⵜⵏ",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "ⴰⵎⴰⴳⵔ ⵏ ⵓⴱⵓⴱ",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "ⴰⵎⵙⴰⵡⴰⵍ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ⴰⵙⵏⵖⵎⵙ",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "ⴰⵙⴼⵙⵔ",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "ⴰⵙⵉⵜ ⵏ ⵡⴰⵙⵙ",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "ⴰⵙⵉⵜ ⵉⵜⵜⵓⵙⵜⴰⵢⵏ",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "ⴰⴷ ⵙⴽⵔⵏ ⵉ ⵍⴱⴷⵓ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ⴰⴷ ⵢⵓⵡⵉ ⴰⵔ ⵓⴳⴳⴰⵔ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ⵙⴽⵔ ⵙⵙⵉ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ⵙⴽⵔ ⵙ ⵓⴷⵔⴰⵔ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ⵙⴽⵍ ⵙ ⵓⴳⴰⴼⴰ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ⵙⴽⵔ ⵙ ⵓⵥⵍⵎⴰⴹ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "ⴰⵙⵏⴼⵍ",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "ⴰⵜ",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "ⴰⵜⵉⵇⵏⵉ ⵏ ⵓⴹⵕⵉⵚ",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "ⴰⵙⴰⵢⵔⴰⵔ ⵏ ⵓⴷⵔⴰⵔ",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "ⴰⴱⵔⵉⴷ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "ⴰⵙⵏⴼⵍ ⵏ ⵜⵎⴰⵣⵉⵖⵜ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "ⴰⵙⵏⴼⵍ ⵏ ⵓⴷⵔⴰⵔ",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "ⴰⵙⵉⵔⴰ",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "ⴰⵙⴼⵙⵔ",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "ⴰⵙⵏⴼⵍ",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "ⴰⵎⴳⴳⴰⵔⵓ",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "ⴰⵙⵏⴼⵍ",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "ⵜⴰⴳⴳⴰⵢⵜ",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "ⵜⴰⴷⴷⴰⵔⵜ ⵜⵓⵎⵍⵉⵍⵜ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "ⴰⵙⵏⴻⴳⵎⵓ",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "ⵎⵉⵜⴰ",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "ⴰⵙⵍⵡⴰⵢ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "ⵉⴼⵔⴰⵏⵙⵉⵙⵏ",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "ⴰⵎⵓⵇⵇⴰⵔ ⵏ ⵓⴷⵍⵉⵙ",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "ⴰⵎⵏⵥⴰⵡ 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "ⵜⴰⴽⵓⵎⵎⴰ ⵏ ⵓⵏⴰⵥⵓⵔ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "ⴰⵙⴱⴹⵓ ⵏ ⵓⵏⴰⵎⵓⵔ",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "ⴰⵎⵎⴰⵙ ⵏ ⵓⵙⵙⵉⵅⴼ",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "ⴰⵎⵏⵣⵓ ⵏ ⵓⴽⵡⴼ",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren ⴰⴳⴰⴼⴰ",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ⴰⵣⴳⵣⴰⵡ",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "ⴰⵙⴼⵓⴳⵍⵓ ⵏ ⵓⵖⵣⵓ",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "ⵜⴰⴱⵔⴰⵜ ⵏ ⵓⴷⵔⴰⵔ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "ⴰⵙⴽⴽⵉⵍ ⴰⴼⵍⵍⴰ",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "ⵜⴰⵣⵓⵣⵔⵜ",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "ⴰⵥⵟⵟⴰ ⵏ ⵓⵥⵟⵟⴰ",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "ⴰⵙⴽⴽⵉⵍ ⵏ ⵓⵙⴽⴽⵉⵍ",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "ⴰⵖⵍⵉⴼ ⵏ ⵓⵙⵙⴼⵍⴷ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "ⴰⵙⵜⴰⵢ",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "ⴰⵙⵏⴼⵍ",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "ⴰⵙⴰⵢⵔⴰⵔ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_umb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_umb.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Oku yulula o menu yoku endisa",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Oku Tiuka",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Oku Yuvula Oku Sakala",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Oku Amamako",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Oku Pukuta",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Oku Pindisiwa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kosãi yi kuãimo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kosãi ya pita",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Okakasia ka kuãimo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Okakasia ka pita",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Kemẽla liatete",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Okakasia ka sulako",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Lombolola olonumbi",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Oku liyelisa",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Ovimalẽho vi sangiwa vemehi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Olovikanda",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Alitalatu:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Oku liwekapo",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Oku Amamako",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Amamako",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Ocisonehua caco",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Oku teta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sanda esapulo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Liwekapo oku tala",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sandiliya vo Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Oku Pongolola Oluali",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ciwa.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Oku kapa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Nõla ovina viosi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Tala ovikanda viuvangi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "OVIMBILIYA",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Ombiali",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Nõla olowola",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Nõla atosi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Oku Puluka",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Ku ka ecelele oku kongeliwa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "D/mm/yyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Unyamo wa nõliwa",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Eteke ka lia tukuiwile",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Otembo ka ya tukuiwile",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Kuata Etendelo",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Eteke Lioku Fetika",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Eteke Lioku Puluka",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Eteke Lioku fetika $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Eteke liesulilo $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ovipama viosãi ka vi kuete esilivilo",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Ovikomo vi lingiwa",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Eteke lioku tunda",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Oku seleka",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Nõla eteke",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "Nõla Etendelo Liovina o Sukila Oku Linga",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Amamako oku linga esokiyo lioku tanga",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Amamako oku talavaya lowola yoku iñila",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Nõla otembo",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Vokiyako otembo",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Owola",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Okamue kamue",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Otembo ka yi kuete esilivilo",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Amamako oku nõla",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Amamako oku talavaya lowola yoku iñila",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Oku soneha onduko",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Oku soleka olombongo",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Lombolola ulandu",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Ovikanda vioku endisa",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Ocimunga Cokulia",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Ovipama vi sangiwa vo menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Oku sapela",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ovikele",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Oku Sandiliya",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Eteke liosãi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Eteke lia nõliwa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Oku fetika",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oku Amamako",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Amamako oku kula",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Likolisilako oku loka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kuende kepĩli",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kuende kondio",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Oku Pongolola",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Olonepa vikuavo",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alitalatu",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ocitumãlo co Konele",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Ocilemo",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Oku Puluka",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Oku Vangula",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Oku endisa",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Oku Pukuta",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Oku tundisiwa",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Oku Puluka",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Oku Tila",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Ociña co ko",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Onjo",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Vongolola",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Olonepa",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Ocikele Coku Songola",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Olonjanela",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Oku Yuvula Oku Yuvula Oku Yuvula",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Ocimãleho 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Ocimãleho 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Ocimãleho 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Ocimãleho 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Ocimãleho 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Ocimãleho 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Ocimãleho ci tukuiwa hati, Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Ocimãleho ci tukuiwa hati, Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Ocimãleho ci tukuiwa hati, Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Ocimãleho coku kapa atosi",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Oku Vokiyako Ovikolo",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Ociña co Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Etendelo Lietendelo Lietendelo",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Oku Tepa Kualua",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Kuata Ukamba la Suku",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Ociña Cimue ci Kuete Esilivilo",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Oku Vokiya",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren wa tunda",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kondio",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Oku tepulula",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Kuata Esanju",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Oku Vokiya Ekalo Liove",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Ongusu",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Olusu ka lu Kuete Ongusu",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Oku Soneha",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Oku Sanda Olonumbi",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Nõla",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Oku Pindisiwa",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ocitumãlo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_uzn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_uzn.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Navigatsiya menyusini ochish",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Orqaga qaytish",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Ochiq",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Oʻz navbatida",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Oʻchirish",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Koʻproq",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Keyingi oy",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "O'tgan oy",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Keyingi sahifa",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Oldingi sahifa",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Birinchi sahifa",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Soʻnggi sahifa",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Menyu koʻrsatish",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Qovurish",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Pastki varaq",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Litsenziyalar",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Sahifa boʻyicha qatorlar:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "bekor qilish",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Oʻz navbatida",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Davom qiling",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Koʻchirilgan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Qitish",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Matnni skan qilish",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Yuqoriga qarang",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internetda qidirish",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bajarish",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Toʻgʻri",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Past",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hamma tanlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Litsenziyalarni koʻrish",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Bosh vazir",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Tanlangan soatlar",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Minotlarni tanlang",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Qutqarish",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Manunichalarni bekor qilish",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tanlangan yil",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Maʼlum boʻlmagan sana",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Maʼlum boʻlmagan muddatlar davomiyligi",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Kiritish sanasi",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Boshlangʻich sanasi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Soʻnggi kun",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Boshlangʻich sanasi $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Oxirgi sana $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Amalsiz sana format",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Amalga oshmagan sanalar doirasi",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Maqsaddan tashqari sanasi",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Qopish",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sana tanlang",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "TASHIRLANG",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Kalendar rejimiga oʻtish",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Kiritish sanasi usuliga oʻtish",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Vaqtni tanlash",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Vaqtni kiriting",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Soat",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Bir daqiqa",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Amalga oshmagan vaqt",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Oʻrnatish usuliga oʻtish",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Kiritish vaqt rejimini oʻzgartirish",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Imzolangan",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Hisoblarni yashirish",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Hisoblarni koʻrsatish",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigatsiya menyusi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menyu bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Oʻqilgan menyu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Suhbat",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ogohlantirish",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Qidirish",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Joriy sanasi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tanlangan sana",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Boshlang",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oxirigacha harakatlaning",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yuqoriga koʻtaring",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pastga koʻtaring",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Chapga oʻtish",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Oʻngga koʻch",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Yangilashtirish",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt grafisi",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Orqa tomoni",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "O'tish kanallari",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Yuqori kanal",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Nazorat",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Oʻchirish",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Oxiri",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Qutish",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Uyga",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kiritish",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komandasi",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Oynalar",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad qoʻshish",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad komasi",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad o'nlik",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad boʻlinishi",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad kirish",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad teng",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad koʻpaytiruvchi",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Chap",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren toʻgʻri",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad cheklovlari",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Sahifaga tushing",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Sahifa yuqoriga",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kuch",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Elektrni o'chirib tashlash",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Bosib chiqarish ekran",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Oʻchirishni oʻchirish",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Tanlang",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Oʻzgarishlar",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Kosmos",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_vec.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_vec.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menù de navigazion aperta",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Torno",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Chiara",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Chiuso",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Scarica",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Piu' de sto",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "El mese dopo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Messo precedente",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Next page",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Pagina precedente",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Prima pagina",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ultima pagina",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Mostra el menù",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrołare",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Sciagno de fondo",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "License",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Righe par pagina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Cancellar",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Chiuso",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Continua",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Scansionar el testo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "varda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca su la rete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Partage",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ok, ciao.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selesionar tuti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Visualizza le license",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "Primo Ministro",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Selezionare orari",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Selezionar minuti",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dispensa",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menù Dispensa",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Selezion de l'anno",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Data non specificata",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Intervallo de data non specificato",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Introdurre la data",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Data de inisio",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Data de fine",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Data de scominsiamento $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Data de fin $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format de data invalida",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Intervallo de data invalida",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Data fora de raggio",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Saver",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Selesion de data",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECTANTE de categoria",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Cambiar a modo calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Cambiar a modo data input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Selezionar el tempo",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Intra ora",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Ora",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Tempo invalido",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Cambiar a modo de marcà",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Cambiar a modo input time",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Firmado",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Nasconde i conti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Mostra i conti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menù de navigazion",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bareta menù",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menù in popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Aviso",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Cerca",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Data corrente",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Data selezionà",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Movimento par cominciar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Via verso la fine",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Stigni su",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Scender giù",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mover a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Moverse a destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Ristrada",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Spazio retrovisorio",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Caps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canałe verso el basso",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canałe su",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Controllo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Scarica",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Ejecutà",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Finì",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Fugio",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Home - El Paco",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Inserir",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Comando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Divide",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiplicare",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Sinistra",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren destra",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Sottotrazione di Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pagina verso el basso",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pagina su",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Potenza",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Dispone de energia",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Scarica Elenco",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scrollo Scalo",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Selezionar",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Scambio",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Spazio",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_war.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_war.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Abrihan nga navigasyon nga menu",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Balik",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Maaramon",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Hirani",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Pag-abo",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Dugang pa",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ha sunod nga bulan",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Naglabay nga bulan",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Sunod nga pakli",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Naglabay nga pakli",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Una nga pakli",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Kataposan nga pakli",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Ipakita an menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Pag-uhaw",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "An ubos nga lamesa",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Mga Lisensya",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Mga linya ha tagsa nga pahina:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Pag-abre",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Hirani",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Padayon",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Pag-scan hin teksto",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kitaa an imo mga mata.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pag-usisa ha Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Okay na",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Pag-ihap",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili han ngatanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Kitaa an mga lisensya",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pagpili hin mga oras",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pagpili hin mga minuto",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Pag-undang",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pag-iwas han Menyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Select Year",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Waray pa igsumat nga petsa",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Waray pa igsumat nga petsa",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "I-enter nga petsa",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Igintikang nga Dato",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Kataposan nga Dato",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start Date $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Kataposan nga petsa $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Waray-waray nga format han petsa",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Waray-waray nga kadamo han petsa",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "An petsa nga diri naabot",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Pagtipig",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pagpili hin petsa",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "HINPILIHAN an RANGO",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pag- switch ngadto ha mode nga kalendaryo",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pag- switch ngadto ha input date mode",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pagpili hin oras",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Pag-abot hin oras",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "An oras",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Waray-waray nga oras",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pag- switch ngadto ha dial mode",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pag- switch ngadto ha input time mode",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Nagpirma",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Iginpapahayag an mga account",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Ipakita an mga asoy",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Navigasyon nga menu",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu Bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Popup menu",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialogue",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "An Alert",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Pagpinamiling",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Yana nga petsa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ginpili nga petsa",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Pag-andam ha pagtikang",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pag-uswag tubtob ha kataposan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mag-uswag",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pag-aawas ha ubos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Lugod, lumakat ha wala.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mag-atubang ha tuo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Pagpahirani",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "An mga butang nga may kalabotan",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Back space",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Kaps Lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "An Kanal Ha Ibaw",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "An Upward Channel",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Pagkontrol",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Pag-abo",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Pag-iwas",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Kataposan",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Paglikay",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "An Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Balay",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Ibutang",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Mga bintana",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Nagbahinbahin an mga Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Higues",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Links",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ha Katulinan",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Subtract han Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Pag-iha an pakli",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Pag-up Page",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "An gahum",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pag-undang ha Koryente",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Print Screen",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Scroll Lock",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pagpili",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pag-usab",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "An Espesyal",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_wo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_wo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigation bi ubbi",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Di dëddu",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Jëfandikukat",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Jëfandikukat",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Déggal",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Yéen ci des",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Ci weer bu ñëw",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Jëfandikukat bi",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Xët wu ñëwe",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Xët bu jëkk",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Xët bu jëkk",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Xët mujj",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Show menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Sëriñ bi",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Xët yi ci suuf",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lisans yi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Xët yi ci wàll:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Di dëddu",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Jëfandikukat",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Soppite",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Jëf-jëf",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Sànk téks bi",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Xoollu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Xët ci web bi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Di bokk",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "OK",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Jëf",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Jëfalu yépp",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Xët yi lëkkalook wii",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Xët yi lëkkalook wii",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Sëriñ bi",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Di dëddu",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Jëfandikukat",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Jëf bu ñu tànn",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ndàqa bu ñu bañ a teg",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Diiwaanu bi ñu bañ a xam",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Diiwaan gi",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ndàkkaay bi",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ndàll bi mujj",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Ndaylu tàmbalee $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Ndayug muj $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Fëpp bu ñu bañ a jëfandikoo",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Diiwaanu taariik yu amul benn njariñ",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Nday bi ñu wàcc",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Sàmm",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Sëriñ bi",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "XELÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉÉ",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Jëf-xal ci modus kalandër",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Jëf-xal ci jëfekaay bi",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Jëfalu jamono",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Wàll jamono",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Jam",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minite",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Jamono bu amul kàttan",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jë",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jëf-jë",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Diine ci",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Sàmm ay kont",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Jëfalu ay kont",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigation bi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Menu bar bi",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu bu ñu tàbbal",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Xët yi ci wàll gi",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Xët yi ci wàll gi",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ndàll bi",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ndàqaat gi ñu tànn",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Jëfleen ci tàmbalee",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jëf-jëf",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Déggal ci kaw",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Daal ci suuf",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Déggal ca càmmoñ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Déggal ci ndeyjoor",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Fëppal",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alti",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Graaf bu alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Xët yi ci suuf",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Sëriñ bi",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Jëf-jëf gi",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Jëf-jëf gi",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Xët yi ci wàll gi",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Déggal",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Jëf-jëf",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Fekk",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Déggal",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ndokk",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Di dugal",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Jàngal",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Jëfandikukat",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad di séddoo",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Equal",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Multiply",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren àddu",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren ci kaw",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Xët ci suuf",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Xët yi ci kaw",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Nguuru",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Wàll bi",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Xët yi ci wàll",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ Sëriñ",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Jëfalu",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Jëfandikukat",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Xët yi ci wàll gi",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_xh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_xh.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Vula imenyu yokukhangela",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Ngasemva",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Cacisa",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Vala",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Cima",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Okungakumbi",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Kwinyanga ezayo",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Kwinyanga edlulileyo",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Iphepha elilandelayo",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Iphepha Elidlulileyo",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Iphepha lokuqala",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Iphepha lokugqibela",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Bonisa imenyu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "I-Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Iphepha elisezantsi",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Iilayisensi",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Imiqolo ngephepha ngalinye:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Rhoxisa",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Vala",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Qhubekeka",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Khuphela",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Sika",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Skena umbhalo",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Jonga phezulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Isetyenziswa ngokwemigqaliselo zichazwe akwi-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "KULUNGILE",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Cola",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha zonke",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Jonga iilayisensi",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "INkulumbuso",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Khetha iiyure",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Khetha imizuzu",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Ukugxotha",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Susa imenyu",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd / mm / yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Khetha unyaka",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Umhla ongachazwanga",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Uluhlu lomhla olungachazwanga",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Faka umhla",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Umhla wokuqalisa",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Umhla wokuphela",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ulungiselelo lomhla olungavunywanga",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Uluhlu lomhla olungavunywanga",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Umhla ongekho kuluhlu",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Gcina",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Khetha umhla",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "KHETHA ULUHLU",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Tshintshela kwinkqubo yekhalenda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Tshintshela kwinkqubo yolwazi lomhla wolwazi olungenisayo",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Khetha ixesha",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Faka ixesha",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Iyure",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Umzuzu",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Ixesha alivunywanga",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Tshintshela kwinkqubo yokucofa",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Tshintshela kwinkqubo yobuxesha lokungenisa",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Ityikitywe",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fihla ii-akhawunti",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Bonisa iiakhawunti",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Imenyu yokuhamba",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Umgca wemenyu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Imenyu yokukhetha okuvelayo",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Incoko yababini",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Isilumkiso",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ukukhangela",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Umhla okhoyo",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Umhla okhethiweyo",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Shenxisela ukuze uyiqale",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Shenxisela esiphelweni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yiya phezulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Yiya ezantsi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yiya ngasekhohlo",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hambisa ngasekunene",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Hlaziya",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Igrafu ye-Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Isithuba esingasemva",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "I-Caps lock",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Isiqhagamshelanisi esisezantsi",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Isiqhagamshelanisi phezulu",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Ulawulo",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Cima",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Khupha",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Isiphelo",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Ukubaleka",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "I-Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Ikhaya",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Faka",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "I-Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Umyalelo",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Iifestile",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Isitshixo seNum",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "I-Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "I-Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "I-Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "I-Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "I-Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "I-Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "I-Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "I-Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "I-Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "I-Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Yongeza i-Numpad",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "I-Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "I-Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Ukwahlula i-Numpad",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Ngenisa i-numpad",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "I-numpad ilingana",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Ipheda-phinda-phinda kwi-numpad",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "I-Numpad Paren ngasekhohlo",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "I-Numpad Paren ekunene",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Susa i-Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Iphepha elisezantsi",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Iphepha eliphezulu",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Amandla",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Ukucima umbane",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Shicilela isikrini",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Ukutshixa ukuhlisa unyusa",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Khetha",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Utshintsho",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Indawo",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_ydd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_ydd.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "עפענען נאַוויגאַציע מעניו",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "צוריק",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "קלאר",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "נאָענט",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "אויסמעקן",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "מער",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "קומענדיגע חודש",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "פֿריִערדיקע חודש",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "ווייַטער בלאַט",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "פֿריִערדיקע בלאַט",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "ערשטער בלאַט",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "לעצטע בלאַט",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "ווייַזן מעניו",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "סקראַמ",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "אונטערן בלאַט",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "דערלויבעניש",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "רייען פּער בלאַט:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "קאנסעלירן",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "נאָענט",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "פאָרזעצן",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "קאָפּע",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "שנייַדן",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "סקאַן טעקסט",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "קוק אַרויף",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "זוכן אין די וועב",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "טיילן",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "אָק, אָק.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "פּאַס",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "אויסקלייַבן אַלע",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "ווי צו זען לייסענסעס",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "פּרים",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "אויסקלייַבן שעה",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "אויסקלייַבן מינוט",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "באַפרייַען",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "אָפּזאָגן מעניו",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "דד/מם/ייייי",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "אויסדערוויילט יאָר",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "אומגעשטעלטע דאַטע",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "אומגעשטעלטע דאַטע קייט",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "אַרייַן דאַטע",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "אָנהייב דאַטע",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "סוף דאַטע",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "אָנהייב דאַטע $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "סוף דאַטע $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "ניט־באַקטיד דאַטע פֿאָרמאַט",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "ניט־באַקטידיק דאַטע־שטרײַך",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "דאַטע אויס פון קייט",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "שפּאָרן",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "אויסקלייַבן דאַטע",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "אויסקלייַבן ראַנג",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "באַשטימען צו קאַלענדאַר מאָדע",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "באַשטימען צו אַרייַנלייגן דאַטע מאָדע",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "אויסקלייַבן צייַט",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "אַרייַן צייַט",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "שעה",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "מינוט",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "ניט־באַקטידישע צייט",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "באַשטימען צו צאָלן מאָדע",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "באַשטימען צו אַרייַנלייגן צייַט מאָדע",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "אונטערגעשריבן",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "באַהאַלטן אַקאַונץ",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "ווייַזן אַקאַונץ",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "נאַוויגאַציע מעניו",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "מעניו בר",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "פּאַפּאַפּ מעניו",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "דיאַלאָג",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "ווארענונג",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "זוכן",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "קראַנט דאַטע",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "אויסגעקליבן דאַטע",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "מאַך צו אָנהייבן",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "מאַך צו סוף",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "רירן אַרויף",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "באַוועגונג אַראָפּ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "מאַך לינקס",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "מאַך רעכטס",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "רענש",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "אָלט",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt גראַף",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "באַקקספּאַס",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "קאַפּס קלאָק",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "קאנאַל אַראָפּ",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "קאנאַל אַרויף",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "קאָנטראָל",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "אויסמעקן",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "אַרויסגעוואָרפן",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "סוף",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "אַנטלויפן",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "פֿן",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "היים",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "אַרייַנלייגן",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "מעטה",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "קאָממאַנדע",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "פֿענצטער",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "נומ לאָק",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "נאַמפּאַד 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "נאַמפּאַד 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "נאַמפּאַד 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "נאַמפּאַד 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "נאַמפּאַד 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "נאַמפּאַד 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "נאַמפּאַד 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "נאַמפּאַד 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "נאַמפּאַד 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "נאַמפּאַד 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "נומפּאַד צוגעבן",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "נאַמפּאַד קאָמאַ",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "נאַמפּאַד דעסמאַיל",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "נאַמפּאַד צעטיילט",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "נאַמפּאַד אַרייַן",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "נאַמפּאַד גלייַך",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "נאַמפּאַד מאַלטיפּאַל",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "נאַמפּאַד פּאַרען לינקס",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "נאַמפּאַד פּאַרען רעכט",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "נאַמפּאַד סאַבסטראַקט",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "בלאַט אַראָפּ",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "בלאַט אַרויף",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "מאַכט",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "מאַכט אַוועק",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "דרוקן פאַרשטעלן",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "סראָלל לאָק",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "אויסקלייַבן",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "שיף",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "פּלאַץ",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_yo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_yo.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Ṣii akojọ aṣayan lilọ kiri",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Lẹ́hìn",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Kó o mọ́",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Tì",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Pa rẹ́",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Jù bẹ́ẹ̀ lọ",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Oṣù tí ó bọ̀",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Oṣù tí ó kọjá",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Ojú ewé tí ó kàn",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Oju-iwe ti tẹlẹ",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Oju-iwe akọkọ",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Oju-iwe ti o kẹhin",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Fi àtòjọ-ẹ̀yàn hàn",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Isalẹ dì",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Awọn iwe-aṣẹ",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Awọn rows fun oju-iwe kan:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Paá rẹ́",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Tì",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Tẹ̀síwájú",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Ṣẹ̀dà",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Gé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Àyẹ̀wò ọ̀rọ̀",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Wo òkè",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ṣawari oju-iwe ayelujara",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ó dáa",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Lẹ̀",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yan gbogbo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Wo awọn iwe-aṣẹ",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Yan awọn wakati",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Yan iṣẹju",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Dá wọn sílẹ̀",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Pa àtòjọ-ẹ̀yàn tì",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Yan odun",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Ọjọ́ tí a kò sọ ní pàtó",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Ọjọ́ tí a kò sọ ní pàtó",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Tẹ Ọjọ",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Ọjọ Ibẹrẹ",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Ipari Ọjọ",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Start date $fullDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "End date $fullDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Ọ̀nà kíkà ọjọ́ tí kò tọ́",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Déètì tí kò tọ́",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Ọjọ jade kuro ni ibiti o",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Fipamọ́",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Yan ọjọ",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "YAN RANGE",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Yipada si ipo kalẹnda",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Yipada si ipo ọjọ input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Yan akoko",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Tẹ akoko",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Wákàtí",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Ìṣẹ́jú",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Àkókò tí kò lẹ́sẹ̀ nílẹ̀",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Yipada si ipo dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Yipada si ipo akoko input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Wole sinu",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Fi àwọn àkátì pamọ́",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Fi àwọn àkáǹtì hàn",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Àtòjọ-ẹ̀yàn ìyíkiri",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Akojọ aṣayan bar",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Àtòjọ-ẹ̀yàn popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Ìtàkùrọ̀sọ",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ìtanijí",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Ṣàwárí",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Ọjọ́ tí ó wà lọ́wọ́lọ́",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Ọjọ́ tí a yàn",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Gbe lati bẹrẹ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gbe lọ si opin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gbé sókè",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gbé lọ sí ìsàlẹ̀",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Gbé apá òsì",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Gbé lọ sí ọ̀tún",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Sọdọ̀tun",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Alt Graph",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Backspace",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Botini ise leta nla",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Channel Down",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Channel Up",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Iṣakoso",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Pa rẹ́",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Ipari",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Sá àsálà",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Awọn ile-iṣẹ",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Kì í bọ̀ ọ́",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Àṣẹ",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Add",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Numpad Comma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad Pin",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Wọlé",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Dogba",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Isodipupo",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Left",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Ọtun",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Numpad Subtract",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Page Down",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Page Up",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Agbara",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Agbara Pa",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Tẹ iboju",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Yi lọ titiipa",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Yan",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Sún",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ààyè",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_yua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_yua.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Je'e menú navegación",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Paachil",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Je'ele'",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Muts'ik in",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Borrar",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Asab",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Láak' wináale'",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Wi'inal anterior",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Linki abas kaambal uláak'",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Linki abas kaambal anterior",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Yáax linki abas kaambal",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Ts'ook linki abas kaambal",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "We'esik menú",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Scrim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Sábana bajera",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "Tu yo'olal $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Licencias",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "T'o'ol tumen linki abas kaambal:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Xu'uls a meyaj",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Muts'ik in",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Táanil",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ch'ak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Escanear analte'o'",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Kaxan",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kaxant ti' le web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ts'aaj",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Ma'alo'ob",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Jats'ik",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar tuláakal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Wil licencias",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Seleccionar horario",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Seleccionar minutos",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Despedir",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menú Descartar",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd leti' mm leti' aaaa",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Seleccionar ja'aba'",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "K'iinil ma' especificada",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Intervalo fechas ma' especificado",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Introduzca u k'iinil",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "K'iinil u Chúunul",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "K'iinil final",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "K'iinil ku Chúunul $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "K'iinil u finalización $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Formato u k'iinil ma' válido",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Intervalo fechas ma' válido",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "K'iinil paach rango",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Salvar",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Seleccionar k'iinil",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "SELECCIONAR RANGO",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "K'ex le modo calendario",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "K'ex le modo k'iinil u yaan",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Seleccionar p'isib",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Introducir le p'isib",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "P'isib",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minuto",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "K'iin ma' válido",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "K'ex le modo marcación",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "K'ex le modo k'iin yaan",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Iniciado xoknáalo'obo'",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Taan in ta'akik ba'ax menta'abij",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "We'esik ba'ax menta'abij",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menú navegación",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Barra menú",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menú emergente",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Diálogo",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Ts'aaj",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Kaxan",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "K'iinil ma'alo'ob",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "K'iinil seleccionada",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Péeksik ti'al u chuumpajal",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Péeksik tak tu Xul",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Desplazar tak ka'anal",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Desplazar tak kaambal",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Péeksik a le izquierda",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Péeksik a le derecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Actualizar",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Gráfico Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Retroceso",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Block mayús",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Canalización tak kaambal",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Canalizar ti' ka'anal",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kaambalil yo'osal",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Borrar",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Expulsar",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Xu'upij",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Púuts'ul",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Wotoch",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Tak' t'aan",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Túuxtik",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Bloqueo numérico",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "(Teclado numérico). 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "(Teclado numérico). 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "(Teclado numérico). 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "(Teclado numérico). 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "(Teclado numérico). 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "(Teclado numérico). 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "(Teclado numérico). 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "(Teclado numérico). 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "(Teclado numérico). 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "(Teclado numérico). 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "(Teclado numérico). Ku ts'áabal",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "(Teclado numérico). Coma",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "(Teclado numérico). Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "(Teclado numérico). Ja'atsal",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "(Teclado numérico). Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "(Teclado numérico). beyli'obe'",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "(Teclado numérico). Multiplicar",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "(Teclado numérico). Paren Izquierda",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "(Teclado numérico). Paren k'abil",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "(Teclado numérico). Restar",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Av Pág",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Na'akal Pág",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "U",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Bo'otiktech",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Imprimir pantalla",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Bloqueo desplazamiento",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Téet",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Taak",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Kúuchil",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/material_zsm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zsm.arb
@@ -1,0 +1,641 @@
+{
+  "scriptCategory": "English-like",
+  "@scriptCategory": {
+    "description": "The name of the language's script category (see https://material.io/design/typography/language-support.html#language-categories-reference).",
+    "x-flutter-type": "scriptCategory"
+  },
+  "timeOfDayFormat": "HH:mm",
+  "@timeOfDayFormat": {
+    "description": "The ICU 'Short Time' pattern, such as 'HH:mm', 'h:mm a', 'H:mm'. See: http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_US",
+    "x-flutter-type": "icuShortTimePattern"
+  },
+  "openAppDrawerTooltip": "Menu navigasi terbuka",
+  "@openAppDrawerTooltip": {
+    "description": "The tooltip for the leading app bar menu (aka 'hamburger') button."
+  },
+  "backButtonTooltip": "Kembali",
+  "@backButtonTooltip": {
+    "description": "The tooltip for the back button, which closes the current page and returns to the previous one."
+  },
+  "clearButtonTooltip": "Jelas",
+  "@clearButtonTooltip": {
+    "description": "The tooltip for the button that clears the text input on the search view."
+  },
+  "closeButtonTooltip": "Dekat",
+  "@closeButtonTooltip": {
+    "description": "The tooltip for the close button, which closes the current page and returns to the previous one."
+  },
+  "deleteButtonTooltip": "Hapus",
+  "@deleteButtonTooltip": {
+    "description": "The tooltip for the delete button of chips."
+  },
+  "moreButtonTooltip": "Lebih banyak",
+  "@moreButtonTooltip": {
+    "description": "The tooltip for the more button in the text selection menu, which shows the overflowing menu items."
+  },
+  "nextMonthTooltip": "Bulan depan.",
+  "@nextMonthTooltip": {
+    "description": "The tooltip for the month picker's 'next month' button."
+  },
+  "previousMonthTooltip": "Bulan sebelumnya",
+  "@previousMonthTooltip": {
+    "description": "The tooltip for the month picker's 'previous month' button."
+  },
+  "nextPageTooltip": "Halaman seterusnya",
+  "@nextPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the next page of a paginated data table."
+  },
+  "previousPageTooltip": "Halaman sebelumnya",
+  "@previousPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the previous page of a paginated data table."
+  },
+  "firstPageTooltip": "Halaman pertama",
+  "@firstPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the first page of a paginated data table."
+  },
+  "lastPageTooltip": "Halaman terakhir",
+  "@lastPageTooltip": {
+    "description": "The tooltip for the button that sends the user to the last page of a paginated data table."
+  },
+  "showMenuTooltip": "Tunjukkan menu",
+  "@showMenuTooltip": {
+    "description": "The tooltip for the button that shows a popup menu."
+  },
+  "scrimLabel": "Skim",
+  "@scrimLabel": {
+    "description": "The label for the scrim rendered underneath the content of a bottom sheet (used as the 'modalRouteContentName' of the 'scrimOnTapHint' message)."
+  },
+  "bottomSheetLabel": "Lembaran bawah",
+  "@bottomSheetLabel": {
+    "description": "The label for a BottomSheet."
+  },
+  "scrimOnTapHint": "Close $modalRouteContentName",
+  "@scrimOnTapHint": {
+    "description": "The onTapHint for the scrim rendered underneath the content of a modal route (especially a bottom sheet) which users can tap to dismiss the content.",
+    "parameters": "modalRouteContentName"
+  },
+  "aboutListTileTitle": "About $applicationName",
+  "@aboutListTileTitle": {
+    "description": "The default title for the drawer item that shows an about page for the application. The value of $applicationName is the name of the application, like GMail or Chrome.",
+    "parameters": "applicationName"
+  },
+  "licensesPageTitle": "Lesen",
+  "@licensesPageTitle": {
+    "description": "The title for the Flutter licenses page."
+  },
+  "licensesPackageDetailTextZero": "No licenses",
+  "@licensesPackageDetailTextZero": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOne": "1 license",
+  "@licensesPackageDetailTextOne": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextTwo": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextFew": {
+    "optional": true
+  },
+  "@licensesPackageDetailTextMany": {
+    "optional": true
+  },
+  "licensesPackageDetailTextOther": "$licenseCount licenses",
+  "@licensesPackageDetailText": {
+    "description": "The subtitle and detail text for a package displayed on the Flutter licenses page. The value of $licenseCount is an integer which indicates the number of licenses the package has.",
+    "plural": "licenseCount"
+  },
+  "pageRowsInfoTitle": "$firstRow–$lastRow of $rowCount",
+  "@pageRowsInfoTitle": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is known. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "pageRowsInfoTitleApproximate": "$firstRow–$lastRow of about $rowCount",
+  "@pageRowsInfoTitleApproximate": {
+    "description": "The text shown in the footer of a paginated data table when the exact overall row count is unknown. This message describes an integer range where $firstRow is the index of the start of the range, $lastRow is the index of the end of the range, and $rowCount is the limit of the range. All values are greater than or equal to zero.",
+    "parameters": "firstRow, lastRow, rowCount"
+  },
+  "rowsPerPageTitle": "Barisan setiap halaman:",
+  "@rowsPerPageTitle": {
+    "description": "The caption for the drop-down button on a paginated data table's footer that allows the user to control the number of rows of data per page of the table."
+  },
+  "tabLabel": "Tab $tabIndex of $tabCount",
+  "@tabLabel": {
+    "description": "The accessibility label used on a tab. This message describes the index of the selected tab and how many tabs there are, e.g. 'Tab 1 of 2'. All values are greater than or equal to one.",
+    "parameters": "tabIndex, tabCount"
+  },
+  "selectedRowCountTitleZero": "No items selected",
+  "@selectedRowCountTitleZero": {
+    "optional": true
+  },
+  "selectedRowCountTitleOne": "1 item selected",
+  "@selectedRowCountTitleOne": {
+    "optional": true
+  },
+  "@selectedRowCountTitleTwo": {
+    "optional": true
+  },
+  "@selectedRowCountTitleFew": {
+    "optional": true
+  },
+  "@selectedRowCountTitleMany": {
+    "optional": true
+  },
+  "selectedRowCountTitleOther": "$selectedRowCount items selected",
+  "@selectedRowCountTitle": {
+    "description": "The title for the header of a paginated data table when the user is selecting rows. The value of $selectedRowCount is an integer which indicates the number of data table row elements that have been selected.",
+    "plural": "selectedRowCount"
+  },
+  "cancelButtonLabel": "Batalkan",
+  "@cancelButtonLabel": {
+    "description": "The label for cancel buttons and menu items."
+  },
+  "closeButtonLabel": "Dekat",
+  "@closeButtonLabel": {
+    "description": "The label for close buttons and menu items."
+  },
+  "continueButtonLabel": "Berlanjut",
+  "@continueButtonLabel": {
+    "description": "The label for continue buttons and menu items."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "scanTextButtonLabel": "Mencari teks",
+  "@scanTextButtonLabel": {
+    "description": "The label for scan text buttons and menu items for starting the insertion of text via OCR."
+  },
+  "lookUpButtonLabel": "Lihat ke atas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Berkongsi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "okButtonLabel": "Baiklah.",
+  "@okButtonLabel": {
+    "description": "The label for OK buttons and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih semua",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "viewLicensesButtonLabel": "Lihat lesen",
+  "@viewLicensesButtonLabel": {
+    "description": "The label for the button in the about box that leads the user to a list of all licenses that apply to the application."
+  },
+  "anteMeridiemAbbreviation": "AM",
+  "@anteMeridiemAbbreviation": {
+    "description": "The abbreviation for ante meridiem (before noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "postMeridiemAbbreviation": "PM",
+  "@postMeridiemAbbreviation": {
+    "description": "The abbreviation for post meridiem (after noon) shown in the time picker. Translations for this abbreviation will only be provided for locales that support it."
+  },
+  "timePickerHourModeAnnouncement": "Pilih jam",
+  "@timePickerHourModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to hour mode."
+  },
+  "timePickerMinuteModeAnnouncement": "Pilih minit",
+  "@timePickerMinuteModeAnnouncement": {
+    "description": "The audio announcement made when the time picker dialog is set to minute mode."
+  },
+  "modalBarrierDismissLabel": "Putus",
+  "@modalBarrierDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for a modal barrier to indicate that a tap dismisses the barrier. A modal barrier can for example be found behind a alert or popup to block user interaction with elements behind it."
+  },
+  "menuDismissLabel": "Menu menolak",
+  "@menuDismissLabel": {
+    "description": "Label read out by accessibility tools (TalkBack or VoiceOver) for the area around a menu to indicate that a tap dismisses the menu."
+  },
+  "dateSeparator": "/",
+  "@dateSeparator": {
+    "description": "The character string used to separate the parts of a compact date format. For example 'mm/dd/yyyy' has a separator of '/'."
+  },
+  "dateHelpText": "dd/mm/yyyyyy",
+  "@dateHelpText": {
+    "description": "The help text used on an empty text input date field to indicate the date format being asked for."
+  },
+  "selectYearSemanticsLabel": "Tahun yang dipilih",
+  "@selectYearSemanticsLabel": {
+    "description": "The accessibility label used to announce when the user has entered the year selection mode in the date picker."
+  },
+  "unspecifiedDate": "Tarikh yang tidak ditentukan",
+  "@unspecifiedDate": {
+    "description": "The label used to indicate a date that has not been entered or selected in the date picker."
+  },
+  "unspecifiedDateRange": "Jangka masa yang tidak ditentukan",
+  "@unspecifiedDateRange": {
+    "description": "The label used to indicate a date range that has not been entered or selected in the date range picker."
+  },
+  "dateInputLabel": "Masukkan Tarikh",
+  "@dateInputLabel": {
+    "description": "The label used to describe the input text field used in the date picker."
+  },
+  "dateRangeStartLabel": "Tarikh permulaan",
+  "@dateRangeStartLabel": {
+    "description": "The label used to describe the starting date input text field used in the date range picker."
+  },
+  "dateRangeEndLabel": "Tarikh akhir",
+  "@dateRangeEndLabel": {
+    "description": "The label used to describe the ending date input text field used in the date range picker."
+  },
+  "dateRangeStartDateSemanticLabel": "Tarikh permulaan $formattedDate",
+  "@dateRangeStartDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected start date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "dateRangeEndDateSemanticLabel": "Tarikh akhir $formattedDate",
+  "@dateRangeEndDateSemanticLabel": {
+    "description": "Accessibility announcement that is used when the user navigates to the selected end date in the date range picker.",
+    "parameters": "$fullDate"
+  },
+  "invalidDateFormatLabel": "Format tarikh yang tidak sah",
+  "@invalidDateFormatLabel": {
+    "description": "Error message displayed to the user when they have entered a text string in an input field of the date picker that is not in a valid date format."
+  },
+  "invalidDateRangeLabel": "Julat tarikh yang tidak sah",
+  "@invalidDateRangeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid date range in the input fields of the date range picker."
+  },
+  "dateOutOfRangeLabel": "Tarikh di luar jangkauan",
+  "@dateOutOfRangeLabel": {
+    "description": "Error message displayed to the user when they have entered a date that is outside the valid range for the date picker."
+  },
+  "saveButtonLabel": "Simpan",
+  "@saveButtonLabel": {
+    "description": "Label for a 'Save' button used in full screen dialogs."
+  },
+  "datePickerHelpText": "Pilih tarikh",
+  "@datePickerHelpText": {
+    "description": "Label used in the header of the date picker dialog"
+  },
+  "dateRangePickerHelpText": "PILIH RANG",
+  "@dateRangePickerHelpText": {
+    "description": "Label used in the header of the date range picker dialog."
+  },
+  "calendarModeButtonLabel": "Pergeseran ke mod kalendar",
+  "@calendarModeButtonLabel": {
+    "description": "Tooltip used for the calendar mode button of the date pickers."
+  },
+  "inputDateModeButtonLabel": "Pergeseran ke mod tarikh input",
+  "@inputDateModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the date pickers."
+  },
+  "timePickerDialHelpText": "Pilih masa",
+  "@timePickerDialHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the clock dial to select a time."
+  },
+  "timePickerInputHelpText": "Masukkan masa",
+  "@timePickerInputHelpText": {
+    "description": "Label used in the header of the time picker dialog when using the text input to enter a time."
+  },
+  "timePickerHourLabel": "Jam",
+  "@timePickerHourLabel": {
+    "description": "Label indicating the text field for inputting an hour when entering a time."
+  },
+  "timePickerMinuteLabel": "Minit",
+  "@timePickerMinuteLabel": {
+    "description": "Label indicating the text field for inputting a minute when entering a time."
+  },
+  "invalidTimeLabel": "Masa tidak sah",
+  "@invalidTimeLabel": {
+    "description": "Error message displayed to the user when they have entered an invalid time."
+  },
+  "dialModeButtonLabel": "Pergeseran ke mod dial",
+  "@dialModeButtonLabel": {
+    "description": "Tooltip used for the clock dial mode button of the time picker."
+  },
+  "inputTimeModeButtonLabel": "Pergeseran ke mod masa input",
+  "@inputTimeModeButtonLabel": {
+    "description": "Tooltip used for the text input mode button of the time picker."
+  },
+  "signedInLabel": "Difirmankan",
+  "@signedInLabel": {
+    "description": "The accessibility label used to indicate which account is signed in, in a UserAccountsDrawerHeader, when the accessibility user navigates the UI. This phrase serves as an adjective with respect to the user. The phrase indicates that the user is currently signed in."
+  },
+  "hideAccountsLabel": "Sembunyikan akaun",
+  "@hideAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that hides the list of accounts."
+  },
+  "showAccountsLabel": "Tunjukkan akaun",
+  "@showAccountsLabel": {
+    "description": "The accessibility label used for the button on a UserAccountsDrawerHeader that shows the list of accounts."
+  },
+  "drawerLabel": "Menu navigasi",
+  "@drawerLabel": {
+    "description": "The audio announcement made when the Drawer is opened."
+  },
+  "menuBarMenuLabel": "Bar menu",
+  "@menuBarMenuLabel": {
+    "description": "The audio announcement made when a MenuBarMenu is opened."
+  },
+  "popupMenuLabel": "Menu Popup",
+  "@popupMenuLabel": {
+    "description": "The audio announcement made when a PopupMenu is opened."
+  },
+  "dialogLabel": "Dialog",
+  "@dialogLabel": {
+    "description": "The audio announcement made when a Dialog is opened."
+  },
+  "alertDialogLabel": "Peringatan",
+  "@alertDialogLabel": {
+    "description": "The audio announcement made when an AlertDialog is opened."
+  },
+  "searchFieldLabel": "Cari",
+  "@searchFieldLabel": {
+    "description": "Label indicating that a text field is a search field. This will be used as a hint text in the text field."
+  },
+  "currentDateLabel": "Tarikh semasa",
+  "@currentDateLabel": {
+    "description": "Label indicating that the focused date is the current date."
+  },
+  "selectedDateLabel": "Tarikh yang dipilih",
+  "@selectedDateLabel": {
+    "description": "The semantics label to describe the selected date in the calendar picker invoked using [showDatePicker]."
+  },
+  "reorderItemToStart": "Bergerak untuk bermula",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Bergerak ke hujung",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah ke atas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gerak ke bawah",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah kiri",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bergerak kanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "expandedIconTapHint": "Collapse",
+  "@expandedIconTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "collapsedIconTapHint": "Expand",
+  "@collapsedIconTapHint": {
+    "description": "The verb which describes what happens when a collapsed ExpandIcon toggle button is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedHint": "double tap to collapse",
+  "@expansionTileExpandedHint": {
+    "description": "The verb which describes the tap action on an expanded ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the collapsedHint string which describes the action to be performed on an expanded ExpansionTile. In the case of US english, this would be 'Expanded\n double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedHint": "double tap to expand",
+  "@expansionTileCollapsedHint": {
+    "description": "The verb which describes the tap action on a collapsed ExpansionTile. This is used by VoiceOver on iOS and macOS. This string will be appended to the expandedHint string which describes the action to be performed on a collapsed ExpansionTile. In the case of US english, this would be 'Collapsed\n double tap to expand.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileExpandedTapHint": "Collapse",
+  "@expansionTileExpandedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to collapse.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expansionTileCollapsedTapHint": "Expand for more details",
+  "@expansionTileCollapsedTapHint": {
+    "description": "The verb which describes what happens when an expanded ExpansionTile is pressed. This is used by TalkBack on Android to replace the default hint on the accessibility action. The verb will be concatenated with a prefix string which describes how to perform the action, which by default is 'double tap to activate'. In the case of US english, this would be 'double tap to expand for more details.' The exact phrasing of the hint will vary based on locale"
+  },
+  "expandedHint": "Collapsed",
+  "@expandedHint": {
+    "description": "The verb which describes the ExpansionTile state when an expanded ExpansionTile is pressed."
+  },
+  "collapsedHint": "Expanded",
+  "@collapsedHint": {
+    "description": "The verb which describes the ExpansionTile state when a collapsed ExpansionTile is pressed."
+  },
+  "remainingTextFieldCharacterCountZero": "No characters remaining",
+  "@remainingTextFieldCharacterCountZero": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOne": "1 character remaining",
+  "@remainingTextFieldCharacterCountOne": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountTwo": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountFew": {
+    "optional": true
+  },
+  "@remainingTextFieldCharacterCountMany": {
+    "optional": true
+  },
+  "remainingTextFieldCharacterCountOther": "$remainingCount characters remaining",
+  "@remainingTextFieldCharacterCount": {
+    "description": "The label for the TextField's character counter. remainingCharacters is a integer representing how many more characters the user can type into the text field before using up a given budget. All values are greater than or equal to zero.",
+    "plural": "remainingCount"
+  },
+  "refreshIndicatorSemanticLabel": "Pemberikan",
+  "@refreshIndicatorSemanticLabel": {
+    "description": "The verb which describes what happens when a RefreshIndicator is displayed on screen.  This is used by TalkBack on Android to announce that a refresh is happening."
+  },
+  "keyboardKeyAlt": "Alt",
+  "@keyboardKeyAlt": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Alt' (alt) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyAltGraph": "Grafik Alt",
+  "@keyboardKeyAltGraph": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'AltGr' (altGraph) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyBackspace": "Ruang belakang",
+  "@keyboardKeyBackspace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Backspace' (backspace) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyCapsLock": "Tutup Kap",
+  "@keyboardKeyCapsLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Caps Lock' (capsLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelDown": "Saluran ke bawah",
+  "@keyboardKeyChannelDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Down' (channelDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyChannelUp": "Saluran ke atas",
+  "@keyboardKeyChannelUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Channel Up' (channelUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyControl": "Kawalan",
+  "@keyboardKeyControl": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Ctrl' (control) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyDelete": "Hapus",
+  "@keyboardKeyDelete": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Del' (delete) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEject": "Eject",
+  "@keyboardKeyEject": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Eject' (eject) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEnd": "Akhir",
+  "@keyboardKeyEnd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'End' (end) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyEscape": "Menyerang",
+  "@keyboardKeyEscape": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Esc' (escape) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyFn": "Fn",
+  "@keyboardKeyFn": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Fn' (fn) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyHome": "Rumah",
+  "@keyboardKeyHome": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Home' (home) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyInsert": "Masukan",
+  "@keyboardKeyInsert": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Insert' (insert) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyMeta": "Meta",
+  "@keyboardKeyMeta": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Meta' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on non-macOS and non-Windows hosts.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on non-macOS keyboards."
+  },
+  "keyboardKeyMetaMacOs": "Komando",
+  "@keyboardKeyMetaMacOs": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Command' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a macOS host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a ⌘ symbol on macOS keyboards."
+  },
+  "keyboardKeyMetaWindows": "Windows",
+  "@keyboardKeyMetaWindows": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Windows' (meta) to be displayed in an application menu next to the menu item that this keyboard key triggers on a Windows host.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This key is usually designated by a Windows logo on keyboards."
+  },
+  "keyboardKeyNumLock": "Num Lock",
+  "@keyboardKeyNumLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Lock' (numLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyNumpad1": "Numpad 1",
+  "@keyboardKeyNumpad1": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 1' (numpad1) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '1', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad2": "Numpad 2",
+  "@keyboardKeyNumpad2": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 2' (numpad2) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '2', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad3": "Numpad 3",
+  "@keyboardKeyNumpad3": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 3' (numpad3) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '3', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad4": "Numpad 4",
+  "@keyboardKeyNumpad4": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 4' (numpad4) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '4', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad5": "Numpad 5",
+  "@keyboardKeyNumpad5": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 5' (numpad5) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '5', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad6": "Numpad 6",
+  "@keyboardKeyNumpad6": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 6' (numpad6) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '6', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad7": "Numpad 7",
+  "@keyboardKeyNumpad7": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 7' (numpad7) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '7', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad8": "Numpad 8",
+  "@keyboardKeyNumpad8": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 8' (numpad8) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '8', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad9": "Numpad 9",
+  "@keyboardKeyNumpad9": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 9' (numpad9) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '9', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpad0": "Numpad 0",
+  "@keyboardKeyNumpad0": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num 0' (numpad0) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular number '0', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadAdd": "Numpad Tambah",
+  "@keyboardKeyNumpadAdd": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num +' (numpadAdd) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '+', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadComma": "Komma Numpad",
+  "@keyboardKeyNumpadComma": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num ,' (numpadComma) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ',', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDecimal": "Numpad Decimal",
+  "@keyboardKeyNumpadDecimal": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num .' (numpadDecimal) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '.', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadDivide": "Numpad membahagikan",
+  "@keyboardKeyNumpadDivide": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num /' (numpadDivide) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '/', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEnter": "Numpad Enter",
+  "@keyboardKeyNumpadEnter": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num Enter' (numpadEnter) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular Enter key, but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadEqual": "Numpad Sama",
+  "@keyboardKeyNumpadEqual": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num =' (numpadEqual) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '=', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadMultiply": "Numpad Berganda",
+  "@keyboardKeyNumpadMultiply": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num *' (numpadMultiply) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '*', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenLeft": "Numpad Paren Kiri",
+  "@keyboardKeyNumpadParenLeft": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num (' (numpadParenLeft) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '(', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadParenRight": "Numpad Paren Kanan",
+  "@keyboardKeyNumpadParenRight": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num )' (numpadParenRight) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular ')', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyNumpadSubtract": "Pengurangan Numpad",
+  "@keyboardKeyNumpadSubtract": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Num -' (numpadSubtract) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is a regular '-', but on the number pad, accessed with the NumLock on."
+  },
+  "keyboardKeyPageDown": "Halaman bawah",
+  "@keyboardKeyPageDown": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgDown' (pageDown) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPageUp": "Halaman ke atas",
+  "@keyboardKeyPageUp": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'PgUp' (pageUp) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyPower": "Kuasa",
+  "@keyboardKeyPower": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power' (power) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns the computer off and on."
+  },
+  "keyboardKeyPowerOff": "Pemanas",
+  "@keyboardKeyPowerOff": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Power Off' (powerOff) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. The key typically turns off the computer."
+  },
+  "keyboardKeyPrintScreen": "Mencetak skrin",
+  "@keyboardKeyPrintScreen": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Print Screen' (printScreen) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyScrollLock": "Mengunci Pergulung",
+  "@keyboardKeyScrollLock": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Scroll Lock' (scrollLock) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeySelect": "Pilih",
+  "@keyboardKeySelect": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Select' (select) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale."
+  },
+  "keyboardKeyShift": "Pergantian",
+  "@keyboardKeyShift": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Shift' (shift) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the shift modifier key on the left or right sides of the keyboard."
+  },
+  "keyboardKeySpace": "Ruang",
+  "@keyboardKeySpace": {
+    "description": "Part of a keyboard shortcut label for the keyboard key 'Space' (space) to be displayed in an application menu next to the menu item that this keyboard key triggers.  Should be as short as possible, using standard computer keyboard symbols/terminology for the key in the locale. This is the space bar key."
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_acm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_acm.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تحرك إلى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزلوا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرّك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطْفُ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "المشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_acq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_acq.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل الى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل للأسفل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_aeb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_aeb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "تمشي للبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تمشي لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "إتحركوا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزلوا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تمشي لليسار",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تمشي يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "كُنْتِ تَمْرِي",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطِّطْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "إطلعو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "فَتِّشْ فِي الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "شُرْكُوا",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "فستة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختروا الكل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_als.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_als.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Të lëvizësh për të filluar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Shko deri në fund",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ngrihu lart.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Shko poshtë.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Shko në të majtë",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Shko drejt.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopje",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Të prerë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Shiko lart.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kërkoni në internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ndarja",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zgjidh të gjitha",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_apc.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_apc.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "حرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرك لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "إتحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "حرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "حرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نطاق",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "البصمة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ars.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ars.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "انتقل لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل الى النهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "انزل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "انتقل يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ابحث فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ary.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ary.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "تحرك لبدء",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "تمشي لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "تحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "خلي لخلا",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "تحرك لليسار",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "تحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "النسخة",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خَطّْ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "بحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "الشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "الصبغ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_arz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_arz.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "حرك ليبدأ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "انتقل لنهاية",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "اتحرك فوق",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "اتحرك أسفل",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "اتحرك يسارا",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "اتحرك يمين",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نُسُخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "خفض",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "شوف فوق",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ابحث في الويب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "مشاركة",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "لفة",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "اختر كل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ayr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ayr.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Jaltañ qalltañ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Qhipa tuqir sarnaqañ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "¡Jach'a sarnaqañani!",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Jank'aki sarañani",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kupi tuqir sarnaqañ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kupi tuqir saram",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kunjamtï amuyki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Q'ipisiña",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Amuyasipxam",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internetan thaqhapjjam",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Mayt'aña",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Jisk'a ch'uqt'añ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taqpach ajllipxam",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_azb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_azb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "حرکت ائدک",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "آخيريندا حرکت ائده",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "حرکت ائده سن",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "آشاغي حرکت ائده",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "سول طرفه حرکت ائده",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ساغ طرفه حرکت ائده",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نُسخ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "کَس",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "يوخاري باخ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "اینترنتده آختار",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "بؤلوم",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هامیسی سئچیب",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_azj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_azj.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Başlamaq üçün hərəkət edin",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Sonuna qədər hərəkət edin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ayağa qalx.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Aşağı gedin.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Soldan hərəkət edin.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sağ hərəkət edin.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "İmzala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kəsmək",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Qula bax.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "İnternetdə axtarış aparın",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Qovşaq",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünləri seçin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ba.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ba.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Башҡа күсереү",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Аҙағынаса күсереү",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өҫкә күтәрелеү",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Аҫҡа күсереү",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Һулға күсереү",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Уңға күсереү",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Күсермәһе",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ҡырҡып алыу",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Өҫкә ҡарағыҙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Поиск в сети",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Уртаҡлашыу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бөтәһен дә һайлап алыу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_bho.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_bho.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "शुरू करे खातिर चाल चलल जाला ।",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "खतम होखे के चाल चलल जाला ।",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर बढ़ल जाला ।",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे चलि जाई ।",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बायाँ चलि जाई ।",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाईं ओर बढ़ीं ।",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "काटल जाला ।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ऊपर देखीं ।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "जाल खोज लीं ।",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चयन करीं",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_bo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_bo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "འགོ་འཛུགས་སར་སྤོ་དགོས།",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "མཐར་ཐུག་གི་གནས་སུ་སྤོ་དགོས།",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ཡར་འཕགས་པ།",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "མར་སྤོས་པ།",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "གཡོན་ཕྱོགས་སུ་གནས་སྤོ་བ།",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "གཡས་ཕྱོགས་སུ་སྤོ་བ།",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "འདྲ་བཟོ་བྱས་པ།",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "གཏུབ་པ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "㚧།",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "འཚོལ་ཞིབ་Webཞེས་པ།",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "མཉམ་དུ་ལོངས་སུ་སྤྱོད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "རབ་རིབ་ཏུ་གྱུར",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ཡོངས་རྫོགས་འདེམས་བསྐོ་བྱ་དགོས",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_brx.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_brx.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "जागायजेन्नो थां।",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "जोबनायाव थां।",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "गोजौआव थां।",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "गाहायाव थां।",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "आगसिथिं थां।",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "आगदाथिं थां।",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "कपि खालाम",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "दान।",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "नाय।",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबखौ नागिर",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "सेयार खालाम",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "गासैखौबो सायख'",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ceb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ceb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Paglihok aron magsugod",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Paglihok hangtod sa kataposan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pag-uswag",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pag-adto sa ubos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pag-adto sa wala",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Paglihok sa tuo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tan-awa sa itaas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pagpangita sa Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili sa tanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_cjk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_cjk.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Kuyile nakuzata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kuhambakana nakuheta kuhambu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nyingilililemo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Nyonga mwilu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nyonga ku chishina",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nyonga ku chishina",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kuzachisa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kuchima",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Talenu mwakwoloka",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sokola muInternet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kuhanjikanga",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Kukutwa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Solola yeswe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ckb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ckb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "بزانە بۆ دەستپێک",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "بەرەو کۆتایی",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "بەرەو سەرەوە بڕۆ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "دابەزێنە خوارەوە",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "بچۆ چەپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "بگەڕێ ڕاست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "سەیری بەرز بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "گەڕان لە تۆڕەکەدا",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "دابەشکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "پست",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەمووان هەڵبژێرە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_crh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_crh.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Başlamaq içün areket et",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Soñuna qadar areket et",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yüklenip çıq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Aşağıya ket",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Solğa ket",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sağğa ket",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopiyalanğan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kesilgen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Yukarğa baq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "İnternette qıdıruv",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Paylaşmaq",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pasta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Bütünlerini sayla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_dik.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_dik.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Lɔɔr tueŋ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Lëk në thök",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Lɔɔr nhial",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Päl piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pälkë lɔŋ cam",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yiɛ̈ɛ̈k cuëëc",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Lɔnë",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ku döt nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kuen në wɛ̈t yic",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Loi käpuɔth",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pël ëlök",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Päm ëbën",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_doi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_doi.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "शुरू करने आस्तै जाओ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत च जाओ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उप्पर जाओ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "खʼल्ल जाओ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "खब्बी बक्खी जाओ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "सज्जी बक्खी जाओ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटोई देओ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "दिक्खो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वैब तुप्पो",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "सांझा करो",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभनें दा चनाऽ करो",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_dsb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_dsb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "K startoju pśesunuś.",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Na kóńc pśesunuś.",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Na kśebjati spóraś.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Dołoj pśesunuś.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nalěwo pśesunuś nalěwo.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Napšawo gibaś.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopěrowaś",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Rězaś",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Zabitki",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pśeglědajśo web web.",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Lichotne zapódaś.",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Kleister",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wšykne wuzwóliś.",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_dv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_dv.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ފަށަން ޖެހޭ ފިޔަވަޅެއް",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ނިމުމަކަށް ގެނައުމަށް ކުރާ މަސައްކަތް",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "މައްޗަށް ދާށެވެ.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ތިރިއަށް ދާށެވެ.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ވާތް ފަރާތަށް މޫވް ކުރުން",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ކަނާތް ފަރާތަށް ދާށެވެ.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ކޮޕީ ކުރޭ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ކަނޑާލުން",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "އިސްއުފުލާ ބަލާށެވެ.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ވެބް ސާޗް ކުރޭ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ޙިއްޞާ ކުރުން",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "ޕޭސްޓް ކުރުން",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ހުރިހާ އެންމެން އިޚްތިޔާރު ކުރޭ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_dyu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_dyu.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Aw ye taga ka baara daminɛ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ka taga a laban",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Aw ye yɛlɛ ka taga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "I ka taga duguma",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "I ka taga numan fɛ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "I ka taga kinibolo fɛ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "O sɛbɛ nin sɛbɛra",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ka tigɛ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "I ka filɛli kɛ sanfɛ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "N'i ye mɔgɔ dɔ ye, a ɲini o yɔrɔ la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ka dɔ fara a kan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Fanga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Aw ye bɛɛ sugandi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_dzo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_dzo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "འགོ་བཙུགས་ནིའི་དོན་ལུ་སྤོ་འགྱོ་",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "མཐའ་མཇུག་ལུ་འགྱོ་ནི་",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ཡར་འགྱོ་ནི་",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "མར་འགྱོ་ནི་",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "གཡག་ལུ་སྤོ་",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "གཡས་ཁ་ཐུག་ལུ་སྤོ་",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ཡིག་སྣོད་",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "བཅད་བཟོ།",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ཡར་བལྟ་",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ཝིང་ནང་ལུ་འཚོལ་",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "བརྗེ་སོར་འབད་",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "སྦྱོར་སྣོད་",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ག་ར་ གདམ་ཁ་རྐྱབས་",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ee.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ee.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ʋu asi ɖo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ʋu yi nuwuwu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ʋu ɖe dzi",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ʋu ɖe anyi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi ɖusime",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ʋu ɖusime",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Woɖe wo ɖe go",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wotso",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kpɔ dzi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Di Internet dzi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wona Nuwo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Nu siwo wotsɔna doa gbe",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tia nu siwo katã",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_epo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_epo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Moviĝas por komenci",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Movi al fino",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pli supren",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Movu malsupren",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Moviĝu maldekstren",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Movu dekstren",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopio",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tranĉita",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Rigardu supren",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Serĉu en la reto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Dividi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pesto",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Elektu ĉiujn",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_fj.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_fj.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Toso me tekivu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Toso ki na itinitini",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Toso cake",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Toso sobu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Toso imawi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Toso imatau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Lavetaki",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Musu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Rai cake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Vakasaqaqara ena mataveilawa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wasea",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Vakabira",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Digitaka kece",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_fo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_fo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Flyt teg fyri at byrja",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Flyt til enda",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Flyt teg upp",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Flyt teg niður",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Flyt/Flytið teg/tykkum til vin",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Flyt/Flytið teg/tykkum til høg",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopiera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skera",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Hygg/Hyggið upp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Leita á netinum",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Líma inn",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velja alt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_fon.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_fon.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mi jɛ nukɔn",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Zɛ̀ yì yì yì",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Dàn yì nukɔn",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Zɛ̀n yì jɛ̀n",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi ɖisíxwé",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Dǒ ɖisí",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Wǔxwɛ́",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wǔ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kpɔ́n jǐ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nɔ́ xo ɖò Internet ɔ mɛ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wě nǔ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Wǔvɔ́",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi bǐ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_fur.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_fur.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Movi par scomençâ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Passi fintremai",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si movi sù",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si movi di là",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si spostin a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si movi a drete",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglât",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Cjale sù",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cîr su la rêt",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Parcjâ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezionâ ducj",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_fuv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_fuv.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ɗaɓɓo fuɗɗugo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jaɓɓorgo Fuuta",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wonduki dow",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Wonduki dow",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Taƴa haa nano",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Wonduki haa nano",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Koode",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ɓanngoo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ndaaree dow",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fandita nder web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Wondirde",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Fedde",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Taƴi fuu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ga.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ga.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Bog go tosaigh",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Bog go dtí an deireadh",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Bog suas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bog síos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Bog ar chlé",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bog ar dheis",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Cóipeáil",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Gearr",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Cuardaigh suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cuardaigh ar an ngréasán",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Comhroinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Greamaigh",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Roghnaigh gach rud",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_gla.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_gla.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "A ' gluasad gus tòiseachadh",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A ' gluasad gu deireadh",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Thoir suas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Thoir sìos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "gluasad gu taobh chlì",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Thoir air làimh dheis",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Còmhdach",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Gearradh",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Thoir sùil suas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Lorg air an lìonra",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "A ' roinn",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tagh uile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_gn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_gn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ñepyrũrã ñepyrũ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oguata opaite peve",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Epu'ã ha epu'ã",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Eho mombyry",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Eho tapére",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Eho oñondive",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ojeja'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ehecha yvate",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Eipukuaa ñandutípe",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ñembojoajúva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Ñemohenda",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Eiporavo opaite",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_gom.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_gom.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "सुरवात करपाची चाल",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "शेवटाक हालचाल",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "वयर सरप",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "सकयल सरप",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "दावे वटेन हालचाल",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "उजवे वटेन सरप",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "प्रत",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कातरप",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "देखीक",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब सोद",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "वांटप",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सगलें वेंचून काडप",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ha.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ha.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Matsar don farawa",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Motsa zuwa ƙarshe",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Matsawa sama",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Matsawa ƙasa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Matsar da hagu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Matsar da dama",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kwafi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Yanke",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Duba sama",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Bincika yanar gizo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Raba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Manna",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Zaɓi duka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_hne.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_hne.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "शुरू करे बर आगे बढ़े",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत तक ले चल",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर बढ़े",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे ले चल",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बाएं ले चल",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिन ले चल",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ऊपर देख",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब म खोज",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "जम्मो चुनव",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ht.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ht.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Deplase pou kòmanse",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Deplase nan fen",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Bouje",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bouje",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Deplase agòch",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Deplase dwat",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Koupé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Gade anlè/anwo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rechèch entènèt la",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pataje",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "kale",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Chwazi tout",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ig.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ig.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Kpụgharịa ka mbido",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gaa na njedebe",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gaa n'ihu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kpụga n'ala",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kpụgharịa n'aka ekpe",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bugharịa n'aka nri",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Debata",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Bee",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Lelee elu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kwa ụbọchị WEB",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ịkekọrịta",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Mado",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Họrọ ihe niile",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ikt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ikt.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Hivunmuklutin aullaqtiriami",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nuutpalianigit ihulitpata",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hivunmuklutin",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hivumuuqtuq",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nuutpalianigit haumikhiani",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nuutirlugu taliqpik",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Aadjiliuqhimayuq",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Qinirlutin",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Qinirlugu qaritauyakkut",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Atuqatigilugu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Kinguani",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilugit tamaita",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ilo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ilo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Umayka tapno mangrugi",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Agturong iti ngudo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Umayka iti ngato",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Agpakumbaba",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Agturong iti kannigid",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Agturongka iti makannawan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Panangputot",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kitaem ti ngato",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Agbirok iti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Agpartak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilien ti amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_iu.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_iu.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ᐱᒋᐊᕐᓗᑎᑦ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ᓅᓪᓗᑎᑦ ᐃᓱᐊᓄᑦ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ᖁᕝᕙᐸᓪᓕᐊᓂᖅ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ᐊᒻᒧᒋᐊᕐᓗᑎᑦ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ᓅᓪᓗᒍ ᓴᐅᒥᒃ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ᑕᓕᖅᐱᒃᑯᑦ ᓅᓪᓗᓂ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ᐊᔾᔨᖓ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ᑭᐱᔭᐅᓂᖅ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ᑕᑯᒋᐊᕐᓂᖅ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ᕿᓂᕐᓗᒍ ᐃᑭᐊᖅᑭᕕᒃ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ᐊᒥᖅᑳᖃᑎᖃᕐᓂᖅ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "ᑭᖑᒻᖏᕐᓂᑯ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ᐃᓘᓐᓇᓯ ᓂᕈᐊᖅᑕᐃᓐᓇᕆᓗᒋᑦ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_jv.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_jv.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Pindhah kanggo miwiti",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindhah nganti pungkasan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindhah munggah",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pindhah mudhun",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindhah kiwa",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindhah tengen",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Sampul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ndeleng munggah",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Goleki ing web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bagéyan",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih kabeh",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kab.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kab.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ad d-nebdu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ruḥ ɣer tagara",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ruḥ ɣer deffir",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ruḥ ɣer lqaεa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ruḥ ɣer tama tama tama tama tamaziɣt",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ruḥ ɣer tama n waman",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tameẓla",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tẓegger",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Muqel ɣer lqaεa",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Afed deg web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ssekni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Taɣawsa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select akk",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kac.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kac.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Hpang de shamu shamawt",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jahtum hkra hkawm sa",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Rawt u",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hpang de shamu shamawt u",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Dingdung maga de shamu shamawt",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "hkra maga de shamu shamawt u",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy galaw",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kaja ai lam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Yu u",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internet kaw tam u",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Hkawp",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Hkrak",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yawng hpe lata u",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kam.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kam.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ĩka moalyũku",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ĩkalaa wĩ mũthyanĩ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ĩka maendeeo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ĩkalaa nthĩ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ĩkĩlya ngalĩko ya kw'oko kwa aka",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ĩkalaa ngalĩ ya kw'oko kwa aũme",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Ĩĩ, nĩ ya w'o.",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ĩvathũkany'o",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Sisya ĩũlũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Mantha ũvoo ũla wĩ vo",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kũĩva",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Ĩnyunga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ũnyuve onthe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kbp.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kbp.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Kpaɣ nɛ ŋpaɣzɩ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kpaɣnɩ pɩ-tɛ nɛ ŋwolo pɩ-tɛ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kpaɣ nɛ ŋwolo pɩ-yɔɔ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kpaɣ-ŋ nɛ ŋwolo pɩ-tɛɛ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kpaɣnɩnɩnɩŋ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kpaɣnɩnɩnɩnɩŋ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Pɩsɩ takayɩhayʋʋ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pɩɩwɛɛ se pɛlɛɣzɩ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kpaɣ nɛ ŋna",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ñɩnɩ intɛrnɛɛtɩ lone taa",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ñɩnɩ ɖama",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pɩsɩ nɛ ŋna-ɩ:",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ñɔɔzɩ tɔm tɩŋa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kea.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kea.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ta muda pa kumesa",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ta bai pa fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Bai pa riba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bai pa baxu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Bai pa ladu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bai direita",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopiadu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tudu algen",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Odja na kel lugar li",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Buska na internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Partilha",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pásta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleksa tudu",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kg.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Beno yantika",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kwenda tii na nsuka",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Telama na zulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Beno kwenda na nsi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kwenda na diboko ya kimama",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kwenda na diboko ya kitata",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kubaka yo",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Katula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tala na zulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sosa na Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kabula",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Bima ya kutula",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pona yonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_khk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_khk.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Эхлэхэд хөдөлгөөн",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Сүүлийнх хүртэл",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өрчөө",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Хурдан буурах",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Зүүн талд шилжих",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Дээр нь баруун замаар",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Хөгжүүлэн",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Хөрөгдөл",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Үргэлж үзээрэй",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Интернэтээр хайж үзээрэй",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Хөдөлмөр",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Хөгжил",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Бүх сонго",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ki.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ki.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Gũthiaga na mbere",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gũthiĩ o nginya mũthia",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ũkĩrai igũrũ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ũikũrũke",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Reke ũthiĩ mwena wa ũmotho",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ĩra mwena wa ũrĩo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kũrita",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kũgũrũ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Rora igũrũ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rora ũhoro thĩinĩ wa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kũgayana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Gĩthaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Thuura ciothe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kmb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kmb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Kuia ku dimatekenu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ku disukilu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Zukama",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Zukama bhoxi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ku mbandu ia kiasu",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ku mbandu ia kadilu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kala ki tua mu mona",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ku batula",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tala ku thandu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sota mu internete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ku di Bhana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Jimbamba",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sola ioso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_kmr.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_kmr.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ber bi destpêkirinê ve here",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ber bi dawiyê ve here",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Berjor",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Berjêr",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Berbi çepê ve here",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Berbi rastê ve here",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Jibergirtin",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Jê bike",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "binihêre",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Li torê bigere",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Parve bike",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hemûyan Hilbijêre",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ks.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ks.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "شروع کرنْہ کُن پْکیو",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "اندس کُن پْکیو",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ہیور کْریو پْکیو",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ڈاون کْریو پْکیو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "کھوفُر کْریو مو",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "دوچُھن کْریو منتقل",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "کاپی کْریو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "کٹ کْریو",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ہیور کْریو نظر",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ویب کْریو تلاش",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "شییر کْریو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "پیسٹْہ کْریو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "تمام ژأریو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ku.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ku.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "بجوڵێ بۆ دەستپێکردن",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "بگوێزەرەوە بۆ کۆتایی",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "بجوڵێ بۆ سەرەوە",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "چوونە خوارەوە",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "بگوێزەرەوە بۆ لای چەپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "بگوێزەرەوە بۆ لای ڕاست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "کۆپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "بڕین",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "سەیری سەرەوە بکە",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "گەڕان لە وێب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "بەش پێکردن",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "لکاندن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "هەموو دیاریبکە",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lg.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Genda okutandikira",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Genda waggulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Genda wansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Genda ku kkono",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Genda ku ddyo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tunuulira waggulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Londa byonna",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lij.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lij.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mòve pe comensâ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mòve a-a fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mòve ascì",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Motta in sciâ sciâ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mòve a-a scinn-a",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mòve a drîva",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copiaçión",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taggia",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Gâ â dõ alan,",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca into web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiçioin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleçionâ tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lim.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lim.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Verplaatsing veur begin",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Verplaats tot 't eind",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gao op.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gaon nao de boeg.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Verplaats nao links",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Gao rechts",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopie",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Snij",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kiek op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Zoek op 't web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selecteer alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lmo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lmo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mova per cumincià",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Moved a end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mòsa sù",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Scenditi giù",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mova a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mova a destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copià",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Guarda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca in web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiment",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pesta",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleziona tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ln.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ln.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Nakei mpo na kobanda",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nakei mpo na kosuka",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Tókende liboso",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Longwá na nse",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kokende na ngámbo mosusu na lobɔkɔ ya mwasi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tókende na lobɔkɔ ya mobali",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Katá",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Talá na likolo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rechercher le site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Poná bato nyonso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ltg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ltg.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Izkuopūt iz suokumu",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Izstuode leidz beigom",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Izstuodeit.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Izmīž iz zemis",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Izmaite iz kreisi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pa kreisi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopiejums",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skurstys",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Pazaudēsim augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Izpieteit vītā",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pīsadaleit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pīsaceņš",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli vysus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ltz.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ltz.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Schreift fir ze starten",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Verréckelt bis zum Enn",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gitt op",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gitt op d'Fënster",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Verréckelt an links",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Réck bewegen",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopéiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Schneiden",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kuckt op",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sich am Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deel",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "All wielt",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lua.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Dienda bua kutuadija",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kulekela",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ndaku kumpala",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ndaku panshi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pambuka ku tshianza tshia bakaji",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Lombola ku tshianza tshia balume",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Dienza mudimu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Badi bakosa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tangila muulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Keba mu site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Difila",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Kanyenga",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sungula bionso",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_luo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_luo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Dhi nyime",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Dhi Nyime",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Dhi malo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Dhi piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Dhi koracham",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Dhiuru korachwich",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi mar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ng'ado mar ng'ado",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ne malo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Many weche e Intanet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Miyo Ji",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yier duto",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lus.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Hman ṭan tûrin kal",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A tawp thlengin kal",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "A chhoh chhoh mai ang",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "A hnuai lamah chuan kal rawh",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hne lamah chuan",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hne lam pan rawh",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "A hniam",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "A chunga en rawh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Web-ah zawng",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Hlawhtling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "A zawng zawng thlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lvs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lvs.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Izstāde",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pieeja līdz beigām",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Izceļot",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Izkļūt uz zemumu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Izgriež uz kreisi",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Izgriež uz kreisi.",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Sārkšana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Izskatīt augšā",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Izmeklējiet interneta",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pievienojiet",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Izvēli visus",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_lzh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_lzh.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "移于始",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "移之终焉",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "上升",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "下移",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "左行",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "右移",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "复制",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "切",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "𴏧",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "搜索 Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "共享",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "糊",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "全选",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mag.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "शुरू करे के लेल आगे बढ़ो",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत तक जा",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ऊपर जा के चल जा",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचे जा",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बाएं तरफ जा",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिना चलल जाय",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "कॉपी करे",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटवा",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ऊपर देखहो",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब पर खोज करे",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करे",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सब के चुनल जाय",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mai.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mai.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "प्रारंभ करबाक लेल घसकाबू",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अंत मे जाउ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उप्पर जाउ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीच्चाँ जाउ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बामाँ जाउ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दहिन्ना जाउ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "कापी करू",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "काटू",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "उप्पर देखू",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेब खोजू",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "साटू",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सभटा चुनू",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mg.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mandrosoa manomboka",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mifindra any amin'ny faran'ny",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mandrosoa",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Midina midina",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mifindra eo ankavia",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mihetsika tsara",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tahadika mitovy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Hetezo",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Jereo ny tohiny",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Tadiavo ny tranonkala",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Zarao",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Apetaho",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny zava-drehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mi.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Nuku ki te tīmata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Nuku ki te mutunga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nuku whakarunga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Nuku whakararo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Nuku whakatemauī",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Nuku whakatematau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tārua",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "tapahi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tirohia ake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Rapua te tukutuku",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Tohaina",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Whakapiri",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tīpako Katoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_min.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_min.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Pindah untuak mulai",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindah ka akhia",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah ateh",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bajalan ka bawah",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah ka kiri",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindah ka kanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tanda-tanda",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Panjang",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Liek ateh",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Barbagi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Piliah kasadonyo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mni.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mni.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "হৌদোক্নবা খোঙথাং",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "লোইশিনবদা চংশিনবা",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "মথক্তা চংশিনবিয়ু",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "মখা তানা চংশিনবিয়ু",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "লেম্না চংশিনবা",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "হকথেংননা খোঙজং চঙ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "কপী",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "কাৎপা",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ৱাংখৎকদৌরিবশিং",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ৱেবতা থিদোকপা",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "শেল থাদবা",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "পেস্ত",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "পুম্নমক খনগৎকনি",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mos.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mos.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "D yik n sɩng",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kẽng n ta a baasgo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kẽng-y n kẽng n tɩ moonẽ.",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kẽng-y n kẽng tẽngre.",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yi n kẽng goabgẽ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yi n kẽng rɩtgo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Sõng-y n deeg-y-yã",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "B sẽn yã wã",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ges-y n gese.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Bao-y Internetã pʋgẽ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "D pʋɩ-ta ne taaba",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Dɩt-y n ges-y",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yi b fãa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mt.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mexxi biex tibda",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mexxi lejn it-tmiem",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Imxi 'l fuq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mexxi 'l isfel",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mexxi lejn ix-xellug",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mexxi lejn il-lemin",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopja",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Maqtugħa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Fittex 'il fuq",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fittex fuq il-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Sehem",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Ippejstja",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Agħżel kollox",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_mww.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_mww.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Txav mus pib",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Txav mus",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "txav mus",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "txav mus",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "txav mus",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "txav mus",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Luam ib daim qauv",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Hlais",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Saib",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nrhiav lub web site",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Sib qhia tawm",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Xaiv tag nrho cov kev xaiv",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_nno.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_nno.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Flyt til å byrja",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Flyt til slutt",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Flyt opp",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Flyt nedover",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Flyt til venstre",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ta deg til høgre",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopiert",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Skjer",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Sjå opp",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sjå på nettet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Deling",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Velg alle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_npi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_npi.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "सुरु गर्न सार्नुहोस्",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अन्त्यसम्मको यात्रा",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उठ्नुस्",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "तल बढ्नु",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "बायाँमा हिँड",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दायाँतिर हिँड",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "प्रतिलिपि",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटौती",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "माथि हेर्नुहोस्",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबमा खोज्नुहोस्",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझेदारी",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "पेस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सबै चयन गर्नुहोस्",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_nso.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_nso.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Move down",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Šwišetša ka go la nngele",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Sepela ka go la go ja",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kgaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Lebelela godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Nyakišiša Websaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kgetha ka moka",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_nus.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_nus.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ji̱i̱ kɛ ɣöö ba tok",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ji̱i̱ kɛ guutdɛ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Jiɛc rɔ nhial",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Jiɛc rɔ piny",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Wut kä caam",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Läthɛ kä kui̱c cuëëc",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kä cuɛɛ jɛ cop",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kɛn ti̱ ca da̱a̱k",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Guic nhial",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kuɛn rɛy webä",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ŋi̱i̱c",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pa̱th",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Kɛn diaal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ny.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ny.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Pitani kuti muyambe",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pitani kumapeto",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pitani m'mwamba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pitani pansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pitani kumanzere",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yendetsani kumanja",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Koperani",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Dulani",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Yang'anani m'mwamba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fufuzani pa intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Gawani",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Phala",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani zonse",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_oci.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_oci.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mòstra per començar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Passa fins a la fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "S'avança",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "S'avança cap a l'èst",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Virar a esquèrra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mòstra-te a drecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cortada",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Vòli sus",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Recercar sul web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartilhar",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar totes",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_om.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_om.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Jalqabatti socho'i",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gara xumuraatti socho'i",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ol socho'i",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gadii socho'i",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Bitaatti socho'i",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mirgatti socho'i",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Look Up",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search Web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select all",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_otq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_otq.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mover pa 'bu̲i",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mover asta ar ngäts'i",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Desplazar nu'bu mañä",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Desplazar nu'bu abajo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mover ga ma jar izquierda",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mover ga ma jar derecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tu̲ki",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Honi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Honi ar web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "T'uni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pegar",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar ga̲tho",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_pag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_pag.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Manpaway",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Manpaarap ya anggad samput",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Onalis ka",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Onsi ka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Onalis ed nikawan",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Onliing ed nikawanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Apatalos",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pangitok",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Manengneng ka ed tagey",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Man-search ed web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Manpabiskegen",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Manpili na amin",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_pap.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_pap.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Move pa kuminsá",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pasá pa fin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pasá ariba",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Bai bai",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move na man robes",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Move drechi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ta ta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Wak ariba",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Busca riba web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartiendo",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccioná tur",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_pbt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_pbt.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "د پیل لپاره حرکت وکړئ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "د پای ته رسیدو لپاره حرکت وکړئ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "پورته لاړ شئ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "لاندې حرکت وکړئ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "چپ ته لاړ شئ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "په ښي خوا حرکت وکړئ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "د دې د ثبت کولو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "د ټوټې کولو لپاره",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "پورته وګورئ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "په ویب کې لټون وکړئ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "د شریکولو لپاره",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "د پټو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ټولې ټاکل",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_pes.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_pes.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "حرکت کن تا شروع کنم",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرکت تا آخر",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "برو بالا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "پایین برو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "به چپ حرکت کن",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "به سمت راست حرکت کن",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "کپی شده",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "قطع",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "نگاه کن بالا",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "در اینترنت جستجو کنید",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "پسته",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "همه را انتخاب کنید",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_plt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_plt.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Mihetsika mba hanombohana",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mihetsika hatrany amin'ny farany",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Miakara",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mifindrà midina",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mihetsika mankany ankavia",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mandehana ankavanana",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Fandikana",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Famoahana",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Jereo ny ambony",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Mitadiava ao amin'ny aterineto",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Mizara",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Fitaovana",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Safidio ny rehetra",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_prs.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_prs.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "حرکت برای شروع",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "حرکت به پایان",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "حرکت به بالا",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "حرکت به پایین",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "حرکت به سمت چپ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "حرکت به سمت راست",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "کپی",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "برش",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "بالا را نگاه کنید",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "جستجو در وب",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "اشتراک گذاری",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "خمیر کردن",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "انتخاب همه",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_rn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_rn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kwimuka gushika ku mpera",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Genda hejuru",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Manuka hasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Genda iburyo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Raba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Search the web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Gusangira",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamwo vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_rw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_rw.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to end",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Manuka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Move right",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Reba hejuru",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Shakisha urubuga",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hitamo byose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_sag.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_sag.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ti londo na ni",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mo gue juska na nda ni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ga na nduzu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Mo gue na gbe ni",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mo gue na mbage ti mbage ti koli",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mo gue na mbage ti koli",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "A-Code",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "A fâ ni",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Bâ ndo na nduzu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Gi na ndo ti Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kangbi ni",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "A yeke zia ni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Soro aye kue",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_san.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_san.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "आरम्भार्थं गच्छति",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "अन्ते गच्छन्ती",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "उपरि गच्छ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "नीचां गच्छ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "वामम् गच्छ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "दाहिनाम् चल",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "अनुच्छेदः",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "कटान",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "अपरं पश्य",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "वेबं सर्च",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "साझा करना",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "पस्ट",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "सर्वम् निवस",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_scn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_scn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Muoviti pi cuminciari",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Muoviti finu a fini",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si muoviti supra",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si muove à a bassa",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si muova a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si muove à destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copiu",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tagghiatu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Guarda 'n alto",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cercate in u web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Cumpartiri",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selezziunate tutti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_sd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_sd.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "شروع ڪرڻ لاء منتقل ڪريو",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ختم ڪرڻ لاء منتقل ڪريو",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "مٿي هلي وڃو",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "هيٺ هلي وڃو",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "کاٻي پاسي منتقل ڪريو",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ساڄي پاسي هلي وڃو",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "نقل ڪريو",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ڪٽي",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "مٿي ڏسو",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ويب ڳوليو",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "حصيداري ڪريو",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "پيسٽ ڪريو",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "سڀ چونڊيو",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_shn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_shn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ၶၢႆႉၵႂႃႇတႄႇ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ၶၢႆႉၵႂႃႇတီႈသုတ်း",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ၶၢႆႉၶိုၼ်ႈ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ၶၢႆႉလူင်းၵႂႃႇ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ၶၢႆႉၵႂႃႇၽၢႆႇသၢႆႉ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ၶၢႆႉၵႂႃႇၽၢႆႇၶႂႃ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ၶၼ်ဢဝ်",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "တူၺ်းၼိူဝ်",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "လဵပ်ႈႁဵၼ်းၼႂ်းဝႅပ်ႉသၢႆႉ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ၽႄ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "မဵတ်ႉ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "လိူၵ်ႈဢဝ် တင်းမူတ်း",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_sm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_sm.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Siitia e amata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Siitia i le faaiuga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Siitia i luga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Alu i lalo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Siitia i le agavale",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Alu i le taumatau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tipi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Vaai i luga",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Su'e i luga o le upega tafa'ilagi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Faasoa atu",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Faapipii",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Filifili uma",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_sn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_sn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Dzvanya pano kuti utange",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Famba kusvika kumagumo",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Enda kumusoro",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Enda pasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Famba kuruboshwe",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Famba kurudyi",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cheka",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tarisa kumusoro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Tsvaga iyo webhu",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Goverana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sarudza zvese",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_so.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_so.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "U dhaqaaq si aad u bilowdo",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Dhaqaaq si jooji",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hore u dhaqaaq",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hoos u dhaqaaq",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "U dhaqaaqo bidix",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Midig u dhaqaaq",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Nuqul",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kor u eeg",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Raadi shabakadda internetka",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Dalbo dhamaantood",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_srd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_srd.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Movimentu pro cumintzare",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Mùvidu a sa fine",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Si movet a su prus",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Si movet a sa terra",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Si movi a manca",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Si movet a sa manu dritta",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copia de su nùmeru",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tagliu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Iscuras su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Proare in sa web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Compartire",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Select all",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ss.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ss.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Hamba ucale",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Hamba uye ekugcineni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hamba uye ngetulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Hamba uye phansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hamba uye ngesancele",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hamba ngesekudla",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Ikhophi",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kugawulwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Buka etulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sesha ku-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Umutsi",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetsa tonkhe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_st.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_st.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Fallela ho qala",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Fallela ho fihlela qetellong",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Nyolohela holimo",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Fallela tlase",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Fallela ka ho le letšehali",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tsamaea ka ho le letona",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kopitsa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Khaola",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Sheba holimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Arolelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Ho beha",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha tsohle",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_su.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_su.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Pindah pikeun ngamimitian",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pindah ka tungtung",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah nepi",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pindah ka handap",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah ka kénca",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Pindahkeun katuhu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Sampel",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Tingali nepi",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Milarian dina wéb",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bagikeun",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih sadaya",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_szl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_szl.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Przesun sie do zacznij",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Przesun do kōńca",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wstŏw sie w górã",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Przijść do dómu",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Przesun sie na lewo",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Idź na prawo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kōmprōj",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Przeciynty",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Wiyź na górã",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Szukaj we internecie",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Dziel sie",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pasyjo",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Wybierz wszyjske",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_taq.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_taq.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ⵙⴽⵔ ⵙ ⵓⵙⵙⵉⵅⴼ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ⴰⵜⵓⴰⵣⴰⵔ ⵉ ⵢⴷⴰⴶ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ⴰⵜⵓⴰⵣⴰⵔ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ⴰⵜⵓⴰⵣⴰⵍ ⵓⴰ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ⴰⴾⴰⵍ ⵙ ⴰⴾⴰⵍ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ⴰⴾⴰⵍ ⵙ ⴰⵣⵓⴾ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⴰⴱⵉⵍⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ⵜⴰⵔⵔⴰⵜ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ⴰⴾⴰⵍ ⵉⵉⵉⴰⵏ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵡⴰⵏⵉⵜⵉⵔ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ⵜⴰⵔⴳⴰ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "ⵜⴰⵔⵔⴰ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⵢⵍⵜ ⴰⴽⴽⵡ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tg.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tg.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Ба оғоз ҳаракат кунед",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ба охир ҳаракат кунед",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Ба боло равед",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Ба поён равед",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Ба чап ҳаракат кунед",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Ба рост ҳаракат кунед",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Нусхаи муаллифӣ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Тақсим",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Ба боло нигаред",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Дар интернет ҷустуҷӯ кунед",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Мубодила",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Паст",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ҳамаро интихоб кунед",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ti.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ti.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ንምጅማር ግዓዝ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ናብ መወዳእታ ግዓዝ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ናብ ላዕሊ ግዓዝ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ናብ ታሕቲ ግዒዝካ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ናብ ጸጋም ግዓዝ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ናብ የማን ግዓዝ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ቅዳሕ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ቍረጽ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ናብ ላዕሊ ጠምት",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ነቲ መርበብ ሓበሬታ ድለዮ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ንኻልኦት ኣካፍሎም",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "መቐመጢ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ንዅሉ ምረጽ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tk.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tk.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Başlamak üçin göç",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Soňuna göç",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ýokaryk galmak",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "aşak süýşür",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Çepe süýşür",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Saga süýşür",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "nusgala",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "gyrkmak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "seretmek",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Webi Ahtar",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "paýlaşmak",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "ýelmemek",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ehlisini Saýla",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Move to start",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Move to End ke gane",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Move up",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Move down",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Move left",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Tsamaya ka fa mojeng",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Cut",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Leba kwa godimo",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Batla Webosaete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Share",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Tlhopha sengwe le sengwe",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_to.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_to.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Hiki ke kamata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ʻUnu ki he ngataʻanga",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Hiki ki ʻolunga",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ʻUnu ki lalo",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Hiki ki toʻohema",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ʻUnu ki toʻomataʻu",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tatau",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tuʻusi",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Sio hake",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Fekumi ʻi he uepisaiti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Vahevahe",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Fili kotoa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tpi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tpi.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Kisim rot long stat",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kisim ol samting i go inap long pinis",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Kisim bek",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kisim ol samting i go daun",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kisim han kais",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kisim han sut",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Tok bilong en",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kisim ol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Lukim antap",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ritim long web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ol i save kisim ol samting",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pas",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Putim olgeta",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ts.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ts.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Famba u ya sungula",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ku ya fika emakumu",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Tlakuka",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Tsutsuma ehansi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Famba hi le ximatsini",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Famba hi ku ya exineneni",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Ku kopa",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ku tsemiwa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Languta ehenhla",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Lavisisa eka Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ku Avelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Xitlhoma-ndzeni",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hlawula Hinkwaswo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tt.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tt.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Башлангыч өчен күчерү",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Ахырына күчерү",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Өскә күтәрелеш",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Түбәнгә күчерү",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Сулга күчерү",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Уңга күчерү",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Күчермә",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Кисү",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Югарыга карагыз",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Интернетта эзләү",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Уртаклашу",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Паста",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Барысын да сайлап алу",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tum.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tum.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Yambani",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Lutilirani kwenda",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Wukani",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Welerani pasi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yenda kumazere",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Yenda kumalyero",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Kupokera",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Kupalasa",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Wukani",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Penjani pa Intaneti",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Kugaŵana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Kupaka",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Sankhani vyose",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tw.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tw.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Yɛkɔyɛ adwuma",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Kɔ awiei",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Monkɔ soro",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Kɔ fam",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kɔ benkum",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Fa wo nsa nifa",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Wɔahyehyɛ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Wodi mu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Hwehwɛ soro",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Hwehwɛ Intanɛt so",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Fa no",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Nkyene",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Paw nyinaa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ty.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ty.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Haere i mua no te haamata",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "A haere i mua e tae atu i te hopea",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "A haere i ni'a",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "A haere i raro",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Haere i te pae aui",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Haere i te pae atau",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Hoho'a",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Tapu",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Hi'o i ni'a",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ma'imi i ni'a i te Itenati",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Faaite",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Te mau nota",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Ma'iti i te taatoaraa",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_tzm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_tzm.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "ⴰⴷ ⵙⴽⵔⵏ ⵉ ⵍⴱⴷⵓ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "ⴰⴷ ⵢⵓⵡⵉ ⴰⵔ ⵓⴳⴳⴰⵔ",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "ⵙⴽⵔ ⵙⵙⵉ",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "ⵙⴽⵔ ⵙ ⵓⴷⵔⴰⵔ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "ⵙⴽⵍ ⵙ ⵓⴳⴰⴼⴰ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "ⵙⴽⵔ ⵙ ⵓⵥⵍⵎⴰⴹ",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "ⵜⴰⴽⵓⴱⵉⵜ",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "ⴰⵖⵔⴼ",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "ⴰⵥⵕ ⵙ ⵓⵍⵍⴰⵙ",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "ⴰⵙⴼⵙⵔ ⴳ ⵓⵙⵉⵜ",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "ⴰⵙⵎⴹⴰⵍ",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "ⵜⴰⴱⵔⴰⵜ",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "ⵙⵜⴰⵢ ⴽⵓⵍⵍⵓ",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_umb.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_umb.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Oku fetika",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oku Amamako",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Amamako oku kula",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Likolisilako oku loka",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Kuende kepĩli",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Kuende kondio",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Ocisonehua caco",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Oku teta",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Liwekapo oku tala",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Sandiliya vo Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Oku Pongolola Oluali",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Oku kapa",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Nõla ovina viosi",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_uzn.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_uzn.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Boshlang",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Oxirigacha harakatlaning",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yuqoriga koʻtaring",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pastga koʻtaring",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Chapga oʻtish",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Oʻngga koʻch",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Koʻchirilgan",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Qitish",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Yuqoriga qarang",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Internetda qidirish",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Bajarish",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Past",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Hamma tanlang",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_vec.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_vec.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Movimento par cominciar",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Via verso la fine",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Stigni su",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Scender giù",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Mover a sinistra",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Moverse a destra",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copia",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Taglio",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "varda su",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cerca su la rete",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Partage",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Selesionar tuti",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_war.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_war.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Pag-andam ha pagtikang",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Pag-uswag tubtob ha kataposan",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Mag-uswag",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Pag-aawas ha ubos",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Lugod, lumakat ha wala.",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Mag-atubang ha tuo",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Pagputol",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kitaa an imo mga mata.",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Pag-usisa ha Internet",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pag-ambit",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Pag-ihap",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pagpili han ngatanan",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_wo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_wo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Jëfleen ci tàmbalee",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Jëf-jëf",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Déggal ci kaw",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Daal ci suuf",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Déggal ca càmmoñ",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Déggal ci ndeyjoor",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Jëf-jëf",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Xoollu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Xët ci web bi",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Di bokk",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Jëf",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Jëfalu yépp",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_xh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_xh.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Shenxisela ukuze uyiqale",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Shenxisela esiphelweni",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Yiya phezulu",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Yiya ezantsi",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Yiya ngasekhohlo",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Hambisa ngasekunene",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Khuphela",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Sika",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Jonga phezulu",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Isetyenziswa ngokwemigqaliselo zichazwe akwi-web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Yabelana",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Cola",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Khetha zonke",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_ydd.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_ydd.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "מאַך צו אָנהייבן",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "מאַך צו סוף",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "רירן אַרויף",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "באַוועגונג אַראָפּ",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "מאַך לינקס",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "מאַך רעכטס",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "קאָפּע",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "שנייַדן",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "קוק אַרויף",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "זוכן אין די וועב",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "טיילן",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "פּאַס",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "אויסקלייַבן אַלע",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_yo.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_yo.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Gbe lati bẹrẹ",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Gbe lọ si opin",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Gbé sókè",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gbé lọ sí ìsàlẹ̀",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Gbé apá òsì",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Gbé lọ sí ọ̀tún",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Ṣẹ̀dà",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Gé",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Wo òkè",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Ṣawari oju-iwe ayelujara",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Pin",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Lẹ̀",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Yan gbogbo",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_yua.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_yua.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Péeksik ti'al u chuumpajal",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Péeksik tak tu Xul",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Desplazar tak ka'anal",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Desplazar tak kaambal",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Péeksik a le izquierda",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Péeksik a le derecha",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copiar",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Ch'ak",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Kaxan",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Kaxant ti' le web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Ts'aaj",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Jats'ik",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Seleccionar tuláakal",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}

--- a/packages/flutter_localizations/lib/src/l10n/widgets_zsm.arb
+++ b/packages/flutter_localizations/lib/src/l10n/widgets_zsm.arb
@@ -1,0 +1,67 @@
+{
+  "reorderItemToStart": "Bergerak untuk bermula",
+  "@reorderItemToStart": {
+    "description": "The audio announcement to move an item in a Reorderable List to the start of the list."
+  },
+  "reorderItemToEnd": "Bergerak ke hujung",
+  "@reorderItemToEnd": {
+    "description": "The audio announcement to move an item in a Reorderable List to the end of the list."
+  },
+  "reorderItemUp": "Pindah ke atas",
+  "@reorderItemUp": {
+    "description": "The audio announcement to move an item in a Reorderable List up in the list when it is oriented vertically."
+  },
+  "reorderItemDown": "Gerak ke bawah",
+  "@reorderItemDown": {
+    "description": "The audio announcement to move an item in a Reorderable List down in the list when it is oriented vertically."
+  },
+  "reorderItemLeft": "Pindah kiri",
+  "@reorderItemLeft": {
+    "description": "The audio announcement to move an item in a Reorderable List left in the list when it is oriented horizontally."
+  },
+  "reorderItemRight": "Bergerak kanan",
+  "@reorderItemRight": {
+    "description": "The audio announcement to move an item in a Reorderable List right in the list when it is oriented horizontally."
+  },
+  "searchResultsFound": "Search results found",
+  "@searchResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become available."
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "The audio announcement when Autocomplete search results become unavailable."
+  },
+  "copyButtonLabel": "Copy",
+  "@copyButtonLabel": {
+    "description": "The label for copy buttons and menu items."
+  },
+  "cutButtonLabel": "Potong",
+  "@cutButtonLabel": {
+    "description": "The label for cut buttons and menu items."
+  },
+  "lookUpButtonLabel": "Lihat ke atas",
+  "@lookUpButtonLabel": {
+    "description": "The label for the Look Up button and menu items."
+  },
+  "searchWebButtonLabel": "Cari di web",
+  "@searchWebButtonLabel": {
+    "description": "The label for the Search Web button and menu items."
+  },
+  "shareButtonLabel": "Berkongsi",
+  "@shareButtonLabel": {
+    "description": "The label for the Share button and menu items."
+  },
+  "pasteButtonLabel": "Paste",
+  "@pasteButtonLabel": {
+    "description": "The label for paste buttons and menu items."
+  },
+  "selectAllButtonLabel": "Pilih semua",
+  "@selectAllButtonLabel": {
+    "description": "The label for select-all buttons and menu items."
+  },
+  "radioButtonUnselectedLabel": "Not selected",
+  "@radioButtonUnselectedLabel": {
+    "description": "The accessibility hint for an unselected radio button.",
+    "type": "text"
+  }
+}


### PR DESCRIPTION
jav, arz, pes, bho, orm, lin, hau, awa, uzn, sun, ary, gaz, ibo, mlg, snd, azb, ceb, apc, mai, zsm, yor, xho, som, bam, hat, kin, run, aka, nya, tir, twi, tsn, tgk, lug, kas, kik, kon, sna, tuk, kur, grn, sot, tat, wol, ewe, tso, ssw

Material Localization are almost on par except for @description 
Cupertino and Widgets also included but a lot of English as fallback

Note : translations also have the following limits :

licensesPackageDetailText(int licenseCount)
   - Returns: '$licenseCount licenses'
   - Should be: Translated with proper pluralization remainingTextFieldCharacterCount(int remaining)
   - Returns: '$remaining characters remaining'
   - Should be: Translated with proper pluralization selectedRowCountTitle(int selectedRowCount)
   - Returns: '$selectedRowCount items selected'
   - Should be: Translated with proper pluralization tabLabel({required int tabIndex, required int tabCount})
   - Returns: 'Tab $tabIndex of $tabCount'
   - Should be: Translated format string pageRowsInfoTitle(int firstRow, int lastRow, int rowCount, bool rowCountIsApproximate)
   - Returns: '$firstRow–$lastRow / ~$rowCount' or '$firstRow–$lastRow / $rowCount' aboutListTileTitle(String applicationName)
   - Sometimes returns: Just applicationName (missing "About" prefix)
   - Should be: "About $applicationName" format

Original issue : https://github.com/flutter/flutter/issues/164462
