### PR TITLE
Only call glCheckFrameBufferStatus in the render pass in debug builds

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -7,6 +7,7 @@
 #include <format>
 #include <sstream>
 
+#include "GLES3/gl3.h"
 #include "impeller/base/allocation.h"
 #include "impeller/base/comparable.h"
 #include "impeller/base/validation.h"
@@ -445,5 +446,12 @@ std::string ProcTableGLES::GetProgramInfoLogString(GLuint program) const {
   return std::string{reinterpret_cast<const char*>(allocation.GetBuffer()),
                      static_cast<size_t>(length)};
 }
+
+GLenum ProcTableGLES::CheckFramebufferStatusDebug(GLenum target) const {
+#ifdef IMPELLER_DEBUG
+  return CheckFramebufferStatus(target);
+#endif
+  return GL_FRAMEBUFFER_COMPLETE;
+};
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include "GLES3/gl3.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
@@ -316,6 +317,11 @@ class ProcTableGLES {
   std::string DescribeCurrentFramebuffer() const;
 
   std::string GetProgramInfoLogString(GLuint program) const;
+
+  // Only check framebuffer status in debug builds.
+  // Prefer this if possible to direct calls to CheckFramebufferStatus,
+  // which can cause CPU<->GPU round-trips.
+  GLenum CheckFramebufferStatusDebug(GLenum target) const;
 
   bool IsCurrentFramebufferComplete() const;
 

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -258,7 +258,7 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
         }
       }
 
-      auto status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
+      auto status = gl.CheckFramebufferStatusDebug(GL_FRAMEBUFFER);
       if (status != GL_FRAMEBUFFER_COMPLETE) {
         VALIDATION_LOG << "Could not create a complete framebuffer: "
                        << DebugToFramebufferError(status);
@@ -538,8 +538,8 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
       return false;
     }
 
-    auto status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
-    if (gl.CheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    auto status = gl.CheckFramebufferStatusDebug(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
       VALIDATION_LOG << "Could not create a complete frambuffer: "
                      << DebugToFramebufferError(status);
       return false;


### PR DESCRIPTION
Rendering to an offscreen texture on platforms without implicit MSAA resolve causes the creation of a framebuffer each frame and a subsequent call to glCheckFramebufferStatus. 

This call can cause a full [GPU round trip] (https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_blocking_api_calls_in_production). 

This change creates a function in the proc table that only actually makes the glCheckFramebufferStatus check in debug builds, and changes the calls in render_pass_gles to use this function instead.

An alternate way of doing this would be to directly wrap the callsites with `ifdef` checks, but this way was more easily testable and seemed cleaner. 

Also removes a redundant call to CheckFramebufferStatus.

Fixes https://github.com/flutter/flutter/issues/175522

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x] I signed the [CLA].
- [ x] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ x] All existing and new tests are passing.