### PR TITLE
Build hooks: Don't require toolchain for unit tests

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -70,7 +70,7 @@ Future<CCompilerConfig?> cCompilerConfigLinux({required bool throwIfNotFound}) a
 
 /// Searches for an executable with a name in [possibleExecutableNames]
 /// at [path] and returns the first one it finds, if one is found.
-/// Otherwise, throws an error.
+/// Otherwise, returns `null`.
 Uri? _findExecutableIfExists({
   required List<String> possibleExecutableNames,
   required Directory path,

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -9,10 +9,17 @@ import '../../../base/file_system.dart';
 import '../../../base/io.dart';
 import '../../../globals.dart' as globals;
 
-/// Flutter expects `clang++` to be on the path on Linux hosts.
+/// Returns a [CCompilerConfig] matching a toolchain that would be used to
+/// compile the main app with CMake on Linux.
 ///
-/// Search for the accompanying `clang`, `ar`, and `ld`.
-Future<CCompilerConfig> cCompilerConfigLinux() async {
+/// Flutter expects `clang++` to be on the path on Linux hosts, which this uses
+/// to search for the accompanying `clang`, `ar`, and `ld`.
+///
+/// If [mustMatchAppBuild] is false, this is allowed to fail (in which case
+/// `null`) is returned. This is used for `flutter test` setups, where no main
+/// app is compiled and we thus don't want a `clang` toolchain to be a
+/// requirement.
+Future<CCompilerConfig?> cCompilerConfigLinux({required bool mustMatchAppBuild}) async {
   const kClangPlusPlusBinary = 'clang++';
   // NOTE: these binaries sometimes have different names depending on the installation;
   // thus, we check for a few possible options (in order of preference).
@@ -25,30 +32,53 @@ Future<CCompilerConfig> cCompilerConfigLinux() async {
     kClangPlusPlusBinary,
   ]);
   if (whichResult.exitCode != 0) {
-    throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
+    if (mustMatchAppBuild) {
+      throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
+    } else {
+      return null;
+    }
   }
   File clangPpFile = globals.fs.file((whichResult.stdout as String).trim());
   clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
 
   final Directory clangDir = clangPpFile.parent;
-  return CCompilerConfig(
-    linker: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kLdBinaryOptions),
-    compiler: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kClangBinaryOptions),
-    archiver: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kArBinaryOptions),
+  Uri? findExecutable({required List<String> possibleExecutableNames, required Directory path}) {
+    final Uri? found = _findExecutableIfExists(
+      possibleExecutableNames: possibleExecutableNames,
+      path: path,
+    );
+
+    if (found == null && mustMatchAppBuild) {
+      throwToolExit('Failed to find any of $possibleExecutableNames in $path');
+    }
+
+    return found;
+  }
+
+  final Uri? linker = findExecutable(path: clangDir, possibleExecutableNames: kLdBinaryOptions);
+  final Uri? compiler = findExecutable(
+    path: clangDir,
+    possibleExecutableNames: kClangBinaryOptions,
   );
+  final Uri? archiver = findExecutable(path: clangDir, possibleExecutableNames: kArBinaryOptions);
+
+  if (linker == null || compiler == null || archiver == null) {
+    assert(!mustMatchAppBuild); // otherwise, findExecutable would have thrown
+    return null;
+  }
+  return CCompilerConfig(linker: linker, compiler: compiler, archiver: archiver);
 }
 
 /// Searches for an executable with a name in [possibleExecutableNames]
 /// at [path] and returns the first one it finds, if one is found.
 /// Otherwise, throws an error.
