### PR TITLE
[ Tool ] Use a separate output directory when the native hooks run the build system

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -456,11 +456,14 @@ class Environment {
   });
 
   Environment copyWith({Directory? outputDir}) {
-    return Environment(
+    return Environment._(
+      outputDir: outputDir ?? this.outputDir,
       projectDir: projectDir,
       packageConfigPath: packageConfigPath,
-      outputDir: outputDir ?? this.outputDir,
+      buildDir: buildDir,
+      rootBuildDir: rootBuildDir,
       cacheDir: cacheDir,
+      defines: defines,
       flutterRootDir: flutterRootDir,
       fileSystem: fileSystem,
       logger: logger,
@@ -469,12 +472,8 @@ class Environment {
       platform: platform,
       analytics: analytics,
       engineVersion: engineVersion,
-      generateDartPluginRegistry: generateDartPluginRegistry,
-      // Use rootBuildDir, which represents the original buildDir passed to
-      // this environment's constructor
-      buildDir: rootBuildDir,
-      defines: defines,
       inputs: inputs,
+      generateDartPluginRegistry: generateDartPluginRegistry,
     );
   }
 

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -455,6 +455,29 @@ class Environment {
     required this.generateDartPluginRegistry,
   });
 
+  Environment copyWith({Directory? outputDir}) {
+    return Environment(
+      projectDir: projectDir,
+      packageConfigPath: packageConfigPath,
+      outputDir: outputDir ?? this.outputDir,
+      cacheDir: cacheDir,
+      flutterRootDir: flutterRootDir,
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+      platform: platform,
+      analytics: analytics,
+      engineVersion: engineVersion,
+      generateDartPluginRegistry: generateDartPluginRegistry,
+      // Use rootBuildDir, which represents the original buildDir passed to
+      // this environment's constructor
+      buildDir: rootBuildDir,
+      defines: defines,
+      inputs: inputs,
+    );
+  }
+
   /// The [Source] value which is substituted with the path to [projectDir].
   static const kProjectDirectory = '{PROJECT_DIR}';
 

--- a/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
@@ -33,7 +33,7 @@ class FlutterHookRunnerNative implements FlutterHookRunner {
     }
     logger?.printTrace('runHooks() - will perform dart build');
 
-    // Use a clone of the environment with a different output direectory
+    // Use a clone of the environment with a different output directory
     // to avoid conflicts with the primary build's outputs.
     final String outputDirPath = environment.fileSystem.path.join(
       environment.outputDir.path,

--- a/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
@@ -39,23 +39,8 @@ class FlutterHookRunnerNative implements FlutterHookRunner {
       environment.outputDir.path,
       kHooksOutputDirectory,
     );
-    final hooksEnvironment = Environment(
-      projectDir: environment.projectDir,
-      packageConfigPath: environment.packageConfigPath,
+    final Environment hooksEnvironment = environment.copyWith(
       outputDir: environment.fileSystem.directory(outputDirPath),
-      cacheDir: environment.cacheDir,
-      flutterRootDir: environment.flutterRootDir,
-      fileSystem: environment.fileSystem,
-      logger: environment.logger,
-      artifacts: environment.artifacts,
-      processManager: environment.processManager,
-      platform: environment.platform,
-      analytics: environment.analytics,
-      engineVersion: environment.engineVersion,
-      generateDartPluginRegistry: environment.generateDartPluginRegistry,
-      buildDir: environment.rootBuildDir,
-      defines: environment.defines,
-      inputs: environment.inputs,
     );
     final BuildResult lastBuild = await globals.buildSystem.build(
       DartBuild(specifiedTargetPlatform: targetPlatform),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/hook_runner_native_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/hook_runner_native_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/targets/hook_runner_native.dart';
+
+import '../../../src/common.dart';
+import '../../../src/context.dart';
+import '../../../src/test_build_system.dart';
+
+void main() {
+  late FileSystem fs;
+
+  setUp(() {
+    fs = MemoryFileSystem.test();
+  });
+
+  testUsingContext(
+    'FlutterHookRunnerNative uses a separate output directory',
+    () async {
+      final hookRunner = FlutterHookRunnerNative();
+      final environment = Environment.test(
+        fs.currentDirectory,
+        processManager: FakeProcessManager.any(),
+        artifacts: Artifacts.test(),
+        fileSystem: fs,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(),
+        defines: {},
+      );
+
+      await hookRunner.runHooks(
+        targetPlatform: TargetPlatform.linux_x64,
+        environment: environment,
+        logger: environment.logger,
+      );
+    },
+    overrides: <Type, Generator>{
+      BuildSystem: () =>
+          TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
+            expect(
+              fs.path.basename(environment.outputDir.path),
+              FlutterHookRunnerNative.kHooksOutputDirectory,
+            );
+          }),
+    },
+  );
+}


### PR DESCRIPTION
FlutterBuildSystem.trackSharedBuildDirectory stores a hash of the most recently run build configuration in the output directory defined in the environment.

If the build executed by FlutterHookRunnerNative uses the same output directory as other builds, then trackSharedBuildDirectory may think that the hook build's output list replaces the outputs of those previous builds.  trackSharedBuildDirectory will then incorrectly delete files in the previous output list because they are not part of the hook build's outputs.

See https://github.com/flutter/flutter/issues/178529