### PR TITLE
Add DropdownMenuFormField.decorationBuilder

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -50,6 +50,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
     TextAlign textAlign = TextAlign.start,
     // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
     Object? inputDecorationTheme,
+    DropdownMenuDecorationBuilder? decorationBuilder,
     MenuStyle? menuStyle,
     this.controller,
     T? initialSelection,
@@ -95,6 +96,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
                textStyle: textStyle,
                textAlign: textAlign,
                inputDecorationTheme: inputDecorationTheme,
+               decorationBuilder: decorationBuilder,
                menuStyle: menuStyle,
                controller: state.textFieldController,
                initialSelection: state.value,

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -472,6 +472,36 @@ void main() {
     expect(dropdownMenu.inputDecorationTheme, inputDecorationTheme);
   });
 
+  testWidgets('Passes decorationBuilder to underlying DropdownMenu', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries)),
+      ),
+    );
+
+    // Check default value.
+    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
+    expect(dropdownMenu.decorationBuilder, null);
+
+    InputDecoration buildDecoration(BuildContext context, MenuController controller) {
+      return const InputDecoration(labelText: 'labelText');
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            decorationBuilder: buildDecoration,
+            dropdownMenuEntries: menuEntries,
+          ),
+        ),
+      ),
+    );
+
+    dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
+    expect(dropdownMenu.decorationBuilder, buildDecoration);
+  });
+
   testWidgets('Passes menuStyle to underlying DropdownMenu', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

This PR adds `DropdownMenuFormField.decorationBuilder` and passes it to the underlying `DropdownMenu`.

## Related Issue

Follow-up to https://github.com/flutter/flutter/pull/176264 which added `DropdownMenu.decorationBuilder`.

## Tests

- Adds 1 test.

