### PR TITLE
Fix for win32 embedder failing to send all alt key downs to the flutter app

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_window.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_window.h
@@ -42,7 +42,8 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
                 int height,
                 std::shared_ptr<DisplayManagerWin32> const& display_manager,
                 std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr,
-                std::unique_ptr<TextInputManager> text_input_manager = nullptr);
+                std::unique_ptr<TextInputManager> text_input_manager = nullptr,
+                std::unique_ptr<KeyboardManager> keyboard_manager = nullptr);
 
   virtual ~FlutterWindow();
 

--- a/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_window_unittests.cc
@@ -25,6 +25,30 @@ using ::testing::Return;
 namespace {
 static constexpr int32_t kDefaultPointerDeviceId = 0;
 
+class InjectableFlutterWindow : public FlutterWindow {
+ public:
+  InjectableFlutterWindow(
+      int width,
+      int height,
+      std::shared_ptr<DisplayManagerWin32> const& display_manager,
+      std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr,
+      std::unique_ptr<TextInputManager> text_input_manager = nullptr,
+      std::unique_ptr<KeyboardManager> keyboard_manager = nullptr)
+      : FlutterWindow(width,
+                      height,
+                      display_manager,
+                      std::move(windows_proc_table),
+                      std::move(text_input_manager),
+                      std::move(keyboard_manager)) {}
+
+  // Simulates a WindowProc message from the OS.
+  LRESULT InjectWindowMessage(UINT const message,
+                              WPARAM const wparam,
+                              LPARAM const lparam) {
+    return HandleMessage(message, wparam, lparam);
+  }
+};
+
 class MockFlutterWindow : public FlutterWindow {
  public:
   MockFlutterWindow(bool reset_view_on_exit = true)
@@ -109,6 +133,15 @@ class MockFlutterWindowsView : public FlutterWindowsView {
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
+};
+
+class MockKeyboardManager : public KeyboardManager {
+ public:
+  MockKeyboardManager() : KeyboardManager(nullptr) {}
+  MOCK_METHOD(bool,
+              HandleMessage,
+              (UINT const, WPARAM const, LPARAM const),
+              (override));
 };
 
 class FlutterWindowTest : public WindowsTest {};
@@ -308,6 +341,19 @@ TEST_F(FlutterWindowTest, OnThemeChange) {
   EXPECT_CALL(delegate, OnHighContrastChanged).Times(1);
 
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
+}
+
+TEST_F(FlutterWindowTest, VkMenuSysKeyDownMessageIsAlwaysHandled) {
+  std::unique_ptr<FlutterWindowsEngine> engine =
+      FlutterWindowsEngineBuilder{GetContext()}.Build();
+  std::unique_ptr<MockKeyboardManager> keyboard_manager =
+      std::make_unique<MockKeyboardManager>();
+  EXPECT_CALL(*keyboard_manager, HandleMessage)
+      .WillOnce(testing::Return(false));
+  InjectableFlutterWindow window(800, 600, engine->display_manager(), nullptr,
+                                 nullptr, std::move(keyboard_manager));
+
+  EXPECT_EQ(window.InjectWindowMessage(WM_SYSKEYDOWN, VK_MENU, 0), 0);
 }
 
 // The window should return no root accessibility node if

--- a/engine/src/flutter/shell/platform/windows/keyboard_manager.h
+++ b/engine/src/flutter/shell/platform/windows/keyboard_manager.h
@@ -93,6 +93,7 @@ class KeyboardManager {
   using KeyEventCallback = WindowDelegate::KeyEventCallback;
 
   explicit KeyboardManager(WindowDelegate* delegate);
+  virtual ~KeyboardManager() = default;
 
   // Processes Win32 messages related to keyboard and text.
   //
@@ -106,9 +107,9 @@ class KeyboardManager {
   // message here usually means that this message is a redispatched message,
   // but there are other rare cases too. |Window| should forward unhandled
   // messages to |DefWindowProc|.
-  bool HandleMessage(UINT const message,
-                     WPARAM const wparam,
-                     LPARAM const lparam);
+  virtual bool HandleMessage(UINT const message,
+                             WPARAM const wparam,
+                             LPARAM const lparam);
 
  protected:
   struct Win32Message {


### PR DESCRIPTION
fixes [#177822](https://github.com/flutter/flutter/issues/177822)

## What's new?
- The `FlutterWindow` now consumes any `WM_SYSKEYDOWN (VK_MENU)` message
- Wrote a test to validate that this is the case
- Make it so that the `KeyboardManager` can be provided

This PR was made possible by https://github.com/flutter/flutter/pull/178523

## How to test?
1. Create a new flutter project
2. Add the following:

```dart
import 'package:flutter/material.dart';
import 'package:flutter/services.dart';

void main() {
  runApp(const MyApp());

  HardwareKeyboard.instance.addHandler((event) {
    if (event is KeyDownEvent) {
      print('Key pressed: ${event.logicalKey.debugName}');
    }
    return false;
  });
}

// Rest of file unchanged from flutter create output
```
3. Click alt. Note that the message is received.
4. Continue clicking alt and validate that the message is received.
5. Alt tab out and back and note that subsequent alts are correctly received.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

