### PR TITLE
Use WidgetsBinding.instance.platformDispatcher in windowing instead of PlatformDispatcher.instance

### DIFF
--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -407,7 +407,9 @@ class _FlView extends _GtkWidget {
   _FlView()
     : super(
         _flViewNewForEngine(
-          ffi.Pointer<ffi.NativeType>.fromAddress(PlatformDispatcher.instance.engineId!),
+          ffi.Pointer<ffi.NativeType>.fromAddress(
+            WidgetsBinding.instance.platformDispatcher.engineId!,
+          ),
         ),
       );
 
@@ -542,7 +544,7 @@ class WindowingOwnerLinux extends WindowingOwner {
     }
 
     assert(
-      PlatformDispatcher.instance.engineId != null,
+      WidgetsBinding.instance.platformDispatcher.engineId != null,
       'WindowingOwnerLinux must be created after the engine has been initialized.',
     );
   }

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -68,7 +68,7 @@ class WindowingOwnerMacOS extends WindowingOwner {
     }
 
     assert(
-      PlatformDispatcher.instance.engineId != null,
+      WidgetsBinding.instance.platformDispatcher.engineId != null,
       'WindowingOwnerMacOS must be created after the engine has been initialized.',
     );
   }
@@ -117,7 +117,7 @@ class WindowingOwnerMacOS extends WindowingOwner {
   /// The window handle is a pointer to the NSWindow instance.
   static Pointer<Void> getWindowHandle(FlutterView view) {
     return _MacOSPlatformInterface.getWindowHandle(
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       view.viewId,
     );
   }
@@ -554,7 +554,10 @@ class _MacOSPlatformInterface {
         ..constraints.maxWidth = preferredConstraints.maxWidth
         ..constraints.maxHeight = preferredConstraints.maxHeight;
     }
-    final int viewId = _createRegularWindow(PlatformDispatcher.instance.engineId!, request);
+    final int viewId = _createRegularWindow(
+      WidgetsBinding.instance.platformDispatcher.engineId!,
+      request,
+    );
     _allocator.free(request);
     return viewId;
   }
@@ -595,7 +598,10 @@ class _MacOSPlatformInterface {
         ..constraints.maxHeight = preferredConstraints.maxHeight;
     }
     try {
-      final int viewId = _createDialogWindow(PlatformDispatcher.instance.engineId!, request);
+      final int viewId = _createDialogWindow(
+        WidgetsBinding.instance.platformDispatcher.engineId!,
+        request,
+      );
       return viewId;
     } finally {
       _allocator.free(request);
@@ -606,7 +612,7 @@ class _MacOSPlatformInterface {
   external static void _destroyWindow(int engineId, Pointer<Void> handle);
 
   static void destroyWindow(Pointer<Void> windowHandle) {
-    _destroyWindow(PlatformDispatcher.instance.engineId!, windowHandle);
+    _destroyWindow(WidgetsBinding.instance.platformDispatcher.engineId!, windowHandle);
   }
 
   @Native<_Size Function(Pointer<Void>)>(symbol: 'InternalFlutter_Window_GetContentSize')

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -23,6 +23,7 @@ import 'package:flutter/rendering.dart';
 
 import '../foundation/_features.dart';
 import '_window.dart';
+import 'binding.dart';
 
 /// A Win32 window handle.
 ///
@@ -111,13 +112,13 @@ class WindowingOwnerWin32 extends WindowingOwner {
     }
 
     assert(
-      PlatformDispatcher.instance.engineId != null,
+      WidgetsBinding.instance.platformDispatcher.engineId != null,
       'WindowingOwnerWin32 must be created after the engine has been initialized.',
     );
 
     _Win32PlatformInterface.initializeWindowing(
       allocator,
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       _onMessage,
     );
   }
@@ -195,7 +196,7 @@ class WindowingOwnerWin32 extends WindowingOwner {
   }
 
   void _onMessage(ffi.Pointer<_WindowsMessage> message) {
-    final FlutterView flutterView = PlatformDispatcher.instance.views.firstWhere(
+    final FlutterView flutterView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == message.ref.viewId,
     );
 
@@ -274,7 +275,7 @@ class RegularWindowControllerWin32 extends RegularWindowController {
     owner._addMessageHandler(_handler);
     final int viewId = _Win32PlatformInterface.createRegularWindow(
       _owner.allocator,
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       preferredSize,
       preferredConstraints,
       title,
@@ -283,7 +284,7 @@ class RegularWindowControllerWin32 extends RegularWindowController {
       throw Exception('Windows failed to create a regular window with a valid view id.');
     }
 
-    final FlutterView flutterView = PlatformDispatcher.instance.views.firstWhere(
+    final FlutterView flutterView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
     );
     rootView = flutterView;
@@ -406,7 +407,7 @@ class RegularWindowControllerWin32 extends RegularWindowController {
   HWND getWindowHandle() {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       rootView.viewId,
     );
   }
@@ -507,13 +508,13 @@ class DialogWindowControllerWin32 extends DialogWindowController {
     owner._addMessageHandler(_handler);
     final int viewId = _Win32PlatformInterface.createDialogWindow(
       _owner.allocator,
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       preferredSize,
       preferredConstraints,
       title,
       parent != null
           ? _Win32PlatformInterface.getWindowHandle(
-              PlatformDispatcher.instance.engineId!,
+              WidgetsBinding.instance.platformDispatcher.engineId!,
               parent.rootView.viewId,
             )
           : null,
@@ -522,7 +523,7 @@ class DialogWindowControllerWin32 extends DialogWindowController {
       throw Exception('Windows failed to create a dialog window with a valid view id.');
     }
 
-    final FlutterView flutterView = PlatformDispatcher.instance.views.firstWhere(
+    final FlutterView flutterView = WidgetsBinding.instance.platformDispatcher.views.firstWhere(
       (FlutterView view) => view.viewId == viewId,
     );
     rootView = flutterView;
@@ -621,7 +622,7 @@ class DialogWindowControllerWin32 extends DialogWindowController {
   HWND getWindowHandle() {
     _ensureNotDestroyed();
     return _Win32PlatformInterface.getWindowHandle(
-      PlatformDispatcher.instance.engineId!,
+      WidgetsBinding.instance.platformDispatcher.engineId!,
       rootView.viewId,
     );
   }


### PR DESCRIPTION
This is the recommended way to do this as it allows us to override the platform dispatcher when that is necessary

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


