### PR TITLE
Add support for riscv64 desktop linux engine

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -401,6 +401,9 @@ config("compiler") {
       cflags += [ "--target=aarch64-linux-gnu" ]
       ldflags += [ "--target=aarch64-linux-gnu" ]
       cflags += [ "-DBORINGSSL_CLANG_SUPPORTS_DOT_ARCH" ]
+    } else if (current_cpu == "riscv64") {
+      cflags += [ "--target=riscv64-linux-gnu" ]
+      ldflags += [ "--target=riscv64-linux-gnu" ]
     }
   }
 

--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -411,6 +411,9 @@ config("compiler") {
       cflags += [ "--target=aarch64-linux-gnu" ]
       ldflags += [ "--target=aarch64-linux-gnu" ]
       cflags += [ "-DBORINGSSL_CLANG_SUPPORTS_DOT_ARCH" ]
+    } else if (current_cpu == "riscv64") {
+      cflags += [ "--target=riscv64-linux-gnu" ]
+      ldflags += [ "--target=riscv64-linux-gnu" ]
     }
   }
 

--- a/engine/src/build/linux/sysroot_scripts/install-sysroot.py
+++ b/engine/src/build/linux/sysroot_scripts/install-sysroot.py
@@ -102,6 +102,31 @@ def GetSysrootDict(sysroots_json_path, target_platform, target_arch):
     if sysroot_key not in sysroots:
         raise Error("No sysroot for: %s %s" % (target_platform, target_arch))
     return sysroots[sysroot_key]
+def PatchAtkVersionHeader(sysroot):
+  """Patch atkversion.h in the sysroot to add C linkage declarations.
+
+  The atkversion.h header in at-spi2-core (used by Debian Bullseye and
+  Trixie sysroots) lacks G_BEGIN_DECLS/G_END_DECLS, causing link failures
+  when the header is included from C++ code.  This was fixed upstream in
+  https://gitlab.gnome.org/GNOME/at-spi2-core/-/merge_requests/219
+  but the fix has not yet propagated to all Debian stable releases.
+  """
+  for atkversion in glob.glob(
+      os.path.join(sysroot, "usr", "include", "atk-1.0", "atk", "atkversion.h")):
+    with open(atkversion, "r") as f:
+      content = f.read()
+    if "G_BEGIN_DECLS" in content or 'extern "C"' in content:
+      continue  # Already has C linkage declarations
+    # Add G_BEGIN_DECLS after #include <glib.h> and G_END_DECLS
+    # before the final #endif.
+    content = content.replace(
+        "#include <glib.h>\n", "#include <glib.h>\n\nG_BEGIN_DECLS\n", 1)
+    content = content.replace(
+        '#endif /* __ATK_VERSION_H__ */',
+        'G_END_DECLS\n\n#endif /* __ATK_VERSION_H__ */', 1)
+    with open(atkversion, "w") as f:
+      f.write(content)
+
 def InstallSysroot(sysroots_json_path, target_platform, target_arch):
     sysroot_dict = GetSysrootDict(sysroots_json_path, target_platform,
                                   target_arch)
@@ -120,6 +145,7 @@ def InstallSysroot(sysroots_json_path, target_platform, target_arch):
             os.path.join(sysroot, ".*_is_first_class_gcs")):
         with open(stamp) as s:
             if s.read() == url:
+                PatchAtkVersionHeader(sysroot)
                 return
     print("Installing Debian %s %s root image: %s" %
           (target_platform, target_arch, sysroot))
@@ -145,6 +171,7 @@ def InstallSysroot(sysroots_json_path, target_platform, target_arch):
         raise Error("Tarball sha256sum is wrong."
                     "Expected %s, actual: %s" % (tarball_sha256sum, sha256sum))
     subprocess.check_call(["tar", "mxf", tarball, "-C", sysroot])
+    PatchAtkVersionHeader(sysroot)
     os.remove(tarball)
     with open(stamp, "w") as s:
         s.write(url)

