### PR TITLE
Update .ci.yaml and TESTOWNERS for arc macrobenchmark tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3553,6 +3553,42 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: rrect_blur_perf_ios__timeline_summary
 
+  - name: Linux_pixel_7pro draw_arcs_all_fill_styles_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "pixel", "7pro"]
+      task_name: draw_arcs_all_fill_styles_perf__timeline_summary
+
+  - name: Mac_ios draw_arcs_all_fill_styles_perf_ios__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: draw_arcs_all_fill_styles_perf_ios__timeline_summary
+
+  - name: Linux_pixel_7pro draw_arcs_all_stroke_styles_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "pixel", "7pro"]
+      task_name: draw_arcs_all_stroke_styles_perf__timeline_summary
+
+  - name: Mac_ios draw_arcs_all_stroke_styles_perf_ios__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: draw_arcs_all_stroke_styles_perf_ios__timeline_summary
+
   # Uses Impeller.
   - name: Linux_pixel_7pro animated_blur_backdrop_filter_perf_opengles__timeline_summary
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3556,6 +3556,7 @@ targets:
   - name: Linux_pixel_7pro draw_arcs_all_fill_styles_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -3565,6 +3566,7 @@ targets:
   - name: Mac_ios draw_arcs_all_fill_styles_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -3574,6 +3576,7 @@ targets:
   - name: Linux_pixel_7pro draw_arcs_all_stroke_styles_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -3583,6 +3586,7 @@ targets:
   - name: Mac_ios draw_arcs_all_stroke_styles_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -114,6 +114,8 @@
 /dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_gles__timeline_summary.dart @jonahwilliams @flutter/engine
 /dev/devicelab/bin/tasks/rrect_blur_perf__timeline_summary.dart @gaaclarke @flutter/engine
 /dev/devicelab/bin/tasks/platform_views_hcpp_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
+/dev/devicelab/bin/tasks/draw_arcs_all_fill_styles_perf__timeline_summary.dart @b-luk @flutter/engine
+/dev/devicelab/bin/tasks/draw_arcs_all_stroke_styles_perf__timeline_summary.dart @b-luk @flutter/engine
 
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @bkonyi @flutter/tool
@@ -234,6 +236,8 @@
 /dev/devicelab/bin/tasks/static_path_stroke_tessellation_perf_ios__timeline_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/dynamic_path_stroke_tessellation_perf_ios__timeline_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/rrect_blur_perf_ios__timeline_summary.dart @gaaclarke @flutter/engine
+/dev/devicelab/bin/tasks/draw_arcs_all_fill_styles_perf_ios__timeline_summary.dart @b-luk @flutter/engine
+/dev/devicelab/bin/tasks/draw_arcs_all_stroke_styles_perf_ios__timeline_summary.dart @b-luk @flutter/engine
 
 ## Host only DeviceLab tests
 /dev/devicelab/bin/tasks/animated_complex_opacity_perf_macos__e2e_summary.dart @cbracken @flutter/desktop


### PR DESCRIPTION
The benchmarks were added in #178690, but that PR didn't update the .ci.yaml and TESTOWNERS files.