### PR TITLE
remove unnecessary virtual destructor from VertexDescriptor

### DIFF
--- a/engine/src/flutter/impeller/renderer/vertex_descriptor.h
+++ b/engine/src/flutter/impeller/renderer/vertex_descriptor.h
@@ -28,7 +28,7 @@ class VertexDescriptor final : public Comparable<VertexDescriptor> {
   VertexDescriptor();
 
   // |Comparable<PipelineVertexDescriptor>|
-  virtual ~VertexDescriptor();
+  ~VertexDescriptor();
 
   template <size_t Size, size_t LayoutSize>
   void SetStageInputs(


### PR DESCRIPTION
`virtual` qualifier on `VertexDescriptor` descriptor is unnecessary as the class is `final`, and raises `-Wunnecessary-virtual-specifier` in Clang 21.1.0+

Closes #178681


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
