### PR TITLE
Ensure positive rects in DlPath factory methods

### DIFF
--- a/engine/src/flutter/display_list/geometry/dl_path.cc
+++ b/engine/src/flutter/display_list/geometry/dl_path.cc
@@ -37,32 +37,32 @@ using FillType = impeller::FillType;
 using Convexity = impeller::Convexity;
 
 DlPath DlPath::MakeRect(const DlRect& rect) {
-  return DlPath(SkPath::Rect(ToSkRect(rect)));
+  return DlPath(SkPath::Rect(ToSkRect(rect.GetPositive())));
 }
 
 DlPath DlPath::MakeRectLTRB(DlScalar left,
                             DlScalar top,
                             DlScalar right,
                             DlScalar bottom) {
-  return DlPath(SkPath::Rect(SkRect::MakeLTRB(left, top, right, bottom)));
+  return MakeRect(DlRect::MakeLTRB(left, top, right, bottom));
 }
 
 DlPath DlPath::MakeRectXYWH(DlScalar x,
                             DlScalar y,
                             DlScalar width,
                             DlScalar height) {
-  return DlPath(SkPath::Rect(SkRect::MakeXYWH(x, y, width, height)));
+  return MakeRect(DlRect::MakeXYWH(x, y, width, height));
 }
 
 DlPath DlPath::MakeOval(const DlRect& bounds) {
-  return DlPath(SkPath::Oval(ToSkRect(bounds)));
+  return DlPath(SkPath::Oval(ToSkRect(bounds.GetPositive())));
 }
 
 DlPath DlPath::MakeOvalLTRB(DlScalar left,
                             DlScalar top,
                             DlScalar right,
                             DlScalar bottom) {
-  return DlPath(SkPath::Oval(SkRect::MakeLTRB(left, top, right, bottom)));
+  return MakeOval(DlRect::MakeLTRB(left, top, right, bottom));
 }
 
 DlPath DlPath::MakeCircle(const DlPoint center, DlScalar radius) {
@@ -78,7 +78,7 @@ DlPath DlPath::MakeRoundRectXY(const DlRect& rect,
                                DlScalar y_radius,
                                bool counter_clock_wise) {
   return DlPath(SkPath::RRect(
-      ToSkRect(rect), x_radius, y_radius,
+      ToSkRect(rect.GetPositive()), x_radius, y_radius,
       counter_clock_wise ? SkPathDirection::kCCW : SkPathDirection::kCW));
 }
 


### PR DESCRIPTION
Skia does not have a consistent policy for handling "inverted" shapes (rects, rrects, ovals): some Skia APIs check or flip the bounds, some do not. In general, Skia treats inverted shapes as undefined behavior and doesn't want to commit to an explicit contract for handling them. Further, this undefined behavior is actually soon going to change (to different undefined behavior; parent bug is skbug.com/454646294).

One instance where reliance on this undefined Skia behavior impacts flutter is mentioned in https://github.com/flutter/engine/pull/42556.

This PR applies a normalization to DlPaths created via factory methods that consume a DlRect, ensuring that the path geometry created from the input rects is not inverted.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