--- a/engine/src/flutter/ci/builders/linux_riscv_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_riscv_host_engine.json
@@ -1,0 +1,151 @@
+{
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
+    "builds": [
+        {
+            "archives": [
+                {
+                    "name": "ci/linux_profile_riscv64",
+                    "type": "gcs",
+                    "base_path": "out/ci/linux_profile_riscv64/zip_archives/",
+                    "include_paths": [
+                        "out/ci/linux_profile_riscv64/zip_archives/linux-riscv64-profile/linux-riscv64-flutter-gtk.zip"
+                    ],
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/linux_profile_riscv64",
+                "--runtime-mode",
+                "profile",
+                "--target-os=linux",
+                "--linux-cpu=riscv64",
+                "--prebuilt-dart-sdk",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/linux_profile_riscv64",
+            "description": "Produces profile mode artifacts to target riscv64 Linux from a Linux host.",
+            "ninja": {
+                "config": "ci/linux_profile_riscv64",
+                "targets": [
+                    "flutter/shell/platform/linux:flutter_gtk"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "name": "ci/linux_debug_riscv64",
+                    "type": "gcs",
+                    "base_path": "out/ci/linux_debug_riscv64/zip_archives/",
+                    "include_paths": [
+                        "out/ci/linux_debug_riscv64/zip_archives/linux-riscv64/artifacts.zip",
+                        "out/ci/linux_debug_riscv64/zip_archives/linux-riscv64/impeller_sdk.zip",
+                        "out/ci/linux_debug_riscv64/zip_archives/linux-riscv64/linux-riscv64-embedder.zip",
+                        "out/ci/linux_debug_riscv64/zip_archives/linux-riscv64/font-subset.zip",
+                        "out/ci/linux_debug_riscv64/zip_archives/linux-riscv64-debug/linux-riscv64-flutter-gtk.zip",
+                        "out/ci/linux_debug_riscv64/zip_archives/dart-sdk-linux-riscv64.zip"
+                    ],
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/linux_debug_riscv64",
+                "--runtime-mode",
+                "debug",
+                "--target-os=linux",
+                "--linux-cpu=riscv64",
+                "--prebuilt-dart-sdk",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/linux_debug_riscv64",
+            "description": "Produces debug mode artifacts to target riscv64 Linux from a Linux host.",
+            "ninja": {
+                "config": "ci/linux_debug_riscv64",
+                "targets": [
+                    "flutter/build/archives:artifacts",
+                    "flutter/build/archives:dart_sdk_archive",
+                    "flutter/tools/font_subset",
+                    "flutter/shell/platform/linux:flutter_gtk",
+                    "flutter/impeller/toolkit/interop:sdk",
+                    "flutter/build/archives:embedder"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
+                    "name": "ci/linux_release_riscv64",
+                    "type": "gcs",
+                    "base_path": "out/ci/linux_release_riscv64/zip_archives/",
+                    "include_paths": [
+                        "out/ci/linux_release_riscv64/zip_archives/linux-riscv64-release/linux-riscv64-flutter-gtk.zip"
+                    ],
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/linux_release_riscv64",
+                "--runtime-mode",
+                "release",
+                "--target-os=linux",
+                "--linux-cpu=riscv64",
+                "--prebuilt-dart-sdk",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/linux_release_riscv64",
+            "description": "Produces release mode artifacts to target riscv64 Linux from a Linux host.",
+            "ninja": {
+                "config": "ci/linux_release_riscv64",
+                "targets": [
+                    "flutter/shell/platform/linux:flutter_gtk"
+                ]
+            }
+        }
+    ]
+}

--- a/engine/src/flutter/shell/platform/linux/fl_accessibility_handler_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_accessibility_handler_test.cc
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Workaround missing C code compatibility in ATK header.
-// Fixed in https://gitlab.gnome.org/GNOME/at-spi2-core/-/merge_requests/219
-extern "C" {
 #include <atk/atk.h>
-}
 
 #include "flutter/shell/platform/linux/fl_accessibility_handler.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"

--- a/engine/src/flutter/shell/platform/linux/fl_view_accessible.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view_accessible.cc
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Workaround missing C code compatibility in ATK header.
-// Fixed in https://gitlab.gnome.org/GNOME/at-spi2-core/-/merge_requests/219
-extern "C" {
 #include <atk/atk.h>
-}
 
 #include "flutter/shell/platform/linux/fl_accessible_node.h"
 #include "flutter/shell/platform/linux/fl_accessible_text_field.h"

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/run_command.dart
@@ -246,6 +246,10 @@ final class RunTarget {
       TargetPlatform.linuxArm64 ||
       TargetPlatform.windowsArm64 => 'host_${mode}_arm64',
 
+      // RISCV64 Desktop (Linux)
+      // Here, we support cross-build
+      TargetPlatform.linuxRiscv64 => 'linux_${mode}_riscv64',
+
       // WEB
       TargetPlatform.webJavascript => 'chrome_$mode',
 
@@ -307,7 +311,7 @@ final class RunTarget {
         [Label.parseGn('//flutter/shell/platform/darwin/macos:flutter_framework')],
 
       // Desktop (Linux).
-      TargetPlatform.linuxX64 || TargetPlatform.linuxArm64 => [
+      TargetPlatform.linuxX64 || TargetPlatform.linuxArm64 || TargetPlatform.linuxRiscv64 => [
         Label.parseGn('//flutter/shell/platform/linux:flutter_linux_gtk'),
       ],
 

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/run_command.dart
@@ -263,6 +263,10 @@ final class RunTarget {
       TargetPlatform.linuxArm64 ||
       TargetPlatform.windowsArm64 => 'host_${mode}_arm64',
 
+      // RISCV64 Desktop (Linux)
+      // Here, we support cross-build
+      TargetPlatform.linuxRiscv64 => 'linux_${mode}_riscv64',
+
       // WEB
       TargetPlatform.webJavascript => 'chrome_$mode',
 
@@ -324,7 +328,7 @@ final class RunTarget {
         [Label.parseGn('//flutter/shell/platform/darwin/macos:flutter_framework')],
 
       // Desktop (Linux).
-      TargetPlatform.linuxX64 || TargetPlatform.linuxArm64 => [
+      TargetPlatform.linuxX64 || TargetPlatform.linuxArm64 || TargetPlatform.linuxRiscv64 => [
         Label.parseGn('//flutter/shell/platform/linux:flutter_linux_gtk'),
       ],
 

--- a/engine/src/flutter/tools/engine_tool/lib/src/flutter_tool_interop/target_platform.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/flutter_tool_interop/target_platform.dart
@@ -35,6 +35,9 @@ final class TargetPlatform {
   /// Linux ARM64.
   static const linuxArm64 = TargetPlatform._('linux-arm64');
 
+  /// Linux RISCV64.
+  static const linuxRiscv64 = TargetPlatform._('linux-riscv64');
+
   /// Linux x64.
   static const linuxX64 = TargetPlatform._('linux-x64');
 
@@ -94,6 +97,7 @@ final class TargetPlatform {
     androidX64,
     androidX86,
     linuxArm64,
+    linuxRiscv64,
     linuxX64,
     windowsArm64,
     windowsX64,

--- a/engine/src/flutter/tools/engine_tool/test/run_target_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/run_target_test.dart
@@ -69,6 +69,7 @@ void main() {
       TargetPlatform.darwinArm64: 'host_debug_arm64',
       TargetPlatform.linuxX64: 'host_debug',
       TargetPlatform.linuxArm64: 'host_debug_arm64',
+      TargetPlatform.linuxRiscv64: 'linux_debug_riscv64',
       TargetPlatform.windowsX64: 'host_debug',
       TargetPlatform.windowsArm64: 'host_debug_arm64',
       TargetPlatform.webJavascript: 'chrome_debug',
@@ -124,6 +125,9 @@ void main() {
       ],
       TargetPlatform.linuxX64: [Label.parseGn('//flutter/shell/platform/linux:flutter_linux_gtk')],
       TargetPlatform.linuxArm64: [
+        Label.parseGn('//flutter/shell/platform/linux:flutter_linux_gtk'),
+      ],
+      TargetPlatform.linuxRiscv64: [
         Label.parseGn('//flutter/shell/platform/linux:flutter_linux_gtk'),
       ],
       TargetPlatform.windowsX64: [Label.parseGn('//flutter/shell/platform/windows')],

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -990,7 +990,7 @@ def parse_args(args):
   parser.add_argument('--web', action='store_true', default=False)
   parser.add_argument('--windows', dest='target_os', action='store_const', const='win')
 
-  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
+  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm', 'riscv64'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default='x64')
   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default='x64')
   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default='x64')

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -983,7 +983,7 @@ def parse_args(args):
   parser.add_argument('--web', action='store_true', default=False)
   parser.add_argument('--windows', dest='target_os', action='store_const', const='win')
 
-  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
+  parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm', 'riscv64'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default='x64')
   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64', 'x86'], default='x64')
   parser.add_argument('--simulator-cpu', type=str, choices=['x64', 'arm64'], default='x64')

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -719,6 +719,16 @@ def to_gn_args(args):
     # dartdevc, web SDK kernel and source files.
     gn_args['dart_platform_sdk'] = not args.full_dart_sdk
 
+  # When the Dart SDK is built from source (i.e. no usable prebuilt is
+  # available for the target, such as for riscv64 Linux cross builds), exclude
+  # the wasm-opt target. Binaryen's wasm-opt is built with exceptions enabled
+  # and links the toolchain libc++, whose bundled libcxxabi exception symbols
+  # collide with the no-exceptions stubs in the engine's libcxxabi. The
+  # prebuilt Dart SDK already ships a wasm-opt binary for platforms that have
+  # one, so this only affects from-source builds.
+  if not gn_args.get('flutter_prebuilt_dart_sdk'):
+    gn_args['dart_include_wasm_opt'] = False
+
   if args.build_glfw_shell is not None:
     gn_args['build_glfw_shell'] = args.build_glfw_shell
 


### PR DESCRIPTION
This allows to cross-compile a Flutter engine for riscv64 desktop linux from an x64 linux host.

This is a first move towards fixing https://github.com/flutter/flutter/issues/99963. Along with https://github.com/flutter/flutter/pull/178711 that allows using the flutter tool on riscv64, this PR allows me to build and run the flutter 'hello world' app on RISC-V hardware:

<img width="1920" height="1080" alt="Screenshot from 2025-11-18 08-58-03" src="https://github.com/user-attachments/assets/089810d4-84f0-43cd-8168-02bf2c94a1ed" />

This allows to build a Flutter engine on x64 host, and then expose the artifacts with a webserver to the flutter tool of #178711:
```
# Host
et build -c ci/linux_debug_riscv64 && et build -c ci/linux_profile_riscv64 && et build -c ci/linux_release_riscv64
...http server...
# RISC-V
export FLUTTER_STORAGE_BASE_URL=http://host-server-url
flutter
```

This means that even if Google does not want to support Flutter on RISC-V officially (hosting the artifacts), community-managed servers could host the RISC-V flutter engines/artifacts. It also means that internally, companies using Flutter on RISC-V would just have to build their engine with upstream flutter instead of relying on third-party patches.

For now, building the engine on RISC-V still requires another patch:
```
diff --git a/src/Reactor/BUILD.gn b/src/Reactor/BUILD.gn
index 67dfeb0ec..dcb13614a 100644
--- a/src/Reactor/BUILD.gn
+++ b/src/Reactor/BUILD.gn
@@ -307,7 +307,7 @@ if (supports_subzero) {

 if (supports_llvm) {
   swiftshader_source_set("swiftshader_llvm_reactor") {
-    llvm_dir = "../../third_party/llvm-10.0"
+    llvm_dir = "../../third_party/llvm-16.0"

     deps = [
       ":swiftshader_reactor_base",
```
However once that dependency is upgraded, everything builds without issues.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
