### PR TITLE
[Impeller] Deny-list Adreno 640 and 650 for Vulkan eligibility.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -361,7 +361,11 @@ bool DriverInfoVK::IsKnownBadDriver() const {
   // Fall back to OpenGL ES on older Adreno devices that require additional
   // workarounds in the Impeller Vulkan back end such as disabling framebuffer
   // fetch.
-  if (adreno_gpu_ && *adreno_gpu_ <= AdrenoGPU::kAdreno630) {
+  //
+  // See the following issues:
+  // https://github.com/flutter/flutter/issues/178285
+  // https://github.com/flutter/flutter/issues/178498
+  if (adreno_gpu_ && *adreno_gpu_ <= AdrenoGPU::kAdreno650) {
     return true;
   }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -164,18 +164,18 @@ TEST(DriverInfoVKTest, DriverParsingAdreno) {
 }
 
 TEST(DriverInfoVKTest, DisabledDevices) {
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 620"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 610"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 530"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 512"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 509"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 508"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 505"));
   EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 504"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 505"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 508"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 509"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 512"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 530"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 610"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 620"));
   EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 630"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 640"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 650"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 640"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 650"));
 }
 
 TEST(DriverInfoVKTest, EnabledDevicesMali) {
@@ -184,14 +184,14 @@ TEST(DriverInfoVKTest, EnabledDevicesMali) {
 }
 
 TEST(DriverInfoVKTest, EnabledDevicesAdreno) {
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 750"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 740"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 732"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 730"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 725"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 720"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 710"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 702"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 710"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 720"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 725"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 730"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 732"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 740"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 750"));
 }
 
 bool CanUseFramebufferFetch(std::string_view driver_name, bool qc = true) {


### PR DESCRIPTION
Fallback to OpenGL ES on these devices. See linked issues for rationale.

Fixes https://github.com/flutter/flutter/issues/178285
Fixes https://github.com/flutter/flutter/issues/178498
