### PR TITLE
Make sure that a CupertinoContextMenu doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -1540,4 +1540,20 @@ void main() {
     // availableWidthForChild = 310.0 - 250.0 (menu width) = 60.0
     expect(fittedBoxSize.width, 60.0);
   });
+
+  testWidgets('CupertinoContextMenu does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: CupertinoContextMenu(
+              actions: const <Widget>[Text('X'), Text('Y')],
+              child: const Text('Y'),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CupertinoContextMenu)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CupertinoContextMenu widget.