### PR TITLE
Fix layout for macOS frameworks for code assets

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -146,18 +146,23 @@ Future<void> copyNativeCodeAssetsMacOS(
     await resourcesDir.create(recursive: true);
     final File dylibFile = versionADir.childFile(name);
     final Link currentLink = versionsDir.childLink('Current');
+    final Directory currentLinkAsDirectory = versionsDir.childDirectory('Current');
+
     await currentLink.create(
       fileSystem.path.relative(versionADir.path, from: currentLink.parent.path),
     );
     final Link resourcesLink = frameworkDir.childLink('Resources');
     await resourcesLink.create(
-      fileSystem.path.relative(resourcesDir.path, from: resourcesLink.parent.path),
+      fileSystem.path.relative(
+        currentLinkAsDirectory.childFile('Resources').path,
+        from: resourcesLink.parent.path,
+      ),
     );
     await lipoDylibs(dylibFile, sources);
     final Link dylibLink = frameworkDir.childLink(name);
     await dylibLink.create(
       fileSystem.path.relative(
-        versionsDir.childDirectory('Current').childFile(name).path,
+        currentLinkAsDirectory.childFile(name).path,
         from: dylibLink.parent.path,
       ),
     );

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -350,6 +350,20 @@ void main() {
           // Multi arch.
           expect(buildRunner.buildInvocations, flutterTester ? 1 : 2);
           expect(buildRunner.linkInvocations, buildMode == BuildMode.release ? 2 : 0);
+
+          if (!flutterTester) {
+            // Not running on the host system, so the code asset has been turned into a framework.
+            final Directory frameworkRoot = fileSystem.directory(
+              '/build/native_assets/macos/bar.framework',
+            );
+
+            // MacOS frameworks use symlinks for versioned content:
+            // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html
+            expect(frameworkRoot.childLink('bar').targetSync(), 'Versions/Current/bar');
+            expect(frameworkRoot.childLink('Resources').targetSync(), 'Versions/Current/Resources');
+
+            expect(frameworkRoot.childLink('Versions/Current').targetSync(), 'A');
+          }
         },
       );
     }


### PR DESCRIPTION
To implement code assets, Flutter tooling converts `.dylib` files emitted by hooks into Apple frameworks. The format of frameworks is slightly different between macOS and other Apple platforms, and this comment explains the correct format for macOS:

https://github.com/flutter/flutter/blob/f954fb79dd1570d0d05c033df85b4041fddb151f/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart#L134-L142

Currently, the link from `Resources` to `Versions/Current/Resources` is incorrectly generated to `Versions/A/Resources`. This fixes that to generate both links to `Versions/Current`.

Closes https://github.com/flutter/flutter/issues/178623.
