### PR TITLE
[native assets] Bump minimum iOS version from 12 to 13

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -11,7 +11,7 @@ import '../macos/native_assets_host.dart';
 import '../native_assets.dart';
 
 // TODO(dcharkes): Fetch minimum iOS version from somewhere. https://github.com/flutter/flutter/issues/145104
-const targetIOSVersion = 12;
+const targetIOSVersion = 13;
 
 IOSSdk getIOSSdk(EnvironmentType environmentType) {
   return switch (environmentType) {
@@ -126,9 +126,11 @@ Future<void> copyNativeCodeAssetsIOS(
     }
     dylibs.add((dylibFile, newInstallName, frameworkDir));
 
-    // TODO(knopp): Wire the value once there is a way to configure that in the hook.
-    // https://github.com/dart-lang/native/issues/1133
-    await createInfoPlist(targetUri.pathSegments.last, frameworkDir, minimumIOSVersion: '12.0');
+    await createInfoPlist(
+      targetUri.pathSegments.last,
+      frameworkDir,
+      minimumIOSVersion: '$targetIOSVersion.0',
+    );
   }
 
   for (final (File dylibFile, String newInstallName, Directory frameworkDir) in dylibs) {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -419,7 +419,7 @@ void expectDylibIsBundledIos(Directory appDirectory, String buildMode) {
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>12.0</string>
+	<string>13.0</string>
 </dict>
 </plist>''');
 }


### PR DESCRIPTION
We don't have a single place to update the minimum iOS version in the code base:

* https://github.com/flutter/flutter/issues/145104

So, when the minimum version was bumped, one place was missed.

Thanks for reporting @tnarik! (https://github.com/flutter/flutter/pull/148504#issuecomment-3575518076)