### PR TITLE
[ Widget Preview ] Always generate scaffold under `$TMP`

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -96,6 +96,7 @@ class ResidentWebRunner extends ResidentRunner {
     String? target,
     bool stayResident = true,
     bool machine = false,
+    String? projectRootPath,
     required this.flutterProject,
     required DebuggingOptions debuggingOptions,
     required FileSystem fileSystem,
@@ -125,6 +126,7 @@ class ResidentWebRunner extends ResidentRunner {
            outputPreferences: outputPreferences,
          ),
          dartBuilder: hookRunner,
+         projectRootPath: projectRootPath,
        );
 
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -231,7 +231,10 @@ class FlutterProject {
 
   /// The location of the generated scaffolding project for hosting widget
   /// previews from this project.
-  Directory get widgetPreviewScaffold => dartTool.childDirectory('widget_preview_scaffold');
+  // TODO(bkonyi): don't create this project in $TMP.
+  // See https://github.com/flutter/flutter/issues/179036
+  late final Directory widgetPreviewScaffold = directory.fileSystem.systemTempDirectory
+      .createTempSync('widget_preview_scaffold');
 
   /// The directory containing the generated code for this project.
   Directory get generated => directory.absolute

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1123,7 +1123,7 @@ abstract class ResidentRunner extends ResidentHandlers {
     processManager: globals.processManager,
     platform: globals.platform,
     analytics: globals.analytics,
-    projectDir: globals.fs.currentDirectory,
+    projectDir: globals.fs.directory(projectRootPath),
     packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
     generateDartPluginRegistry: generateDartPluginRegistry,
     defines: <String, String>{

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
 import 'package:widget_preview_scaffold/src/dtd/utils.dart';
-import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -14,16 +14,16 @@ import 'package:flutter/widget_previews.dart';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'dtd/editor_service.dart';
-import 'theme/ide_theme.dart';
-import 'theme/theme.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/theme/ide_theme.dart';
+import 'package:widget_preview_scaffold/src/theme/theme.dart';
 
-import 'controls.dart';
-import 'generated_preview.dart';
-import 'utils.dart';
-import 'widget_preview.dart';
-import 'widget_preview_inspector_service.dart';
-import 'widget_preview_scaffold_controller.dart';
+import 'package:widget_preview_scaffold/src/controls.dart';
+import 'package:widget_preview_scaffold/src/generated_preview.dart';
+import 'package:widget_preview_scaffold/src/utils.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_inspector_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_scaffold_controller.dart';
 
 /// Displayed when an unhandled exception is thrown when initializing the widget
 /// tree for a preview (i.e., before the build phase).

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
@@ -62,9 +62,7 @@ void main() {
           for (var i = 0; i < root.deferredComponents!.length; ++i) {
             expect(
               updated.deferredComponents![i].toString(),
-              PreviewPubspecBuilder.transformDeferredComponent(
-                root.deferredComponents![i],
-              ).toString(),
+              pubspecBuilder.transformDeferredComponent(root.deferredComponents![i]).toString(),
             );
           }
         }
@@ -132,6 +130,9 @@ flutter:
     fileSystem: fileSystem,
     logger: logger,
   )!;
+
+  @override
+  late final Directory directory = fileSystem.directory(projectRoot);
 
   @override
   late FlutterProject widgetPreviewScaffoldProject = FakeFlutterProject(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
@@ -92,9 +92,9 @@ dependencies:
         final yaml =
             loadYaml(rootProject.widgetPreviewScaffoldProject.pubspecFile.readAsStringSync())
                 as YamlMap;
-        const expectedDependencies = <String, Object?>{
-          'abcd': {'path': '../../packages/$kPackageProjectName'},
-          'example': {'path': '../../packages/$kExampleProjectName'},
+        final expectedDependencies = <String, Object?>{
+          'abcd': {'path': packageProject.projectRoot.path},
+          'example': {'path': exampleProject.projectRoot.path},
         };
 
         // The generated pubspec.yaml should have path dependencies on both the package and example

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -290,7 +290,7 @@ void main() {
           ),
         },
       );
-    }, skip: true);
+    });
 
     testUsingContext(
       'start succeeds when no .dart_tool/ directory exists',

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -150,10 +150,6 @@ void main() {
     return fs.directory(await createProject(tempDir, arguments: <String>['--pub']));
   }
 
-  Directory widgetPreviewScaffoldFromRootProject({required Directory rootProject}) {
-    return rootProject.childDirectory('.dart_tool').childDirectory('widget_preview_scaffold');
-  }
-
   Future<void> runWidgetPreviewCommand(List<String> arguments) async {
     final CommandRunner<void> runner = createTestCommandRunner(
       WidgetPreviewCommand(
@@ -211,15 +207,12 @@ void main() {
       '--verbose',
       ?rootProject?.path,
     ]);
-    final Directory widgetPreviewScaffoldDir = widgetPreviewScaffoldFromRootProject(
-      rootProject: rootProject ?? current,
-    );
     // Don't perform analysis on Windows since `dart pub add` will use '\' for
     // path dependencies and cause analysis to fail.
     // TODO(bkonyi): enable analysis on Windows once https://github.com/dart-lang/pub/issues/4520
     // is resolved.
     if (!platform.isWindows) {
-      await analyzeProject(widgetPreviewScaffoldDir.path);
+      await analyzeProject(WidgetPreviewStartCommand.widgetPreviewScaffold.path);
     }
     fs.currentDirectory = current;
   }
@@ -297,7 +290,7 @@ void main() {
           ),
         },
       );
