### PR TITLE
[fuchsia] Add wrapper for zx_iob_writev

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -239,6 +239,10 @@ base class System extends NativeFieldWrapperClass1 {
   @pragma('vm:external-name', 'System_VmoMap')
   external static MapResult vmoMap(Handle vmo);
 
+  // Iob operations.
+  @pragma('vm:external-name', 'System_IobWrite')
+  external static int iobWrite(Handle iob, int regionIndex, ByteData data);
+
   // Time operations.
   static int clockGetMonotonic() {
     if (zirconFFIBindings == null) {

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -58,6 +58,10 @@ class System : public fml::RefCountedThreadSafe<System>,
 
   static Dart_Handle VmoMap(fml::RefPtr<Handle> vmo);
 
+  static zx_status_t IobWrite(fml::RefPtr<Handle> iob,
+                              uint32_t region_index,
+                              const tonic::DartByteData& data);
+
   static uint64_t ClockGetMonotonic();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);


### PR DESCRIPTION
Unfortunately, I don't think there's an easy way to add a test for this because it's possible to create IOBuffers from dart.

I need to add this because Fuchsia logging now uses IOBuffers rather than sockets, so some logging code that I have will need this.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
