### PR TITLE
Fix deprecation warning in API example using Radio widget

### DIFF
--- a/examples/api/lib/material/time_picker/show_time_picker.0.dart
+++ b/examples/api/lib/material/time_picker/show_time_picker.0.dart
@@ -261,18 +261,17 @@ class ChoiceCard<T extends Object?> extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           child: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Padding(padding: const EdgeInsets.all(8.0), child: Text(title)),
-                for (final T choice in choices)
-                  RadioSelection<T>(
-                    value: choice,
-                    groupValue: value,
-                    onChanged: onChanged,
-                    child: Text(choiceLabels[choice]!),
-                  ),
-              ],
+            child: RadioGroup<T>(
+              groupValue: value,
+              onChanged: onChanged,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Padding(padding: const EdgeInsets.all(8.0), child: Text(title)),
+                  for (final T choice in choices)
+                    RadioSelection<T>(value: choice, child: Text(choiceLabels[choice]!)),
+                ],
+              ),
             ),
           ),
         ),
@@ -305,17 +304,9 @@ class EnumCard<T extends Enum> extends StatelessWidget {
 // A button that has a radio button on one side and a label child. Tapping on
 // the label or the radio button selects the item.
 class RadioSelection<T extends Object?> extends StatefulWidget {
-  const RadioSelection({
-    super.key,
-    required this.value,
-    required this.groupValue,
-    required this.onChanged,
-    required this.child,
-  });
+  const RadioSelection({super.key, required this.value, required this.child});
 
   final T value;
-  final T? groupValue;
-  final ValueChanged<T?> onChanged;
   final Widget child;
 
   @override
@@ -330,13 +321,12 @@ class _RadioSelectionState<T extends Object?> extends State<RadioSelection<T>> {
       children: <Widget>[
         Padding(
           padding: const EdgeInsetsDirectional.only(end: 8),
-          child: Radio<T>(
-            groupValue: widget.groupValue,
-            value: widget.value,
-            onChanged: widget.onChanged,
-          ),
+          child: Radio<T>(value: widget.value),
         ),
-        GestureDetector(onTap: () => widget.onChanged(widget.value), child: widget.child),
+        GestureDetector(
+          onTap: () => RadioGroup.maybeOf<T>(context)?.onChanged(widget.value),
+          child: widget.child,
+        ),
       ],
     );
   }


### PR DESCRIPTION
- To solve a part of https://github.com/flutter/flutter/issues/179088 (not sure if there are others too, though)
- This fix is for an example in https://api.flutter.dev/flutter/material/showTimePicker.html

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
