### PR TITLE
[ Widget Preview ] Fix crash when `widget_preview_scaffold/.dart_tool` doesn't exist

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -318,8 +318,9 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     // after we generate the scaffold project as invoking the getter triggers
     // lazy initialization of the preview scaffold's FlutterManifest before
     // the scaffold project's pubspec has been generated.
+    final FlutterProject widgetPreviewScaffoldProject = rootProject.widgetPreviewScaffoldProject;
     _previewCodeGenerator = PreviewCodeGenerator(
-      widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject,
+      widgetPreviewScaffoldProject: widgetPreviewScaffoldProject,
       fs: fs,
     );
 
@@ -333,6 +334,12 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       await _previewPubspecBuilder.populatePreviewPubspec(rootProject: rootProject);
     }
 
+    if (!widgetPreviewScaffoldProject.dartTool.existsSync()) {
+      await _previewPubspecBuilder.generatePackageConfig(
+        widgetPreviewScaffoldProject: widgetPreviewScaffoldProject,
+      );
+    }
+
     shutdownHooks.addShutdownHook(() async {
       await _widgetPreviewApp?.exitApp();
       await _previewDetector.dispose();
@@ -343,7 +350,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
 
     await configureDtd();
     final int result = await runPreviewEnvironment(
-      widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject,
+      widgetPreviewScaffoldProject: widgetPreviewScaffoldProject,
     );
     if (result != 0) {
       throwToolExit('Failed to launch the widget previewer.', exitCode: result);

--- a/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
@@ -164,6 +164,13 @@ class PreviewPubspecBuilder {
       outputMode: outputMode,
     );
 
+    await generatePackageConfig(widgetPreviewScaffoldProject: widgetPreviewScaffoldProject);
+    previewManifest.updatePubspecHash(updatedPubspecPath: updatedPubspecPath);
+  }
+
+  /// Generates `widget_preview_scaffold/.dart_tool/package_config.json`.
+  Future<void> generatePackageConfig({required FlutterProject widgetPreviewScaffoldProject}) async {
+    final PubOutputMode outputMode = verbose ? PubOutputMode.all : PubOutputMode.failuresOnly;
     // Generate package_config.json.
     await pub.get(
       context: PubContext.create,
@@ -171,8 +178,6 @@ class PreviewPubspecBuilder {
       offline: offline,
       outputMode: outputMode,
     );
-
-    previewManifest.updatePubspecHash(updatedPubspecPath: updatedPubspecPath);
   }
 
   void onPubspecChangeDetected(String path) {

--- a/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
@@ -91,6 +91,8 @@ class PreviewPubspecBuilder {
     );
   }
 
+  PubOutputMode get _outputMode => verbose ? PubOutputMode.all : PubOutputMode.failuresOnly;
+
   Future<void> populatePreviewPubspec({
     required FlutterProject rootProject,
     String? updatedPubspecPath,
@@ -126,7 +128,6 @@ class PreviewPubspecBuilder {
           }),
     };
 
-    final PubOutputMode outputMode = verbose ? PubOutputMode.all : PubOutputMode.failuresOnly;
     await pub.interactively(
       <String>[
         pubAdd,
@@ -146,7 +147,7 @@ class PreviewPubspecBuilder {
       context: PubContext.pubAdd,
       command: pubAdd,
       touchesPackageConfig: true,
-      outputMode: outputMode,
+      outputMode: _outputMode,
     );
 
     // Adds dependencies required by the widget preview scaffolding.
@@ -161,7 +162,7 @@ class PreviewPubspecBuilder {
       context: PubContext.pubAdd,
       command: pubAdd,
       touchesPackageConfig: true,
-      outputMode: outputMode,
+      outputMode: _outputMode,
     );
 
     await generatePackageConfig(widgetPreviewScaffoldProject: widgetPreviewScaffoldProject);
@@ -170,13 +171,12 @@ class PreviewPubspecBuilder {
 
   /// Generates `widget_preview_scaffold/.dart_tool/package_config.json`.
   Future<void> generatePackageConfig({required FlutterProject widgetPreviewScaffoldProject}) async {
-    final PubOutputMode outputMode = verbose ? PubOutputMode.all : PubOutputMode.failuresOnly;
     // Generate package_config.json.
     await pub.get(
       context: PubContext.create,
       project: widgetPreviewScaffoldProject,
       offline: offline,
-      outputMode: outputMode,
+      outputMode: _outputMode,
     );
   }
 


### PR DESCRIPTION
If the `.dart_tool/widget_preview_scaffold/.dart_tool/` directory wasn't created during the initial run of `flutter widget-preview start` due to the command being interrupted or `pub` being disabled, `flutter widget-preview start` would crash due to the `package_config.json` logic walking up the directory structure looking for the nearest `package_config.json`. This would point to the parent project's `package_config.json`, which would not be compatible with the widget preview scaffold project.

Fixes https://github.com/flutter/flutter/issues/178660 and https://github.com/flutter/flutter/issues/177655