### PR TITLE
Fix DropdownMenuEntry.style not resolved when entry is highlighted

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -727,6 +727,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
   TextEditingController get _effectiveTextEditingController =>
       widget.controller ?? (_localTextEditingController ??= TextEditingController());
   final FocusNode _internalFocudeNode = FocusNode();
+  WidgetStatesController? _highlightedItemStatesController;
 
   FocusNode? _localTrailingIconButtonFocusNode;
   FocusNode get _trailingIconButtonFocusNode =>
@@ -759,6 +760,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
     _internalFocudeNode.dispose();
     _localTrailingIconButtonFocusNode?.dispose();
     _localTrailingIconButtonFocusNode = null;
+    _highlightedItemStatesController?.dispose();
     super.dispose();
   }
 
@@ -931,7 +933,13 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
       // Simulate the focused state because the text field should always be focused
       // during traversal. Include potential MenuItemButton theme in the focus
       // simulation for all colors in the theme.
-      if (entry.enabled && i == focusedIndex) {
+      final bool entryIsSelected = entry.enabled && i == focusedIndex;
+      if (entryIsSelected) {
+        _highlightedItemStatesController?.dispose();
+        _highlightedItemStatesController = WidgetStatesController(<WidgetState>{
+          WidgetState.focused,
+        });
+
         // Query the Material 3 default style.
         // TODO(bleroux): replace once a standard way for accessing defaults will be defined.
         // See: https://github.com/flutter/flutter/issues/130135.
@@ -986,6 +994,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
           excluding: excludeSemantics,
           child: MenuItemButton(
             key: enableScrollToHighlight ? buttonItemKeys[i] : null,
+            statesController: entryIsSelected ? _highlightedItemStatesController : null,
             style: effectiveStyle,
             leadingIcon: entry.leadingIcon,
             trailingIcon: entry.trailingIcon,


### PR DESCRIPTION
## Description

This PR adds logic to resolve `DropdownMenuEntry.style` properties with the correct `WidgetState` when an item is highlighted.

When `MenuItemButton` are highlighted the focused state is not added automatically because the focus does not move to the items (it stays on the `TextField` in order to let the user enters text to filter the items list). This PR sets the `MenuItemButton.statesController` with a forced focused state to let `MenuItemButton` know that the focused state should be use to resolve the properties.

## Related Issue

Fixes [DropdownMenuEntry style's text style is not resolving with states](https://github.com/flutter/flutter/issues/177363)

## Tests

- Adds 1 tests.

