### PR TITLE
Fix #117755: Fix divider color inconsistencies in M2/M3

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -452,7 +452,7 @@ class ThemeData with Diagnosticable {
       canvasColor ??= colorScheme.surface;
       scaffoldBackgroundColor ??= colorScheme.surface;
       cardColor ??= colorScheme.surface;
-      dividerColor ??= colorScheme.outline;
+      dividerColor ??= colorScheme.outlineVariant;
       dialogBackgroundColor ??= colorScheme.surface;
       indicatorColor ??= onPrimarySurfaceColor;
       applyElevationOverlayColor ??= brightness == Brightness.dark;
@@ -855,7 +855,9 @@ class ThemeData with Diagnosticable {
       canvasColor: colorScheme.surface,
       scaffoldBackgroundColor: colorScheme.surface,
       cardColor: colorScheme.surface,
-      dividerColor: colorScheme.onSurface.withOpacity(0.12),
+      dividerColor: (useMaterial3 ?? false)
+          ? colorScheme.outlineVariant
+          : colorScheme.onSurface.withOpacity(0.12),
       dialogBackgroundColor: colorScheme.surface,
       indicatorColor: onPrimarySurfaceColor,
       textTheme: textTheme,
@@ -1210,6 +1212,14 @@ class ThemeData with Diagnosticable {
   ///
   /// To create an appropriate [BorderSide] that uses this color, consider
   /// [Divider.createBorderSide].
+  ///
+  /// In Material 3, defaults to [ColorScheme.outlineVariant].
+  /// In Material 2, defaults to [ColorScheme.onSurface] with 12% opacity.
+  ///
+  /// See also:
+  ///
+  ///  * [Divider], a widget that uses this color.
+  ///  * [VerticalDivider], another widget that uses this color.
   final Color dividerColor;
 
   /// The focus color used indicate that a component has the input focus.

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -241,4 +241,70 @@ void main() {
     );
     expect(tester.getSize(find.byType(VerticalDivider)), Size.zero);
   });
+
+  testWidgets('M3 - dividerColor matches Divider actual color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const Scaffold(body: Divider()),
+      ),
+    );
+
+    final ThemeData theme = Theme.of(tester.element(find.byType(Divider)));
+    final BorderSide border = Divider.createBorderSide(
+      tester.element(find.byType(Divider)),
+    );
+
+    expect(theme.dividerColor, equals(theme.colorScheme.outlineVariant));
+    expect(border.color, equals(theme.colorScheme.outlineVariant));
+    expect(theme.dividerColor, equals(border.color));
+  });
+
+  testWidgets('M3 with colorSchemeSeed - dividerColor is outlineVariant', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          colorSchemeSeed: Colors.blue,
+          useMaterial3: true,
+        ),
+        home: const Scaffold(body: Divider()),
+      ),
+    );
+
+    final ThemeData theme = Theme.of(tester.element(find.byType(Divider)));
+    expect(theme.dividerColor, equals(theme.colorScheme.outlineVariant));
+  });
+
+  testWidgets('M3 with ThemeData.from - dividerColor is outlineVariant', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.from(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+          useMaterial3: true,
+        ),
+        home: const Scaffold(body: Divider()),
+      ),
+    );
+
+    final ThemeData theme = Theme.of(tester.element(find.byType(Divider)));
+    expect(theme.dividerColor, equals(theme.colorScheme.outlineVariant));
+  });
+
+  testWidgets('M2 - dividerColor matches Divider actual color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(body: Divider()),
+      ),
+    );
+
+    final ThemeData theme = Theme.of(tester.element(find.byType(Divider)));
+    final BorderSide border = Divider.createBorderSide(
+      tester.element(find.byType(Divider)),
+    );
+
+    final Color expectedColor = theme.colorScheme.onSurface.withOpacity(0.12);
+    expect(theme.dividerColor, equals(expectedColor));
+    expect(border.color, equals(expectedColor));
+  });
 }


### PR DESCRIPTION
## Description

This PR fixes `ThemeData.dividerColor` to return the correct color that matches what the `Divider` widget actually renders in Material 2 and Material 3.

### Problem

`ThemeData.dividerColor` returned different values depending on how the theme was created, causing inconsistency with the actual `Divider` widget color:

- `ThemeData()` with M3 returned `outline` instead of `outlineVariant`
- `ThemeData.from()` with M3 returned M2 value `onSurface.withOpacity(0.12)` instead of M3 value `outlineVariant`
- `Divider` widget always correctly used `outlineVariant` in M3

This created confusion for developers who expected `Theme.of(context).dividerColor` to match the actual divider color they saw on screen.

### Solution

Updated both `ThemeData()` and `ThemeData.from()` constructors to use the correct divider colors per Material Design specifications:

- **Material 2:** `ColorScheme.onSurface.withOpacity(0.12)` (unchanged)
- **Material 3:** `ColorScheme.outlineVariant` (fixed)

Now all theme creation methods return the correct `dividerColor` that matches what the `Divider` widget actually renders.

### Testing

Added 4 comprehensive tests that verify:
- M3: `dividerColor` equals `outlineVariant` for all theme creation methods
- M3: `dividerColor` matches actual `Divider` widget color
- M2: `dividerColor` equals `onSurface.withOpacity(0.12)` and matches actual `Divider` widget color

## Related Issues

Fixes https://github.com/flutter/flutter/issues/117755

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md