-    });
+    }, skip: true);
 
     testUsingContext(
       'start succeeds when no .dart_tool/ directory exists',
@@ -404,19 +397,17 @@ List<_i1.WidgetPreview> previews() => [
       'start finds existing previews and injects them into ${PreviewCodeGenerator.getGeneratedPreviewFilePath(fs)}',
       () async {
         final Directory rootProject = await createRootProject();
-        final Directory widgetPreviewScaffoldDir = widgetPreviewScaffoldFromRootProject(
-          rootProject: rootProject,
-        );
         rootProject
             .childDirectory('lib')
             .childFile('foo.dart')
             .writeAsStringSync(samplePreviewFile);
 
-        final File generatedFile = widgetPreviewScaffoldDir.childFile(
+        await startWidgetPreview(rootProject: rootProject);
+
+        final File generatedFile = WidgetPreviewStartCommand.widgetPreviewScaffold.childFile(
           PreviewCodeGenerator.getGeneratedPreviewFilePath(fs),
         );
 
-        await startWidgetPreview(rootProject: rootProject);
         expect(generatedFile.readAsStringSync().stripScriptUris, expectedGeneratedFileContents);
         expectSinglePreviewLaunchTimingEvent();
       },
@@ -438,22 +429,18 @@ List<_i1.WidgetPreview> previews() => [
       'start finds existing previews in the CWD and injects them into ${PreviewCodeGenerator.getGeneratedPreviewFilePath(fs)}',
       () async {
         final Directory rootProject = await createRootProject();
-        final Directory widgetPreviewScaffoldDir = widgetPreviewScaffoldFromRootProject(
-          rootProject: rootProject,
-        );
         rootProject
             .childDirectory('lib')
             .childFile('foo.dart')
             .writeAsStringSync(samplePreviewFile);
 
-        final File generatedFile = widgetPreviewScaffoldDir.childFile(
-          PreviewCodeGenerator.getGeneratedPreviewFilePath(fs),
-        );
-
         // Try to execute using the CWD.
-
         fs.currentDirectory = rootProject;
         await startWidgetPreview(rootProject: null);
+
+        final File generatedFile = WidgetPreviewStartCommand.widgetPreviewScaffold.childFile(
+          PreviewCodeGenerator.getGeneratedPreviewFilePath(fs),
+        );
 
         expect(generatedFile.readAsStringSync().stripScriptUris, expectedGeneratedFileContents);
         expectSinglePreviewLaunchTimingEvent();

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
 import 'package:widget_preview_scaffold/src/dtd/utils.dart';
-import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -14,16 +14,16 @@ import 'package:flutter/widget_previews.dart';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'dtd/editor_service.dart';
-import 'theme/ide_theme.dart';
-import 'theme/theme.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/theme/ide_theme.dart';
+import 'package:widget_preview_scaffold/src/theme/theme.dart';
 
-import 'controls.dart';
-import 'generated_preview.dart';
-import 'utils.dart';
-import 'widget_preview.dart';
-import 'widget_preview_inspector_service.dart';
-import 'widget_preview_scaffold_controller.dart';
+import 'package:widget_preview_scaffold/src/controls.dart';
+import 'package:widget_preview_scaffold/src/generated_preview.dart';
+import 'package:widget_preview_scaffold/src/utils.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_inspector_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_scaffold_controller.dart';
 
 /// Displayed when an unhandled exception is thrown when initializing the widget
 /// tree for a preview (i.e., before the build phase).


### PR DESCRIPTION
Since `flutter clean` can delete the `.dart_tool/` directory while a `flutter widget-preview start` command is active, it's possible for the `widget_preview_scaffold` to be deleted and cause the preview process to crash.

This change works around this issue by always generating the `widget_preview_scaffold` project under $TMP on each invocation of the previewer. This doesn't result in much of a regression in startup times as we currently aren't launching the previewer using restored state as this isn't currently possible with the web device targets. Moving the scaffold under $TMP means Flutter tooling will never accidentally delete the scaffold while the previewer is running.

Filed https://github.com/flutter/flutter/issues/179036 to track reverting this behavior when a better solution is found.

Fixes https://github.com/flutter/flutter/issues/175058