### PR TITLE
Fix PinnedHeaderSliver semantics focus capture

### DIFF
--- a/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
+++ b/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
@@ -106,4 +106,10 @@ class _RenderPinnedHeaderSliver extends RenderSliverSingleBoxAdapter {
       hasVisualOverflow: true, // Conservatively say we do have overflow to avoid complexity.
     );
   }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.addTagForChildren(RenderViewport.excludeFromScrolling);
+  }
 }

--- a/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
+++ b/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
@@ -14,6 +14,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
+import 'basic.dart';
 import 'framework.dart';
 
 /// A sliver that keeps its Widget child at the top of the a [CustomScrollView].
@@ -53,10 +54,26 @@ import 'framework.dart';
 ///    in response to downward and upwards scrolls.
 ///  * [SliverPersistentHeader] - a general purpose header that can be
 ///    configured as a pinned, resizing, or floating header.
-class PinnedHeaderSliver extends SingleChildRenderObjectWidget {
+class PinnedHeaderSliver extends StatelessWidget {
   /// Creates a sliver whose [Widget] child appears at the top of a
   /// [CustomScrollView].
-  const PinnedHeaderSliver({super.key, super.child});
+  const PinnedHeaderSliver({super.key, this.child});
+
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) => _PinnedHeaderSliver(
+    child: Semantics(container: true, explicitChildNodes: true, child: child),
+  );
+}
+
+class _PinnedHeaderSliver extends SingleChildRenderObjectWidget {
+  /// Creates a sliver whose [Widget] child appears at the top of a
+  /// [CustomScrollView].
+  const _PinnedHeaderSliver({super.child});
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -110,6 +127,9 @@ class _RenderPinnedHeaderSliver extends RenderSliverSingleBoxAdapter {
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-    config.addTagForChildren(RenderViewport.excludeFromScrolling);
+
+    if (geometry != null && geometry!.layoutExtent < childExtent) {
+      config.addTagForChildren(RenderViewport.excludeFromScrolling);
+    }
   }
 }

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -247,58 +247,75 @@ void main() {
     expect(tester.getRect(find.text('PinnedHeaderSliver 2')), rect2);
   });
 
