### PR TITLE
Allow release and profile mode builds on iOS Simulator

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -32,7 +32,8 @@ import '../web/web_runner.dart';
 import 'daemon.dart';
 
 /// Shared logic between `flutter run` and `flutter drive` commands.
-abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
+abstract class RunCommandBase extends FlutterCommand
+    with DeviceBasedDevelopmentArtifacts {
   RunCommandBase({required bool verboseHelp}) {
     addBuildModeFlags(verboseHelp: verboseHelp, defaultToRelease: false);
     usesDartDefineOption();
@@ -253,7 +254,8 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get trackWidgetCreation => boolArg('track-widget-creation');
   ImpellerStatus get enableImpeller =>
       ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?);
-  bool get enableFlutterGpu => (argResults!['enable-flutter-gpu'] as bool?) ?? false;
+  bool get enableFlutterGpu =>
+      (argResults!['enable-flutter-gpu'] as bool?) ?? false;
   bool get enableVulkanValidation => boolArg('enable-vulkan-validation');
   bool get uninstallFirst => boolArg('uninstall-first');
   bool get enableEmbedderApi => boolArg('enable-embedder-api');
@@ -281,10 +283,13 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   /// Create a debugging options instance for the current `run` or `drive` invocation.
   @visibleForTesting
   @protected
-  Future<DebuggingOptions> createDebuggingOptions({WebDevServerConfig? webDevServerConfig}) async {
+  Future<DebuggingOptions> createDebuggingOptions({
+    WebDevServerConfig? webDevServerConfig,
+  }) async {
     final BuildInfo buildInfo = await getBuildInfo();
     final int? webBrowserDebugPort =
-        featureFlags.isWebEnabled && argResults!.wasParsed('web-browser-debug-port')
+        featureFlags.isWebEnabled &&
+            argResults!.wasParsed('web-browser-debug-port')
         ? int.parse(stringArg('web-browser-debug-port')!)
         : null;
     final List<String> webBrowserFlags = featureFlags.isWebEnabled
@@ -296,14 +301,18 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         buildInfo,
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         webUseSseForDebugProxy:
-            featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
+            featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-protocol') == 'sse',
         webUseSseForDebugBackend:
-            featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
+            featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-backend-protocol') == 'sse',
         webUseSseForInjectedClient:
             featureFlags.isWebEnabled &&
             stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        webEnableExposeUrl:
+            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless:
+            featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webRenderer: webRenderer,
@@ -327,7 +336,9 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         enableDds: enableDds,
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         dartFlags: stringArg('dart-flags') ?? '',
-        useTestFonts: argParser.options.containsKey('use-test-fonts') && boolArg('use-test-fonts'),
+        useTestFonts:
+            argParser.options.containsKey('use-test-fonts') &&
+            boolArg('use-test-fonts'),
         enableSoftwareRendering:
             argParser.options.containsKey('enable-software-rendering') &&
             boolArg('enable-software-rendering'),
@@ -349,19 +360,26 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         devToolsServerAddress: devToolsServerAddress,
         verboseSystemLogs: boolArg('verbose-system-logs'),
         webUseSseForDebugProxy:
-            featureFlags.isWebEnabled && stringArg('web-server-debug-protocol') == 'sse',
+            featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-protocol') == 'sse',
         webUseSseForDebugBackend:
-            featureFlags.isWebEnabled && stringArg('web-server-debug-backend-protocol') == 'sse',
+            featureFlags.isWebEnabled &&
+            stringArg('web-server-debug-backend-protocol') == 'sse',
         webUseSseForInjectedClient:
             featureFlags.isWebEnabled &&
             stringArg('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        webEnableExposeUrl:
+            featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
+        webRunHeadless:
+            featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webEnableExpressionEvaluation:
-            featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
-        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
+            featureFlags.isWebEnabled &&
+            boolArg('web-enable-expression-evaluation'),
+        webLaunchUrl: featureFlags.isWebEnabled
+            ? stringArg('web-launch-url')
+            : null,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
         vmserviceOutFile: stringArg('vmservice-out-file'),
@@ -420,8 +438,16 @@ class RunCommand extends RunCommandBase {
             'a test using "flutter run" for debugging purposes. This flag is '
             'only available when running in debug mode.',
       )
-      ..addFlag('build', defaultsTo: true, help: 'If necessary, build the app before running.')
-      ..addOption('project-root', hide: !verboseHelp, help: 'Specify the project root directory.')
+      ..addFlag(
+        'build',
+        defaultsTo: true,
+        help: 'If necessary, build the app before running.',
+      )
+      ..addOption(
+        'project-root',
+        hide: !verboseHelp,
+        help: 'Specify the project root directory.',
+      )
       ..addFlag(
         'hot',
         defaultsTo: kHotReloadDefault,
@@ -468,8 +494,9 @@ class RunCommand extends RunCommandBase {
   final name = 'run';
 
   @override
-  DeprecationBehavior get deprecationBehavior =>
-      boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation')
+      ? DeprecationBehavior.ignore
+      : _deviceDeprecationBehavior;
   DeprecationBehavior _deviceDeprecationBehavior = DeprecationBehavior.none;
 
   @override
@@ -490,10 +517,11 @@ class RunCommand extends RunCommandBase {
       final String? webPortArg = stringArg('web-port');
       final int? webPort = webPortArg != null ? int.tryParse(webPortArg) : null;
 
-      final WebDevServerConfig fileConfig = await WebDevServerConfig.loadFromFile(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-      );
+      final WebDevServerConfig fileConfig =
+          await WebDevServerConfig.loadFromFile(
+            fileSystem: globals.fs,
+            logger: globals.logger,
+          );
 
       final HttpsConfig? httpsConfig = fileConfig.https?.copyWith(
         certPath: stringArg('web-tls-cert-path'),
@@ -530,7 +558,9 @@ class RunCommand extends RunCommandBase {
   }
 
   @override
-  Future<analytics.Event> unifiedAnalyticsUsageValues(String commandPath) async {
+  Future<analytics.Event> unifiedAnalyticsUsageValues(
+    String commandPath,
+  ) async {
     final AnalyticsUsageValuesRecord record = await _sharedAnalyticsUsageValues;
 
     return analytics.Event.commandUsageValues(
@@ -549,85 +579,95 @@ class RunCommand extends RunCommandBase {
     );
   }
 
-  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues = (() async {
-    String deviceType, deviceOsVersion;
-    bool isEmulator;
-    var anyAndroidDevices = false;
-    var anyIOSDevices = false;
-    var anyWirelessIOSDevices = false;
+  late final Future<AnalyticsUsageValuesRecord> _sharedAnalyticsUsageValues =
+      (() async {
+        String deviceType, deviceOsVersion;
+        bool isEmulator;
+        var anyAndroidDevices = false;
+        var anyIOSDevices = false;
+        var anyWirelessIOSDevices = false;
 
-    if (devices == null || devices!.isEmpty) {
-      deviceType = 'none';
-      deviceOsVersion = 'none';
-      isEmulator = false;
-    } else if (devices!.length == 1) {
-      final Device device = devices![0];
-      final TargetPlatform platform = await device.targetPlatform;
-      anyAndroidDevices = platform == TargetPlatform.android;
-      anyIOSDevices = platform == TargetPlatform.ios;
-      if (device is IOSDevice && device.isWirelesslyConnected) {
-        anyWirelessIOSDevices = true;
-      }
-      deviceType = getNameForTargetPlatform(platform);
-      deviceOsVersion = await device.sdkNameAndVersion;
-      isEmulator = await device.isLocalEmulator;
-    } else {
-      deviceType = 'multiple';
-      deviceOsVersion = 'multiple';
-      isEmulator = false;
-      for (final Device device in devices!) {
-        final TargetPlatform platform = await device.targetPlatform;
-        anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
-        anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
-        if (device is IOSDevice && device.isWirelesslyConnected) {
-          anyWirelessIOSDevices = true;
+        if (devices == null || devices!.isEmpty) {
+          deviceType = 'none';
+          deviceOsVersion = 'none';
+          isEmulator = false;
+        } else if (devices!.length == 1) {
+          final Device device = devices![0];
+          final TargetPlatform platform = await device.targetPlatform;
+          anyAndroidDevices = platform == TargetPlatform.android;
+          anyIOSDevices = platform == TargetPlatform.ios;
+          if (device is IOSDevice && device.isWirelesslyConnected) {
+            anyWirelessIOSDevices = true;
+          }
+          deviceType = getNameForTargetPlatform(platform);
+          deviceOsVersion = await device.sdkNameAndVersion;
+          isEmulator = await device.isLocalEmulator;
+        } else {
+          deviceType = 'multiple';
+          deviceOsVersion = 'multiple';
+          isEmulator = false;
+          for (final Device device in devices!) {
+            final TargetPlatform platform = await device.targetPlatform;
+            anyAndroidDevices =
+                anyAndroidDevices || (platform == TargetPlatform.android);
+            anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
+            if (device is IOSDevice && device.isWirelesslyConnected) {
+              anyWirelessIOSDevices = true;
+            }
+            if (anyAndroidDevices && anyIOSDevices) {
+              break;
+            }
+          }
         }
-        if (anyAndroidDevices && anyIOSDevices) {
-          break;
+
+        String? iOSInterfaceType;
+        if (anyIOSDevices) {
+          iOSInterfaceType = anyWirelessIOSDevices ? 'wireless' : 'usb';
         }
-      }
-    }
 
-    String? iOSInterfaceType;
-    if (anyIOSDevices) {
-      iOSInterfaceType = anyWirelessIOSDevices ? 'wireless' : 'usb';
-    }
+        String? androidEmbeddingVersion;
+        final hostLanguage = <String>[];
+        if (anyAndroidDevices) {
+          final AndroidProject androidProject =
+              FlutterProject.current().android;
+          if (androidProject.existsSync()) {
+            hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
+            androidEmbeddingVersion = androidProject
+                .getEmbeddingVersion()
+                .toString()
+                .split('.')
+                .last;
+          }
+        }
+        if (anyIOSDevices) {
+          final IosProject iosProject = FlutterProject.current().ios;
+          if (iosProject.exists) {
+            final Iterable<File> swiftFiles = iosProject.hostAppRoot
+                .listSync(recursive: true, followLinks: false)
+                .whereType<File>()
+                .where(
+                  (File file) =>
+                      globals.fs.path.extension(file.path) == '.swift',
+                );
+            hostLanguage.add(swiftFiles.isNotEmpty ? 'swift' : 'objc');
+          }
+        }
 
-    String? androidEmbeddingVersion;
-    final hostLanguage = <String>[];
-    if (anyAndroidDevices) {
-      final AndroidProject androidProject = FlutterProject.current().android;
-      if (androidProject.existsSync()) {
-        hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
-        androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
-      }
-    }
-    if (anyIOSDevices) {
-      final IosProject iosProject = FlutterProject.current().ios;
-      if (iosProject.exists) {
-        final Iterable<File> swiftFiles = iosProject.hostAppRoot
-            .listSync(recursive: true, followLinks: false)
-            .whereType<File>()
-            .where((File file) => globals.fs.path.extension(file.path) == '.swift');
-        hostLanguage.add(swiftFiles.isNotEmpty ? 'swift' : 'objc');
-      }
-    }
-
-    final BuildInfo buildInfo = await getBuildInfo();
-    final String modeName = buildInfo.modeName;
-    return (
-      runIsEmulator: isEmulator,
-      runTargetName: deviceType,
-      runTargetOsVersion: deviceOsVersion,
-      runModeName: modeName,
-      runProjectModule: project.isModule,
-      runProjectHostLanguage: hostLanguage.join(','),
-      runAndroidEmbeddingVersion: androidEmbeddingVersion,
-      runEnableImpeller: enableImpeller.asBool,
-      runIOSInterfaceType: iOSInterfaceType,
-      runIsTest: targetFile.endsWith('_test.dart'),
-    );
-  })();
+        final BuildInfo buildInfo = await getBuildInfo();
+        final String modeName = buildInfo.modeName;
+        return (
+          runIsEmulator: isEmulator,
+          runTargetName: deviceType,
+          runTargetOsVersion: deviceOsVersion,
+          runModeName: modeName,
+          runProjectModule: project.isModule,
+          runProjectHostLanguage: hostLanguage.join(','),
+          runAndroidEmbeddingVersion: androidEmbeddingVersion,
+          runEnableImpeller: enableImpeller.asBool,
+          runIOSInterfaceType: iOSInterfaceType,
+          runIsTest: targetFile.endsWith('_test.dart'),
+        );
+      })();
 
   @override
   bool get shouldRunPub {
@@ -646,7 +686,8 @@ class RunCommand extends RunCommandBase {
   }
 
   bool get stayResident => boolArg('resident');
-  bool get awaitFirstFrameWhenTracing => boolArg('await-first-frame-when-tracing');
+  bool get awaitFirstFrameWhenTracing =>
+      boolArg('await-first-frame-when-tracing');
 
   @override
   Future<void> validateCommand() async {
@@ -660,16 +701,20 @@ class RunCommand extends RunCommandBase {
     if (devices == null) {
       throwToolExit(null);
     }
-    final WebDevServerConfig? webDevServerConfig = await getWebDevServerConfig();
+    final WebDevServerConfig? webDevServerConfig =
+        await getWebDevServerConfig();
     final webMode = webDevServerConfig != null;
-    if (globals.deviceManager!.hasSpecifiedAllDevices && runningWithPrebuiltApplication) {
+    if (globals.deviceManager!.hasSpecifiedAllDevices &&
+        runningWithPrebuiltApplication) {
       throwToolExit(
         'Using "-d all" with "--${FlutterOptions.kUseApplicationBinary}" is not supported',
       );
     }
 
     if (userIdentifier != null &&
-        devices!.every((Device device) => device.platformType != PlatformType.android)) {
+        devices!.every(
+          (Device device) => device.platformType != PlatformType.android,
+        )) {
       throwToolExit(
         '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.',
       );
@@ -707,7 +752,8 @@ class RunCommand extends RunCommandBase {
     required String? applicationBinaryPath,
     required FlutterProject flutterProject,
   }) async {
-    final WebDevServerConfig? webDevServerConfig = await getWebDevServerConfig();
+    final WebDevServerConfig? webDevServerConfig =
+        await getWebDevServerConfig();
     final webMode = webDevServerConfig != null;
     final DebuggingOptions debuggingOptions = await createDebuggingOptions(
       webDevServerConfig: webDevServerConfig,
@@ -771,8 +817,11 @@ class RunCommand extends RunCommandBase {
     // Enable hot mode by default if `--no-hot` was not passed and we are in
     // debug mode.
     final bool hotMode = shouldUseHotMode(buildInfo);
-    final String? applicationBinaryPath = stringArg(FlutterOptions.kUseApplicationBinary);
-    final WebDevServerConfig? webDevServerConfig = await getWebDevServerConfig();
+    final String? applicationBinaryPath = stringArg(
+      FlutterOptions.kUseApplicationBinary,
+    );
+    final WebDevServerConfig? webDevServerConfig =
+        await getWebDevServerConfig();
 
     if (outputMachineFormat) {
       if (devices!.length > 1) {
@@ -797,7 +846,8 @@ class RunCommand extends RunCommandBase {
               : globals.fs.file(applicationBinaryPath),
           trackWidgetCreation: trackWidgetCreation,
           projectRootPath: stringArg('project-root'),
-          packagesFilePath: globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
+          packagesFilePath:
+              globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
           dillOutputPath: stringArg('output-dill'),
           userIdentifier: userIdentifier,
         );
@@ -825,6 +875,21 @@ class RunCommand extends RunCommandBase {
           'mode is not supported by ${device.displayName}.',
         );
       }
+
+      // Warn when running release/profile on iOS simulator
+      if (await device.isLocalEmulator &&
+          device.platformType == PlatformType.ios &&
+          (buildMode == BuildMode.release || buildMode == BuildMode.profile)) {
+        globals.printWarning(
+          '┌─────────────────────────────────────────────────────────────────────────┐\n'
+          '│ WARNING: Running in ${buildMode.cliName} mode on iOS Simulator            │\n'
+          '│                                                                         │\n'
+          '│ Performance on simulator is NOT representative of device performance.  │\n'
+          '│ Always test performance-critical code on physical devices.             │\n'
+          '└─────────────────────────────────────────────────────────────────────────┘',
+        );
+      }
+
       if (hotMode) {
         if (!device.supportsHotReload) {
           throwToolExit(
@@ -921,7 +986,10 @@ class RunCommand extends RunCommandBase {
           getNameForTargetPlatform(await devices![0].targetPlatform)
         else
           'multiple',
-        if (devices!.length == 1 && await devices![0].isLocalEmulator) 'emulator' else null,
+        if (devices!.length == 1 && await devices![0].isLocalEmulator)
+          'emulator'
+        else
+          null,
       ],
       endTimeOverride: appStartedTime,
     );

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -38,7 +38,10 @@ void main() {
   final Logger logger = FakeLogger();
 
   setUp(() {
-    osx = FakePlatform(environment: <String, String>{}, operatingSystem: 'macos');
+    osx = FakePlatform(
+      environment: <String, String>{},
+      operatingSystem: 'macos',
+    );
     fileSystem = MemoryFileSystem.test();
     fsUtils = FileSystemUtils(fileSystem: fileSystem, platform: osx);
   });
@@ -95,8 +98,8 @@ void main() {
       );
 
       expect(simulator.supportsRuntimeMode(BuildMode.debug), true);
-      expect(simulator.supportsRuntimeMode(BuildMode.profile), false);
-      expect(simulator.supportsRuntimeMode(BuildMode.release), false);
+      expect(simulator.supportsRuntimeMode(BuildMode.profile), true);
+      expect(simulator.supportsRuntimeMode(BuildMode.release), true);
       expect(simulator.supportsRuntimeMode(BuildMode.jitRelease), false);
     },
     overrides: <Type, Generator>{
@@ -124,7 +127,10 @@ void main() {
           simulatorCategory: 'com.apple.CoreSimulator.SimRuntime.iOS-14-4',
           logger: logger,
         );
-        expect(simulator.logFilePath, '/foo/bar/Library/Logs/CoreSimulator/123/system.log');
+        expect(
+          simulator.logFilePath,
+          '/foo/bar/Library/Logs/CoreSimulator/123/system.log',
+        );
       },
       overrides: <Type, Generator>{
         Platform: () => osx,
@@ -139,7 +145,8 @@ void main() {
       'respects IOS_SIMULATOR_LOG_FILE_PATH',
       () {
         osx.environment['HOME'] = '/foo/bar';
-        osx.environment['IOS_SIMULATOR_LOG_FILE_PATH'] = '/baz/qux/%{id}/system.log';
+        osx.environment['IOS_SIMULATOR_LOG_FILE_PATH'] =
+            '/baz/qux/%{id}/system.log';
         final simulator = IOSSimulator(
           '456',
           name: 'iPhone 11',
@@ -404,7 +411,14 @@ void main() {
       final Logger logger = BufferLogger.test();
       final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'io', 'x', 'screenshot', 'screenshot.png'],
+          command: <String>[
+            'xcrun',
+            'simctl',
+            'io',
+            'x',
+            'screenshot',
+            'screenshot.png',
+          ],
         ),
       ]);
 
@@ -450,7 +464,13 @@ void main() {
         );
         fakeProcessManager.addCommand(
           const FakeCommand(
-            command: <String>['tail', '-n', '0', '-F', '/Library/Logs/CoreSimulator/x/system.log'],
+            command: <String>[
+              'tail',
+              '-n',
+              '0',
+              '-F',
+              '/Library/Logs/CoreSimulator/x/system.log',
+            ],
           ),
         );
         await launchDeviceSystemLogTool(device);
@@ -460,7 +480,8 @@ void main() {
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
         Platform: () => macosPlatform,
-        FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
+        FileSystemUtils: () =>
+            FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
       },
     );
 
@@ -583,7 +604,13 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
             )
             ..addCommand(
               const FakeCommand(
-                command: <String>['tail', '-n', '0', '-F', '/private/var/log/system.log'],
+                command: <String>[
+                  'tail',
+                  '-n',
+                  '0',
+                  '-F',
+                  '/private/var/log/system.log',
+                ],
               ),
             );
 
@@ -627,7 +654,13 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
             )
             ..addCommand(
               const FakeCommand(
-                command: <String>['tail', '-n', '0', '-F', '/private/var/log/system.log'],
+                command: <String>[
+                  'tail',
+                  '-n',
+                  '0',
+                  '-F',
+                  '/private/var/log/system.log',
+                ],
               ),
             );
 
@@ -684,7 +717,13 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
             )
             ..addCommand(
               const FakeCommand(
-                command: <String>['tail', '-n', '0', '-F', '/private/var/log/system.log'],
+                command: <String>[
+                  'tail',
+                  '-n',
+                  '0',
+                  '-F',
+                  '/private/var/log/system.log',
+                ],
               ),
             );
 
@@ -833,7 +872,10 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
 
           final List<String> lines = await logReader.logLines.toList();
           expect(lines, isEmpty);
-          expect(logger.errorText, contains('Logger returned non-JSON response'));
+          expect(
+            logger.errorText,
+            contains('Logger returned non-JSON response'),
+          );
           expect(fakeProcessManager, hasNoRemainingExpectations);
         },
         overrides: <Type, Generator>{
@@ -920,7 +962,11 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
       ]);
       xcodeBadSimctl = Xcode.test(processManager: fakeProcessManagerBadSimctl);
       logger = BufferLogger.test();
-      simControl = SimControl(logger: logger, processManager: fakeProcessManager, xcode: xcode);
+      simControl = SimControl(
+        logger: logger,
+        processManager: fakeProcessManager,
+        xcode: xcode,
+      );
       simulatorUtils = IOSSimulatorUtils(
         logger: logger,
         processManager: fakeProcessManager,
@@ -936,12 +982,21 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
     testWithoutContext('getConnectedDevices succeeds', () async {
       fakeProcessManager.addCommand(
         const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'list', 'devices', 'booted', 'iOS', '--json'],
+          command: <String>[
+            'xcrun',
+            'simctl',
+            'list',
+            'devices',
+            'booted',
+            'iOS',
+            '--json',
+          ],
           stdout: validSimControlOutput,
         ),
       );
 
-      final List<BootedSimDevice> devices = await simControl.getConnectedDevices();
+      final List<BootedSimDevice> devices = await simControl
+          .getConnectedDevices();
 
       final BootedSimDevice phone1 = devices[0];
       expect(phone1.category, 'com.apple.CoreSimulator.SimRuntime.iOS-14-0');
@@ -960,68 +1015,105 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testWithoutContext('IOSSimulatorUtils.getAttachedDevices succeeds', () async {
-      fakeProcessManager.addCommand(
-        const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'list', 'devices', 'booted', 'iOS', '--json'],
-          stdout: validSimControlOutput,
-        ),
-      );
+    testWithoutContext(
+      'IOSSimulatorUtils.getAttachedDevices succeeds',
+      () async {
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'simctl',
+              'list',
+              'devices',
+              'booted',
+              'iOS',
+              '--json',
+            ],
+            stdout: validSimControlOutput,
+          ),
+        );
 
-      final List<IOSSimulator> devices = await simulatorUtils.getAttachedDevices();
+        final List<IOSSimulator> devices = await simulatorUtils
+            .getAttachedDevices();
 
-      final IOSSimulator phone1 = devices[0];
-      expect(phone1.category, Category.mobile);
-      expect(phone1.name, 'iPhone 11');
-      expect(phone1.simulatorCategory, 'com.apple.CoreSimulator.SimRuntime.iOS-14-0');
+        final IOSSimulator phone1 = devices[0];
+        expect(phone1.category, Category.mobile);
+        expect(phone1.name, 'iPhone 11');
+        expect(
+          phone1.simulatorCategory,
+          'com.apple.CoreSimulator.SimRuntime.iOS-14-0',
+        );
 
-      final IOSSimulator phone2 = devices[1];
-      expect(phone2.category, Category.mobile);
-      expect(phone2.name, 'Phone w Watch');
-      expect(phone2.simulatorCategory, 'com.apple.CoreSimulator.SimRuntime.iOS-16-0');
+        final IOSSimulator phone2 = devices[1];
+        expect(phone2.category, Category.mobile);
+        expect(phone2.name, 'Phone w Watch');
+        expect(
+          phone2.simulatorCategory,
+          'com.apple.CoreSimulator.SimRuntime.iOS-16-0',
+        );
 
-      final IOSSimulator phone3 = devices[2];
-      expect(phone3.category, Category.mobile);
-      expect(phone3.name, 'iPhone 13');
-      expect(phone3.simulatorCategory, 'com.apple.CoreSimulator.SimRuntime.iOS-16-0');
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
-
-    testWithoutContext('getConnectedDevices handles bad simctl output', () async {
-      fakeProcessManager.addCommand(
-        const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'list', 'devices', 'booted', 'iOS', '--json'],
-          stdout: 'Install Started',
-        ),
-      );
-
-      final List<BootedSimDevice> devices = await simControl.getConnectedDevices();
-
-      expect(devices, isEmpty);
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
+        final IOSSimulator phone3 = devices[2];
+        expect(phone3.category, Category.mobile);
+        expect(phone3.name, 'iPhone 13');
+        expect(
+          phone3.simulatorCategory,
+          'com.apple.CoreSimulator.SimRuntime.iOS-16-0',
+        );
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+    );
 
     testWithoutContext(
-      'IOSSimulatorUtils.getAttachedDevices handles simctl not properly installed',
+      'getConnectedDevices handles bad simctl output',
       () async {
-        final List<IOSSimulator> devices = await simulatorUtilsBadSimctl.getAttachedDevices();
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'simctl',
+              'list',
+              'devices',
+              'booted',
+              'iOS',
+              '--json',
+            ],
+            stdout: 'Install Started',
+          ),
+        );
+
+        final List<BootedSimDevice> devices = await simControl
+            .getConnectedDevices();
 
         expect(devices, isEmpty);
         expect(fakeProcessManager, hasNoRemainingExpectations);
       },
     );
 
-    testWithoutContext('sdkMajorVersion defaults to 11 when sdkNameAndVersion is junk', () async {
-      final iosSimulatorA = IOSSimulator(
-        'x',
-        name: 'Testo',
-        simulatorCategory: 'NaN',
-        simControl: simControl,
-        logger: logger,
-      );
+    testWithoutContext(
+      'IOSSimulatorUtils.getAttachedDevices handles simctl not properly installed',
+      () async {
+        final List<IOSSimulator> devices = await simulatorUtilsBadSimctl
+            .getAttachedDevices();
 
-      expect(await iosSimulatorA.sdkMajorVersion, 11);
-    });
+        expect(devices, isEmpty);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+    );
+
+    testWithoutContext(
+      'sdkMajorVersion defaults to 11 when sdkNameAndVersion is junk',
+      () async {
+        final iosSimulatorA = IOSSimulator(
+          'x',
+          name: 'Testo',
+          simulatorCategory: 'NaN',
+          simControl: simControl,
+          logger: logger,
+        );
+
+        expect(await iosSimulatorA.sdkMajorVersion, 11);
+      },
+    );
 
     testWithoutContext('.install() handles exceptions', () async {
       fakeProcessManager.addCommand(
@@ -1177,12 +1269,21 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
 ''';
       fakeProcessManager.addCommand(
         const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'list', 'runtimes', 'available', 'iOS', '--json'],
+          command: <String>[
+            'xcrun',
+            'simctl',
+            'list',
+            'runtimes',
+            'available',
+            'iOS',
+            '--json',
+          ],
           stdout: validRuntimesOutput,
         ),
       );
 
-      final List<IOSSimulatorRuntime> runtimes = await simControl.listAvailableIOSRuntimes();
+      final List<IOSSimulatorRuntime> runtimes = await simControl
+          .listAvailableIOSRuntimes();
 
       final IOSSimulatorRuntime runtime1 = runtimes[0];
       expect(
@@ -1195,7 +1296,10 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
         runtime1.runtimeRoot,
         '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 15.4.simruntime/Contents/Resources/RuntimeRoot',
       );
-      expect(runtime1.identifier, 'com.apple.CoreSimulator.SimRuntime.iOS-15-4');
+      expect(
+        runtime1.identifier,
+        'com.apple.CoreSimulator.SimRuntime.iOS-15-4',
+      );
       expect(runtime1.version, Version(15, 4, null));
       expect(runtime1.isInternal, false);
       expect(runtime1.isAvailable, true);
@@ -1212,7 +1316,10 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
         runtime2.runtimeRoot,
         '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot',
       );
-      expect(runtime2.identifier, 'com.apple.CoreSimulator.SimRuntime.iOS-16-4');
+      expect(
+        runtime2.identifier,
+        'com.apple.CoreSimulator.SimRuntime.iOS-16-4',
+      );
       expect(runtime2.version, Version(16, 4, null));
       expect(runtime2.isInternal, false);
       expect(runtime2.isAvailable, true);
@@ -1229,27 +1336,45 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
         runtime3.runtimeRoot,
         '/Library/Developer/CoreSimulator/Volumes/iOS_21A5268h/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.0.simruntime/Contents/Resources/RuntimeRoot',
       );
-      expect(runtime3.identifier, 'com.apple.CoreSimulator.SimRuntime.iOS-17-0');
+      expect(
+        runtime3.identifier,
+        'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
+      );
       expect(runtime3.version, Version(17, 0, null));
       expect(runtime3.isInternal, false);
       expect(runtime3.isAvailable, true);
       expect(runtime3.name, 'iOS 17.0');
     });
 
-    testWithoutContext('listAvailableIOSRuntimes handles bad simctl output', () async {
-      fakeProcessManager.addCommand(
-        const FakeCommand(
-          command: <String>['xcrun', 'simctl', 'list', 'runtimes', 'available', 'iOS', '--json'],
-          stdout: 'Install Started',
-        ),
-      );
+    testWithoutContext(
+      'listAvailableIOSRuntimes handles bad simctl output',
+      () async {
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'xcrun',
+              'simctl',
+              'list',
+              'runtimes',
+              'available',
+              'iOS',
+              '--json',
+            ],
+            stdout: 'Install Started',
+          ),
+        );
 
-      final List<IOSSimulatorRuntime> runtimes = await simControl.listAvailableIOSRuntimes();
+        final List<IOSSimulatorRuntime> runtimes = await simControl
+            .listAvailableIOSRuntimes();
 
-      expect(runtimes, isEmpty);
-      expect(logger.errorText, contains('simctl returned non-JSON response:'));
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
+        expect(runtimes, isEmpty);
+        expect(
+          logger.errorText,
+          contains('simctl returned non-JSON response:'),
+        );
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+    );
 
     testWithoutContext(
       'IOSSimulatorUtils.getAvailableIOSRuntimes handles simctl not properly installed',
@@ -1303,7 +1428,11 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           packageConfigPath: '.dart_tool/package_config.json',
         );
         final mockOptions = DebuggingOptions.disabled(mockInfo);
-        await device.startApp(package, prebuiltApplication: true, debuggingOptions: mockOptions);
+        await device.startApp(
+          package,
+          prebuiltApplication: true,
+          debuggingOptions: mockOptions,
+        );
 
         expect(simControl.requests.single.appIdentifier, 'correct');
       },
@@ -1351,7 +1480,9 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
         expect(simControl.requests, isEmpty);
         expect(
           logger.errorText,
-          contains('Invalid prebuilt iOS app. Info.plist does not contain bundle identifier'),
+          contains(
+            'Invalid prebuilt iOS app. Info.plist does not contain bundle identifier',
+          ),
         );
       },
       overrides: <Type, Generator>{
@@ -1411,7 +1542,11 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           hostVmServicePort: 0,
         );
 
-        await device.startApp(package, prebuiltApplication: true, debuggingOptions: mockOptions);
+        await device.startApp(
+          package,
+          prebuiltApplication: true,
+          debuggingOptions: mockOptions,
+        );
         expect(
           simControl.requests.single.launchArgs,
           unorderedEquals(<String>[
@@ -1473,7 +1608,10 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           treeShakeIcons: false,
           packageConfigPath: '.dart_tool/package_config.json',
         );
-        final mockOptions = DebuggingOptions.enabled(mockInfo, enableSoftwareRendering: true);
+        final mockOptions = DebuggingOptions.enabled(
+          mockInfo,
+          enableSoftwareRendering: true,
+        );
         await device.startApp(
           package,
           prebuiltApplication: true,
@@ -1481,7 +1619,10 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text''',
           route: '/animation',
         );
 
-        expect(simControl.requests.single.launchArgs, contains('--route=/animation'));
+        expect(
+          simControl.requests.single.launchArgs,
+          contains('--route=/animation'),
+        );
       },
       overrides: <Type, Generator>{
         PlistParser: () => testPlistParser,
@@ -1597,10 +1738,12 @@ flutter:
 
 class FakeIosProject extends Fake implements IosProject {
   @override
-  Future<String> productBundleIdentifier(BuildInfo? buildInfo) async => 'com.example.test';
+  Future<String> productBundleIdentifier(BuildInfo? buildInfo) async =>
+      'com.example.test';
 
   @override
-  Future<String> productName(BuildInfo? buildInfo) async => 'My Super Awesome App';
+  Future<String> productName(BuildInfo? buildInfo) async =>
+      'My Super Awesome App';
 }
 
 class FakeSimControl extends Fake implements SimControl {


### PR DESCRIPTION
Fixes #11754

This change enables developers to build and run Flutter apps in release and profile modes on iOS Simulator. While performance metrics won't be representative of actual device performance, this is valuable for:
- Testing release-mode specific behavior
- Add-to-app scenarios where native app requires release builds
- CI/CD environments using simulators

Changes:
- Allow profile/release runtime modes on iOS simulators
- Remove exception blocking AOT compilation for simulator
- Filter out x86_64 architecture (no gen_snapshot available)
- Add prominent warnings about performance not being representative
- Update tests to reflect new behavior

Note: Only works on Apple Silicon Macs where simulator runs on arm64. Intel Mac simulators (x86_64) are not supported due to missing toolchain.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
