### PR TITLE
Allow SliverMainAxisGroup children to remain pinned

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1853,14 +1853,29 @@ class SliverCrossAxisGroup extends MultiChildRenderObjectWidget {
 class SliverMainAxisGroup extends MultiChildRenderObjectWidget {
   /// Creates a sliver that places sliver children in a linear array along
   /// the main axis.
-  const SliverMainAxisGroup({super.key, required List<Widget> slivers}) : super(children: slivers);
+  const SliverMainAxisGroup({super.key, this.keepPinned = false, required List<Widget> slivers})
+    : super(children: slivers);
+
+  /// Whether to keep the sliver children pinned in place.
+  final bool keepPinned;
 
   @override
   MultiChildRenderObjectElement createElement() => _SliverMainAxisGroupElement(this);
 
   @override
   RenderSliverMainAxisGroup createRenderObject(BuildContext context) {
-    return RenderSliverMainAxisGroup();
+    return RenderSliverMainAxisGroup(keepPinned: keepPinned);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, RenderSliverMainAxisGroup renderObject) {
+    renderObject.keepPinned = keepPinned;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('keepPinned', keepPinned, defaultValue: false));
   }
 }
 


### PR DESCRIPTION
Fix #178808.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