-  testWidgets('PinnedHeaderSliver: presence of RenderViewport.excludeFromScrolling tag', (
-    WidgetTester tester,
-  ) async {
-    final semantics = SemanticsTester(tester);
+  testWidgets(
+    'PinnedHeaderSliver: presence of RenderViewport.excludeFromScrolling tag when pinned',
+    (WidgetTester tester) async {
+      final semantics = SemanticsTester(tester);
 
-    await tester.pumpWidget(
-      Semantics(
-        textDirection: TextDirection.ltr,
-        child: Localizations(
-          locale: const Locale('en', 'us'),
-          delegates: const <LocalizationsDelegate<dynamic>>[
-            DefaultWidgetsLocalizations.delegate,
-            DefaultMaterialLocalizations.delegate,
-          ],
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: MediaQuery(
-              data: const MediaQueryData(),
-              child: CustomScrollView(
-                slivers: <Widget>[
-                  const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
-                  SliverList.builder(
-                    itemCount: 50,
-                    itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-                  ),
-                ],
+      await tester.pumpWidget(
+        Semantics(
+          textDirection: TextDirection.ltr,
+          child: Localizations(
+            locale: const Locale('en', 'us'),
+            delegates: const <LocalizationsDelegate<dynamic>>[
+              DefaultWidgetsLocalizations.delegate,
+              DefaultMaterialLocalizations.delegate,
+            ],
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: MediaQuery(
+                data: const MediaQueryData(),
+                child: CustomScrollView(
+                  slivers: <Widget>[
+                    const SliverToBoxAdapter(
+                      child: SizedBox(height: 100, child: Text('First child')),
+                    ),
+                    const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
+                    SliverList.builder(
+                      itemCount: 50,
+                      itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(
-      semantics,
-      isNot(
-        includesNodeWith(
-          tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
+      expect(
+        semantics,
+        isNot(
+          includesNodeWith(
+            tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
+          ),
         ),
-      ),
-    );
+      );
 
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, -100));
-    await tester.pumpAndSettle();
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -100));
+      await tester.pumpAndSettle();
 
-    expect(
-      semantics,
-      includesNodeWith(
-        tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
-      ),
-    );
+      expect(
+        semantics,
+        isNot(
+          includesNodeWith(
+            tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
+          ),
+        ),
+      );
 
-    semantics.dispose();
-  });
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -20));
+      await tester.pumpAndSettle();
+
+      final SemanticsNode? semanticNode = semantics
+          .nodesWith(label: 'PinnedHeaderSliver')
+          .firstOrNull;
+      expect(semanticNode?.parent?.tags, {
+        RenderViewport.excludeFromScrolling,
+        RenderViewport.useTwoPaneSemantics,
+      });
+
+      semantics.dispose();
+    },
+  );
 }

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -247,6 +247,7 @@ void main() {
     expect(tester.getRect(find.text('PinnedHeaderSliver 2')), rect2);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/179022.
   testWidgets(
     'PinnedHeaderSliver: presence of RenderViewport.excludeFromScrolling tag when pinned',
     (WidgetTester tester) async {
@@ -283,6 +284,15 @@ void main() {
         ),
       );
 
+      Rect getHeaderRect() => tester.getRect(find.text('PinnedHeaderSliver'));
+      Rect getFirstChildRect() => tester.getRect(find.text('First child'));
+
+      // Pinned header appears after first child initially.
+      final Rect firstChildRect = getFirstChildRect();
+      expect(firstChildRect.top, 0.0);
+      expect(firstChildRect.height, 100.0);
+      expect(getHeaderRect().top, 100.0);
+
       expect(
         semantics,
         isNot(
@@ -294,6 +304,9 @@ void main() {
 
       await tester.drag(find.byType(CustomScrollView), const Offset(0, -100));
       await tester.pumpAndSettle();
+
+      // Pinned header should be pinned to the top after drag.
+      expect(getHeaderRect().top, 0.0);
 
       expect(
         semantics,

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'semantics_tester.dart';
 import 'widgets_app_tester.dart';
 
 void main() {
@@ -243,5 +245,48 @@ void main() {
     expect(tester.getRect(find.text('PinnedHeaderSliver 0')), rect0);
     expect(tester.getRect(find.text('PinnedHeaderSliver 1')), rect1);
     expect(tester.getRect(find.text('PinnedHeaderSliver 2')), rect2);
+  });
+
+  testWidgets('PinnedHeaderSliver: presence of RenderViewport.excludeFromScrolling tag', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        textDirection: TextDirection.ltr,
+        child: Localizations(
+          locale: const Locale('en', 'us'),
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: const MediaQueryData(),
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
+                  SliverList.builder(
+                    itemCount: 6,
+                    itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      includesNodeWith(
+        tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
+      ),
+    );
+
+    semantics.dispose();
   });
 }

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -269,7 +269,7 @@ void main() {
                 slivers: <Widget>[
                   const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
                   SliverList.builder(
-                    itemCount: 6,
+                    itemCount: 50,
                     itemBuilder: (BuildContext context, int index) => Text('Item $index'),
                   ),
                 ],
@@ -279,6 +279,18 @@ void main() {
         ),
       ),
     );
+
+    expect(
+      semantics,
+      isNot(
+        includesNodeWith(
+          tags: {RenderViewport.excludeFromScrolling, RenderViewport.useTwoPaneSemantics},
+        ),
+      ),
+    );
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -100));
+    await tester.pumpAndSettle();
 
     expect(
       semantics,

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -254,32 +254,16 @@ void main() {
       final semantics = SemanticsTester(tester);
 
       await tester.pumpWidget(
-        Semantics(
-          textDirection: TextDirection.ltr,
-          child: Localizations(
-            locale: const Locale('en', 'us'),
-            delegates: const <LocalizationsDelegate<dynamic>>[
-              DefaultWidgetsLocalizations.delegate,
-              DefaultMaterialLocalizations.delegate,
-            ],
-            child: Directionality(
-              textDirection: TextDirection.ltr,
-              child: MediaQuery(
-                data: const MediaQueryData(),
-                child: CustomScrollView(
-                  slivers: <Widget>[
-                    const SliverToBoxAdapter(
-                      child: SizedBox(height: 100, child: Text('First child')),
-                    ),
-                    const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
-                    SliverList.builder(
-                      itemCount: 50,
-                      itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-                    ),
-                  ],
-                ),
+        TestWidgetsApp(
+          home: CustomScrollView(
+            slivers: <Widget>[
+              const SliverToBoxAdapter(child: SizedBox(height: 100, child: Text('First child'))),
+              const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
               ),
-            ),
+            ],
           ),
         ),
       );


### PR DESCRIPTION
Fix #179022

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
