### PR TITLE
[CP-beta][ Widget Preview ] Always generate scaffold under `$TMP` (#179039)

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -263,6 +263,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   /// The currently running instance of the widget preview scaffold.
   ResidentRunner? _widgetPreviewApp;
 
+  /// The location of the widget_preview_scaffold for the current execution of the command.
+  ///
+  /// This is only meant for testing as there's no simple mapping from the target project to the
+  /// scaffold project.
+  // TODO(bkonyi): remove once https://github.com/flutter/flutter/issues/179036 is resolved.
+  @visibleForTesting
+  static late Directory widgetPreviewScaffold;
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     assert(_logger is WidgetPreviewMachineAwareLogger);
@@ -272,7 +280,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     logger.sendInitializingEvent();
 
     final String? customPreviewScaffoldOutput = stringArg(kWidgetPreviewScaffoldOutputDir);
-    final Directory widgetPreviewScaffold = customPreviewScaffoldOutput != null
+    widgetPreviewScaffold = customPreviewScaffoldOutput != null
         ? fs.directory(customPreviewScaffoldOutput)
         : rootProject.widgetPreviewScaffold;
 
@@ -491,6 +499,15 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
           platform: platform,
           outputPreferences: globals.outputPreferences,
           systemClock: globals.systemClock,
+          // Explicitly provide the project root path rather than relying on the current directory
+          // as the current directory exists within $TMP. At least on MacOS, when setting the
+          // current directory to the widget_preview_scaffold project created under
+          // `/var/folders/...`, the underlying chdir call actually changes the directory to
+          // `/private/var/folders/...`. These directories are identical, but confuse the package
+          // config resolution logic.
+          // TODO(bkonyi): consider removing if we stop placing the scaffold in $TMP.
+          // See https://github.com/flutter/flutter/issues/179036
+          projectRootPath: widgetPreviewScaffoldProject.directory.absolute.path,
         );
         unawaited(_widgetPreviewApp!.run(appStartedCompleter: appStarted));
         await appStarted.future;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -96,6 +96,7 @@ class ResidentWebRunner extends ResidentRunner {
     String? target,
     bool stayResident = true,
     bool machine = false,
+    String? projectRootPath,
     required this.flutterProject,
     required DebuggingOptions debuggingOptions,
     required FileSystem fileSystem,
@@ -125,6 +126,7 @@ class ResidentWebRunner extends ResidentRunner {
            outputPreferences: outputPreferences,
          ),
          dartBuilder: hookRunner,
+         projectRootPath: projectRootPath,
        );
 
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -231,7 +231,10 @@ class FlutterProject {
 
   /// The location of the generated scaffolding project for hosting widget
   /// previews from this project.
-  Directory get widgetPreviewScaffold => dartTool.childDirectory('widget_preview_scaffold');
+  // TODO(bkonyi): don't create this project in $TMP.
+  // See https://github.com/flutter/flutter/issues/179036
+  late final Directory widgetPreviewScaffold = directory.fileSystem.systemTempDirectory
+      .createTempSync('widget_preview_scaffold');
 
   /// The directory containing the generated code for this project.
   Directory get generated => directory.absolute

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1123,7 +1123,7 @@ abstract class ResidentRunner extends ResidentHandlers {
     processManager: globals.processManager,
     platform: globals.platform,
     analytics: globals.analytics,
-    projectDir: globals.fs.currentDirectory,
+    projectDir: globals.fs.directory(projectRootPath),
     packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
     generateDartPluginRegistry: generateDartPluginRegistry,
     defines: <String, String>{

--- a/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 
 import '../base/deferred_component.dart';
+import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../convert.dart';
 import '../dart/pub.dart';
@@ -57,10 +58,10 @@ class PreviewPubspecBuilder {
     'web',
   ];
 
-  /// Maps asset URIs to relative paths for the widget preview project to
+  /// Maps asset URIs to absolute paths for the widget preview project to
   /// include.
   @visibleForTesting
-  static Uri transformAssetUri(Uri uri) {
+  Uri transformAssetUri(Uri uri) {
     // Assets provided by packages always start with 'packages' and do not
     // require their URIs to be updated.
     if (uri.path.startsWith('packages')) {
@@ -68,11 +69,13 @@ class PreviewPubspecBuilder {
     }
     // Otherwise, the asset is contained within the root project and needs
     // to be referenced from the widget preview scaffold project's pubspec.
-    return Uri(path: '../../${uri.path}');
+    final Directory rootProjectDir = rootProject.directory;
+    final FileSystem fs = rootProjectDir.fileSystem;
+    return Uri(path: fs.path.join(rootProjectDir.absolute.path, uri.path));
   }
 
   @visibleForTesting
-  static AssetsEntry transformAssetsEntry(AssetsEntry asset) {
+  AssetsEntry transformAssetsEntry(AssetsEntry asset) {
     return AssetsEntry(
       uri: transformAssetUri(asset.uri),
       flavors: asset.flavors,
@@ -81,7 +84,7 @@ class PreviewPubspecBuilder {
   }
 
   @visibleForTesting
-  static DeferredComponent transformDeferredComponent(DeferredComponent component) {
+  DeferredComponent transformDeferredComponent(DeferredComponent component) {
     return DeferredComponent(
       name: component.name,
       // TODO(bkonyi): verify these library paths are always package: paths from the parent project.
@@ -118,8 +121,7 @@ class PreviewPubspecBuilder {
         if (project.manifest.appName.isNotEmpty)
           // Use `json.encode` to handle escapes correctly.
           project.manifest.appName: json.encode(<String, Object?>{
-            // `pub add` interprets relative paths relative to the current directory.
-            'path': widgetPreviewScaffoldProject.directory.fileSystem.path.relative(
+            'path': widgetPreviewScaffoldProject.directory.fileSystem.path.absolute(
               project.directory.path,
             ),
           }),

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
 import 'package:widget_preview_scaffold/src/dtd/utils.dart';
-import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -14,16 +14,16 @@ import 'package:flutter/widget_previews.dart';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'dtd/editor_service.dart';
-import 'theme/ide_theme.dart';
-import 'theme/theme.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/theme/ide_theme.dart';
+import 'package:widget_preview_scaffold/src/theme/theme.dart';
 
-import 'controls.dart';
-import 'generated_preview.dart';
-import 'utils.dart';
-import 'widget_preview.dart';
-import 'widget_preview_inspector_service.dart';
-import 'widget_preview_scaffold_controller.dart';
+import 'package:widget_preview_scaffold/src/controls.dart';
+import 'package:widget_preview_scaffold/src/generated_preview.dart';
+import 'package:widget_preview_scaffold/src/utils.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_inspector_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_scaffold_controller.dart';
 
 /// Displayed when an unhandled exception is thrown when initializing the widget
 /// tree for a preview (i.e., before the build phase).

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
@@ -62,9 +62,7 @@ void main() {
           for (var i = 0; i < root.deferredComponents!.length; ++i) {
             expect(
               updated.deferredComponents![i].toString(),
-              PreviewPubspecBuilder.transformDeferredComponent(
-                root.deferredComponents![i],
-              ).toString(),
+              pubspecBuilder.transformDeferredComponent(root.deferredComponents![i]).toString(),
             );
           }
         }
@@ -132,6 +130,9 @@ flutter:
     fileSystem: fileSystem,
     logger: logger,
   )!;
+
+  @override
+  late final Directory directory = fileSystem.directory(projectRoot);
 
   @override
   late FlutterProject widgetPreviewScaffoldProject = FakeFlutterProject(

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
@@ -92,9 +92,9 @@ dependencies:
         final yaml =
             loadYaml(rootProject.widgetPreviewScaffoldProject.pubspecFile.readAsStringSync())
                 as YamlMap;
-        const expectedDependencies = <String, Object?>{
-          'abcd': {'path': '../../packages/$kPackageProjectName'},
-          'example': {'path': '../../packages/$kExampleProjectName'},
+        final expectedDependencies = <String, Object?>{
+          'abcd': {'path': packageProject.projectRoot.path},
+          'example': {'path': exampleProject.projectRoot.path},
         };
 
         // The generated pubspec.yaml should have path dependencies on both the package and example

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:dtd/dtd.dart';
 import 'package:file/file.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/widget_preview.dart';

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -116,6 +116,10 @@ void main() {
     await completer.future;
   }
 
+  void runFlutterClean() {
+    processManager.runSync(<String>[flutterBin, 'clean'], workingDirectory: tempDir.path);
+  }
+
   group('flutter widget-preview start', () {
     testWithoutContext('smoke test', () async {
       await runWidgetPreview(expectedMessages: firstLaunchMessagesWeb);
@@ -125,13 +129,53 @@ void main() {
       await runWidgetPreview(expectedMessages: firstLaunchMessagesWebServer, useWebServer: true);
     });
 
-    testWithoutContext('does not recreate project on subsequent runs', () async {
-      // The first run of 'flutter widget-preview start' should generate a new preview scaffold
-      await runWidgetPreview(expectedMessages: firstLaunchMessagesWeb);
+    testWithoutContext(
+      'runs flutter pub get in widget_preview_scaffold if '
+      "widget_preview_scaffold/.dart_tool doesn't exist",
+      () async {
+        // Regression test for https://github.com/flutter/flutter/issues/178660
+        // Generate the widget preview scaffold, but don't bother launching it.
+        processManager.runSync(<String>[
+          flutterBin,
+          'widget-preview',
+          'start',
+          '--no-${WidgetPreviewStartCommand.kLaunchPreviewer}',
+        ], workingDirectory: tempDir.path);
 
-      // We shouldn't regenerate the scaffold after the initial run.
-      await runWidgetPreview(expectedMessages: subsequentLaunchMessagesWeb);
-    });
+        // Ensure widget_preview_scaffold/.dart_tool/package_config.json exists.
+        final Directory widgetPreviewScaffoldDartTool = tempDir
+            .childDirectory('.dart_tool')
+            .childDirectory('widget_preview_scaffold')
+            .childDirectory('.dart_tool');
+        expect(widgetPreviewScaffoldDartTool, exists);
+        expect(widgetPreviewScaffoldDartTool.childFile('package_config.json'), exists);
+
+        // Delete widget_preview_scaffold/.dart_tool/. This simulates an interrupted
+        // flutter widget-preview start where 'flutter pub get' wasn't run after
+        // the widget_preview_scaffold project was created.
+        widgetPreviewScaffoldDartTool.deleteSync(recursive: true);
+
+        // Ensure we don't crash due to the package_config.json lookup pointing to
+        // the parent project's package_config.json due to
+        // widget_preview_scaffold/.dart_tool/package_config.json not existing.
+        await runWidgetPreview(expectedMessages: subsequentLaunchMessagesWeb);
+      },
+      // Project is always regenerated.
+      skip: true, // See https://github.com/flutter/flutter/issues/179036.
+    );
+
+    testWithoutContext(
+      'does not recreate project on subsequent runs',
+      () async {
+        // The first run of 'flutter widget-preview start' should generate a new preview scaffold
+        await runWidgetPreview(expectedMessages: firstLaunchMessagesWeb);
+
+        // We shouldn't regenerate the scaffold after the initial run.
+        await runWidgetPreview(expectedMessages: subsequentLaunchMessagesWeb);
+      },
+      // Project is always regenerated.
+      skip: true, // See https://github.com/flutter/flutter/issues/179036.
+    );
 
     testUsingContext('can connect to an existing DTD instance', () async {
       dtdLauncher = DtdLauncher(
@@ -180,6 +224,49 @@ void main() {
         ],
         devToolsServerAddress: devtoolsUri,
       );
+    });
+
+    testUsingContext("doesn't crash on flutter clean", () async {
+      // Regression test for https://github.com/flutter/flutter/issues/175058.\
+      dtdLauncher = DtdLauncher(
+        logger: logger!,
+        artifacts: globals.artifacts!,
+        processManager: globals.processManager,
+      );
+
+      // Start a DTD instance.
+      final Uri dtdUri = await dtdLauncher!.launch();
+
+      // Connect to it and listen to the WidgetPreviewScaffold stream.
+      //
+      // The preview scaffold will send a 'Connected' event on this stream once it has initialized
+      // and is ready.
+      final DartToolingDaemon dtdConnection = await DartToolingDaemon.connect(dtdUri);
+      const kWidgetPreviewScaffoldStream = 'WidgetPreviewScaffold';
+      final completer = Completer<void>();
+      var firstConnection = true;
+      dtdConnection.onEvent(kWidgetPreviewScaffoldStream).listen((DTDEvent event) {
+        expect(event.stream, kWidgetPreviewScaffoldStream);
+        expect(event.kind, 'Connected');
+        if (firstConnection) {
+          firstConnection = false;
+          runFlutterClean();
+          dtdConnection.call(
+            WidgetPreviewDtdServices.kWidgetPreviewService,
+            WidgetPreviewDtdServices.kHotRestartPreviewer,
+          );
+          return;
+        }
+        // The second `Connected` event should come after the previewer is hot restarted after
+        // we perform the `flutter clean`. This event won't be sent again if the previewer has
+        // crashed.
+        completer.complete();
+      });
+      await dtdConnection.streamListen(kWidgetPreviewScaffoldStream);
+
+      // Start the widget preview and wait for the 'Connected' event.
+      await runWidgetPreview(expectedMessages: firstLaunchMessagesWeb, dtdUri: dtdUri);
+      await completer.future;
     });
   });
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:dtd/dtd.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
 import 'package:widget_preview_scaffold/src/dtd/utils.dart';
-import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -14,16 +14,16 @@ import 'package:flutter/widget_previews.dart';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'dtd/editor_service.dart';
-import 'theme/ide_theme.dart';
-import 'theme/theme.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/theme/ide_theme.dart';
+import 'package:widget_preview_scaffold/src/theme/theme.dart';
 
-import 'controls.dart';
-import 'generated_preview.dart';
-import 'utils.dart';
-import 'widget_preview.dart';
-import 'widget_preview_inspector_service.dart';
-import 'widget_preview_scaffold_controller.dart';
+import 'package:widget_preview_scaffold/src/controls.dart';
+import 'package:widget_preview_scaffold/src/generated_preview.dart';
+import 'package:widget_preview_scaffold/src/utils.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_inspector_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_scaffold_controller.dart';
 
 /// Displayed when an unhandled exception is thrown when initializing the widget
 /// tree for a preview (i.e., before the build phase).


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/175058

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

`flutter widget-preview start` can crash if `flutter clean` is run while the widget previewer is running.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

The widget previewer can silently crash in IDEs if the user runs `flutter clean` on the project. There's no indication that the previewer has crashed other than the fact that the previewer no longer hot reloads when the user make changes to their previews.

### Workaround:
Is there a workaround for this issue?

Not running `flutter clean` while the widget previewer is running, or restarting the IDE after `flutter clean` is run.

### Risk:
What is the risk level of this cherry-pick?

  - [X] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [X] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

1) Run `flutter widget-preview start`
2) Run `flutter clean` and verify the `flutter widget-preview start` process doesn't crash.
