### PR TITLE
Restore OpenGL state modified by fl_compositor_opengl_present_layers

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -232,8 +232,18 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &saved_draw_framebuffer_binding);
   GLint saved_read_framebuffer_binding;
   glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &saved_read_framebuffer_binding);
+  GLint saved_current_program;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &saved_current_program);
   GLboolean saved_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
   GLboolean saved_blend = glIsEnabled(GL_BLEND);
+  GLint saved_src_rgb;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &saved_src_rgb);
+  GLint saved_src_alpha;
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &saved_src_alpha);
+  GLint saved_dst_rgb;
+  glGetIntegerv(GL_BLEND_DST_RGB, &saved_dst_rgb);
+  GLint saved_dst_alpha;
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &saved_dst_alpha);
 
   // Update framebuffer to write into.
   size_t width = layers[0]->size.width;
@@ -332,6 +342,9 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   glBindVertexArray(saved_vao_binding);
   glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, saved_draw_framebuffer_binding);
+  glUseProgram(saved_current_program);
+  glBlendFuncSeparate(saved_src_rgb, saved_dst_rgb, saved_src_alpha,
+                      saved_dst_alpha);
 
   if (!self->shareable) {
     glBindFramebuffer(GL_READ_FRAMEBUFFER,

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -228,8 +228,12 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
   glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &saved_vao_binding);
   GLint saved_array_buffer_binding;
   glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &saved_array_buffer_binding);
-  GLint saved_framebuffer_binding;
-  glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &saved_framebuffer_binding);
+  GLint saved_draw_framebuffer_binding;
+  glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &saved_draw_framebuffer_binding);
+  GLint saved_read_framebuffer_binding;
+  glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &saved_read_framebuffer_binding);
+  GLboolean saved_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
+  GLboolean saved_blend = glIsEnabled(GL_BLEND);
 
   // Update framebuffer to write into.
   size_t width = layers[0]->size.width;
@@ -313,12 +317,21 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
 
   glDeleteVertexArrays(1, &vao);
 
-  glDisable(GL_BLEND);
+  if (saved_blend) {
+    glEnable(GL_BLEND);
+  } else {
+    glDisable(GL_BLEND);
+  }
+  if (saved_scissor_test) {
+    glEnable(GL_SCISSOR_TEST);
+  } else {
+    glDisable(GL_SCISSOR_TEST);
+  }
 
   glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
   glBindVertexArray(saved_vao_binding);
   glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, saved_framebuffer_binding);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, saved_draw_framebuffer_binding);
 
   if (!self->shareable) {
     glBindFramebuffer(GL_READ_FRAMEBUFFER,
@@ -326,6 +339,7 @@ static gboolean fl_compositor_opengl_present_layers(FlCompositor* compositor,
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, self->pixels);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
   }
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, saved_read_framebuffer_binding);
 
   g_mutex_unlock(&self->frame_mutex);
 

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl_test.cc
@@ -156,6 +156,8 @@ TEST(FlCompositorOpenGLTest, RestoresGLState) {
 
   constexpr GLuint kFakeTextureName = 123;
   glBindTexture(GL_TEXTURE_2D, kFakeTextureName);
+  glDisable(GL_BLEND);
+  glEnable(GL_SCISSOR_TEST);
 
   // Present layer and render.
   std::thread([&]() {
@@ -175,6 +177,8 @@ TEST(FlCompositorOpenGLTest, RestoresGLState) {
   glGetIntegerv(GL_TEXTURE_BINDING_2D,
                 reinterpret_cast<GLint*>(&texture_2d_binding));
   EXPECT_EQ(texture_2d_binding, kFakeTextureName);
+  EXPECT_EQ(glIsEnabled(GL_BLEND), GL_FALSE);
+  EXPECT_EQ(glIsEnabled(GL_SCISSOR_TEST), GL_TRUE);
 }
 
 TEST(FlCompositorOpenGLTest, BlitFramebuffer) {

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -388,6 +388,17 @@ static GLuint bound_texture_2d;
 
 static std::map<GLenum, GLuint> framebuffer_renderbuffers;
 
+static GLboolean enable_blend = GL_FALSE;
+static GLboolean enable_scissor_test = GL_FALSE;
+
+static void _setEnable(GLenum cap, GLboolean value) {
+  if (cap == GL_BLEND) {
+    enable_blend = value;
+  } else if (cap == GL_SCISSOR_TEST) {
+    enable_scissor_test = value;
+  }
+}
+
 void _glAttachShader(GLuint program, GLuint shader) {}
 
 static void _glBindFramebuffer(GLenum target, GLuint framebuffer) {}
@@ -446,6 +457,14 @@ void _glDeleteTextures(GLsizei n, const GLuint* textures) {
   if (mock) {
     mock->glDeleteTextures(n, textures);
   }
+}
+
+static void _glDisable(GLenum cap) {
+  _setEnable(cap, GL_FALSE);
+}
+
+static void _glEnable(GLenum cap) {
+  _setEnable(cap, GL_TRUE);
 }
 
 static void _glFramebufferRenderbuffer(GLenum target,
@@ -532,6 +551,16 @@ static void _glGetShaderInfoLog(GLuint shader,
 
 static const GLubyte* _glGetString(GLenum pname) {
   return mock->glGetString(pname);
+}
+
+static GLboolean _glIsEnabled(GLenum cap) {
+  if (cap == GL_BLEND) {
+    return enable_blend;
+  } else if (cap == GL_SCISSOR_TEST) {
+    return enable_scissor_test;
+  } else {
+    return GL_FALSE;
+  }
 }
 
 static void _glTexParameterf(GLenum target, GLenum pname, GLfloat param) {}
@@ -724,6 +753,8 @@ static void library_init() {
   epoxy_glDeleteRenderbuffers = _glDeleteRenderbuffers;
   epoxy_glDeleteShader = _glDeleteShader;
   epoxy_glDeleteTextures = _glDeleteTextures;
+  epoxy_glDisable = _glDisable;
+  epoxy_glEnable = _glEnable;
   epoxy_glFramebufferRenderbuffer = _glFramebufferRenderbuffer;
   epoxy_glFramebufferTexture2D = _glFramebufferTexture2D;
   epoxy_glGenFramebuffers = _glGenFramebuffers;
@@ -737,6 +768,7 @@ static void library_init() {
   epoxy_glGetShaderiv = _glGetShaderiv;
   epoxy_glGetShaderInfoLog = _glGetShaderInfoLog;
   epoxy_glGetString = _glGetString;
+  epoxy_glIsEnabled = _glIsEnabled;
   epoxy_glLinkProgram = _glLinkProgram;
   epoxy_glRenderbufferStorage = _glRenderbufferStorage;
   epoxy_glShaderSource = _glShaderSource;


### PR DESCRIPTION
The OpenGL context used there may be shared with Skia, and Skia assumes that other code has not changed its state.

See https://github.com/flutter/flutter/issues/178547