-Uri _findExecutableIfExists({
+Uri? _findExecutableIfExists({
   required List<String> possibleExecutableNames,
   required Directory path,
 }) {
   return possibleExecutableNames
-          .map((execName) => path.childFile(execName))
-          .where((file) => file.existsSync())
-          .map((file) => file.uri)
-          .firstOrNull ??
-      throwToolExit('Failed to find any of $possibleExecutableNames in $path');
+      .map((execName) => path.childFile(execName))
+      .where((file) => file.existsSync())
+      .map((file) => file.uri)
+      .firstOrNull;
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -9,17 +9,16 @@ import '../../../base/file_system.dart';
 import '../../../base/io.dart';
 import '../../../globals.dart' as globals;
 
-/// Returns a [CCompilerConfig] matching a toolchain that would be used to
-/// compile the main app with CMake on Linux.
+/// Returns a [CCompilerConfig] matching a toolchain that would be used to compile the main app with
+/// CMake on Linux.
 ///
-/// Flutter expects `clang++` to be on the path on Linux hosts, which this uses
-/// to search for the accompanying `clang`, `ar`, and `ld`.
+/// Flutter expects `clang++` to be on the path on Linux hosts, which this uses to search for the
+/// accompanying `clang`, `ar`, and `ld`.
 ///
-/// If [mustMatchAppBuild] is false, this is allowed to fail (in which case
-/// `null`) is returned. This is used for `flutter test` setups, where no main
-/// app is compiled and we thus don't want a `clang` toolchain to be a
-/// requirement.
-Future<CCompilerConfig?> cCompilerConfigLinux({required bool mustMatchAppBuild}) async {
+/// If [throwIfNotFound] is false, this is allowed to fail (in which case `null`) is returned. This
+/// is used for `flutter test` setups, where no main app is compiled and we thus don't want a
+/// `clang` toolchain to be a requirement.
+Future<CCompilerConfig?> cCompilerConfigLinux({required bool throwIfNotFound}) async {
   const kClangPlusPlusBinary = 'clang++';
   // NOTE: these binaries sometimes have different names depending on the installation;
   // thus, we check for a few possible options (in order of preference).
@@ -32,7 +31,7 @@ Future<CCompilerConfig?> cCompilerConfigLinux({required bool mustMatchAppBuild})
     kClangPlusPlusBinary,
   ]);
   if (whichResult.exitCode != 0) {
-    if (mustMatchAppBuild) {
+    if (throwIfNotFound) {
       throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
     } else {
       return null;
@@ -48,7 +47,7 @@ Future<CCompilerConfig?> cCompilerConfigLinux({required bool mustMatchAppBuild})
       path: path,
     );
 
-    if (found == null && mustMatchAppBuild) {
+    if (found == null && throwIfNotFound) {
       throwToolExit('Failed to find any of $possibleExecutableNames in $path');
     }
 
@@ -63,7 +62,7 @@ Future<CCompilerConfig?> cCompilerConfigLinux({required bool mustMatchAppBuild})
   final Uri? archiver = findExecutable(path: clangDir, possibleExecutableNames: kArBinaryOptions);
 
   if (linker == null || compiler == null || archiver == null) {
-    assert(!mustMatchAppBuild); // otherwise, findExecutable would have thrown
+    assert(!throwIfNotFound); // otherwise, findExecutable would have thrown
     return null;
   }
   return CCompilerConfig(linker: linker, compiler: compiler, archiver: archiver);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -236,9 +236,7 @@ class WindowsAssetTarget extends CodeAssetTarget {
 
   @override
   Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
-      // On Windows specifically, mustMatchAppBuild is ignored because we want to invoke hooks even
-      // without a Visual Studio installation. This is different to Linux and Apple targets, where
-      // a compiler toolchain is required for builds and only optional for tests.
+      // TODO(simolus3): Respect the mustMatchAppBuild option in cCompilerConfigWindows.
       cCompilerConfigSync = await cCompilerConfigWindows();
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -236,6 +236,9 @@ class WindowsAssetTarget extends CodeAssetTarget {
 
   @override
   Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      // On Windows specifically, mustMatchAppBuild is ignored because we want to invoke hooks even
+      // without a Visual Studio installation. This is different to Linux and Apple targets, where
+      // a compiler toolchain is required for builds and only optional for tests.
       cCompilerConfigSync = await cCompilerConfigWindows();
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -194,7 +194,19 @@ sealed class CodeAssetTarget extends AssetBuildTarget {
 
   late final CCompilerConfig? cCompilerConfigSync;
 
-  Future<void> setCCompilerConfig();
+  /// On platforms where the Flutter app is compiled with a native toolchain, configures this target
+  /// to contain a [CCompilerConfig] matching that toolchain.
+  ///
+  /// While hooks are supposed to be able to find a toolchain on their own, we want them to use the
+  /// same tools used to build the main app to make static linking easier in the future. So if we're
+  /// e.g. on Linux and use `clang` to compile the app, hooks should use the same `clang` as a
+  /// compiler too.
+  ///
+  /// If [mustMatchAppBuild] is true (the default), this should throw if the expected toolchain
+  /// could not be found. For `flutter test` setups where no app is compiled, we _prefer_ to use the
+  /// same toolchain but would allow not passing a [CCompilerConfig] if that fails. This allows
+  /// hooks that only download code assets instead of compiling them to still function.
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true});
 
   List<CodeAssetExtension> get codeAssetExtensions {
     return <CodeAssetExtension>[
@@ -223,7 +235,8 @@ class WindowsAssetTarget extends CodeAssetTarget {
   ];
 
   @override
-  Future<void> setCCompilerConfig() async => cCompilerConfigSync = await cCompilerConfigWindows();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      cCompilerConfigSync = await cCompilerConfigWindows();
 }
 
 final class LinuxAssetTarget extends CodeAssetTarget {
@@ -231,7 +244,8 @@ final class LinuxAssetTarget extends CodeAssetTarget {
     : super(os: OS.linux);
 
   @override
-  Future<void> setCCompilerConfig() async => cCompilerConfigSync = await cCompilerConfigLinux();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      cCompilerConfigSync = await cCompilerConfigLinux(mustMatchAppBuild: mustMatchAppBuild);
 
   @override
   List<ProtocolExtension> get extensions => <ProtocolExtension>[
@@ -252,7 +266,8 @@ final class IOSAssetTarget extends CodeAssetTarget {
   final FileSystem fileSystem;
 
   @override
-  Future<void> setCCompilerConfig() async => cCompilerConfigSync = await cCompilerConfigMacOS();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      cCompilerConfigSync = await cCompilerConfigMacOS(throwIfNotFound: mustMatchAppBuild);
 
   IOSCodeConfig _getIOSConfig(Map<String, String> environmentDefines, FileSystem fileSystem) {
     final String? sdkRoot = environmentDefines[kSdkRoot];
@@ -299,7 +314,8 @@ final class MacOSAssetTarget extends CodeAssetTarget {
   }
 
   @override
-  Future<void> setCCompilerConfig() async => cCompilerConfigSync = await cCompilerConfigMacOS();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      cCompilerConfigSync = await cCompilerConfigMacOS(throwIfNotFound: mustMatchAppBuild);
 }
 
 final class AndroidAssetTarget extends CodeAssetTarget {
@@ -315,7 +331,8 @@ final class AndroidAssetTarget extends CodeAssetTarget {
   final AndroidCodeConfig? _androidCodeConfig;
 
   @override
-  Future<void> setCCompilerConfig() async => cCompilerConfigSync = await cCompilerConfigAndroid();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
+      cCompilerConfigSync = await cCompilerConfigAndroid();
 
   @override
   List<ProtocolExtension> get extensions => <ProtocolExtension>[
@@ -362,7 +379,8 @@ final class FlutterTesterAssetTarget extends CodeAssetTarget {
   CCompilerConfig? get cCompilerConfigSync => subtarget.cCompilerConfigSync;
 
   @override
-  Future<void> setCCompilerConfig() async => subtarget.setCCompilerConfig();
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) =>
+      subtarget.setCCompilerConfig(mustMatchAppBuild: false);
 }
 
 List<AndroidArch> _androidArchs(TargetPlatform targetPlatform, String? androidArchsEnvironment) {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -245,7 +245,7 @@ final class LinuxAssetTarget extends CodeAssetTarget {
 
   @override
   Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
-      cCompilerConfigSync = await cCompilerConfigLinux(mustMatchAppBuild: mustMatchAppBuild);
+      cCompilerConfigSync = await cCompilerConfigLinux(throwIfNotFound: mustMatchAppBuild);
 
   @override
   List<ProtocolExtension> get extensions => <ProtocolExtension>[

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -123,7 +123,7 @@ void main() {
   );
 
   testUsingContext(
-    'cCompilerConfigLinux with missing binaries',
+    'cCompilerConfigLinux with missing binaries when required',
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <Pattern>['which', 'clang++'], stdout: '/a/path/to/clang++'),
@@ -138,6 +138,23 @@ void main() {
       await fileSystem.file('/a/path/to/clang++').create(recursive: true);
 
       expect(cCompilerConfigLinux(throwIfNotFound: true), throwsA(isA<ToolExit>()));
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux with missing binaries when not required',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <Pattern>['which', 'clang++'], stdout: '/a/path/to/clang++'),
+      ]),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await fileSystem.file('/a/path/to/clang++').create(recursive: true);
       expect(cCompilerConfigLinux(throwIfNotFound: false), completes);
     },
   );

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -93,7 +93,7 @@ void main() {
       await fileSystem.file('/some/path/to/llvm-ar').create();
       await fileSystem.file('/some/path/to/ld.lld').create();
 
-      final CCompilerConfig result = await cCompilerConfigLinux();
+      final CCompilerConfig result = (await cCompilerConfigLinux(mustMatchAppBuild: true))!;
       expect(result.compiler, Uri.file('/some/path/to/clang'));
     },
   );
@@ -115,7 +115,7 @@ void main() {
         await fileSystem.file('/path/to/$execName').create(recursive: true);
       }
 
-      final CCompilerConfig result = await cCompilerConfigLinux();
+      final CCompilerConfig result = (await cCompilerConfigLinux(mustMatchAppBuild: true))!;
       expect(result.linker, Uri.file('/path/to/ld'));
       expect(result.compiler, Uri.file('/path/to/clang'));
       expect(result.archiver, Uri.file('/path/to/ar'));
@@ -137,7 +137,8 @@ void main() {
 
       await fileSystem.file('/a/path/to/clang++').create(recursive: true);
 
-      expect(cCompilerConfigLinux(), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(mustMatchAppBuild: true), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(mustMatchAppBuild: false), completes);
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -93,7 +93,7 @@ void main() {
       await fileSystem.file('/some/path/to/llvm-ar').create();
       await fileSystem.file('/some/path/to/ld.lld').create();
 
-      final CCompilerConfig result = (await cCompilerConfigLinux(mustMatchAppBuild: true))!;
+      final CCompilerConfig result = (await cCompilerConfigLinux(throwIfNotFound: true))!;
       expect(result.compiler, Uri.file('/some/path/to/clang'));
     },
   );
@@ -115,7 +115,7 @@ void main() {
         await fileSystem.file('/path/to/$execName').create(recursive: true);
       }
 
-      final CCompilerConfig result = (await cCompilerConfigLinux(mustMatchAppBuild: true))!;
+      final CCompilerConfig result = (await cCompilerConfigLinux(throwIfNotFound: true))!;
       expect(result.linker, Uri.file('/path/to/ld'));
       expect(result.compiler, Uri.file('/path/to/clang'));
       expect(result.archiver, Uri.file('/path/to/ar'));
@@ -137,8 +137,8 @@ void main() {
 
       await fileSystem.file('/a/path/to/clang++').create(recursive: true);
 
-      expect(cCompilerConfigLinux(mustMatchAppBuild: true), throwsA(isA<ToolExit>()));
-      expect(cCompilerConfigLinux(mustMatchAppBuild: false), completes);
+      expect(cCompilerConfigLinux(throwIfNotFound: true), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(throwIfNotFound: false), completes);
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -6,6 +6,7 @@ import 'package:code_assets/code_assets.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -391,7 +392,7 @@ void main() {
         return;
       }
 
-      final CCompilerConfig result = await cCompilerConfigMacOS();
+      final CCompilerConfig result = (await cCompilerConfigMacOS(throwIfNotFound: true))!;
       expect(
         result.compiler,
         Uri.file(
@@ -429,10 +430,52 @@ void main() {
         return;
       }
 
-      final CCompilerConfig result = await cCompilerConfigMacOS();
+      final CCompilerConfig result = (await cCompilerConfigMacOS(throwIfNotFound: true))!;
       expect(result.compiler, Uri.file('/nix/store/random-path-to-clang-wrapper/bin/clang'));
       expect(result.archiver, Uri.file('/nix/store/random-path-to-clang-wrapper/bin/ar'));
       expect(result.linker, Uri.file('/nix/store/random-path-to-clang-wrapper/bin/ld'));
+    },
+  );
+
+  testUsingContext(
+    'missing xcode when required',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        for (final binary in <String>['clang', 'ar', 'ld'])
+          FakeCommand(
+            command: <Pattern>['xcrun', '--find', binary],
+            exitCode: 1,
+            stderr: 'not found',
+          ),
+      ]),
+    },
+    () async {
+      if (!const LocalPlatform().isMacOS) {
+        return;
+      }
+
+      await expectLater(cCompilerConfigMacOS(throwIfNotFound: true), throwsA(isA<ToolExit>()));
+    },
+  );
+
+  testUsingContext(
+    'missing xcode when not required',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        for (final binary in <String>['clang', 'ar', 'ld'])
+          FakeCommand(
+            command: <Pattern>['xcrun', '--find', binary],
+            exitCode: 1,
+            stderr: 'not found',
+          ),
+      ]),
+    },
+    () async {
+      if (!const LocalPlatform().isMacOS) {
+        return;
+      }
+
+      expect(await cCompilerConfigMacOS(throwIfNotFound: false), isNull);
     },
   );
 }


### PR DESCRIPTION
To ensure build hooks emit code assets that are compatible with the main app, Flutter tools pass a `CCompilerConfig` toolchain configuration object to hooks. This is generally what we want, hooks on macOS should use the same `clang` from XCode as the one used to compile the app and native Flutter plugins for instance.

In some cases however, we need to run hooks without necessarily compiling a full Flutter app with native sources. A good example for this is `flutter test`, which runs unit / widget tests in a regular Dart VM without embedding it in a Flutter application. So since `flutter test` wouldn't invoke a native compiler, running build hooks shouldn't fail if the expected toolchain is missing.

Currently however, `flutter test` tries to resolve a compiler toolchain for the host platform. Doing that on Windows already allows not passing a `CCompilerConfig` if VSCode wasn't found, but on macOS and Linux, this crashes. This fixes the issue by allowing those methods to return `null` instead of throwing. They still throw by default, but for the test target they are configured to not pass a toolchain to hooks if none could be resolved. This means that hooks not invoking the provided toolchain (say because they're only downloading native artifacts instead) would now work, whereas previously `flutter test` would crash if no toolchian was found.

This closes https://github.com/flutter/flutter/issues/178715 (but only the part shared in the original issue description, @dcharkes suggested fixing a similar issue in the same PR but that is _not_ done here).
