### PR TITLE
Send ScrollMetricsNotification when SingleChildScrollView is scrolled.

### DIFF
--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -45,13 +45,13 @@ void main() {
     await gesture.up();
     await tester.pump(const Duration(seconds: 1));
 
-    expect(events.length, 5);
-    // user scroll do not trigger the ScrollMetricsNotification.
+    expect(events.length, 6);
     expect(events[0] is ScrollStartNotification, true);
     expect(events[1] is UserScrollNotification, true);
     expect(events[2] is ScrollUpdateNotification, true);
-    expect(events[3] is ScrollEndNotification, true);
-    expect(events[4] is UserScrollNotification, true);
+    expect(events[3] is ScrollMetricsNotification, true);
+    expect(events[4] is ScrollEndNotification, true);
+    expect(events[5] is UserScrollNotification, true);
 
     events.clear();
     // Change the content dimensions again.
@@ -222,10 +222,12 @@ void main() {
     ScrollNotification? notification;
 
     void handleNotification(ScrollNotification value) {
-      if (value is ScrollStartNotification ||
-          value is ScrollUpdateNotification ||
-          value is ScrollEndNotification) {
-        notification = value;
+      switch (value) {
+        case ScrollStartNotification():
+        case ScrollUpdateNotification(dragDetails: DragUpdateDetails _):
+        case ScrollEndNotification():
+          notification = value;
+        default:
       }
     }
 


### PR DESCRIPTION
Background: #173857.

`ScrollMetricsNotification` was originally not intended to be triggered during scrolling, but `CustomScrollView` triggers a layout during scrolling, which also triggers `ScrollMetricsNotification`. `SingleChildScrollView` does not trigger a layout when scrolling, resulting in different behaviors between `SingleChildScrollView` and `CustomScrollView`. This PR unifies their behavior so that both trigger `ScrollMetricsNotification` when scrolling. 

@chunhtai, this breaks some of your tests in #87076, mainly because triggering `ScrollMetricsNotification` during scrolling happens one frame earlier than during layout, resulting in one less frame. Is this correct?

The original purpose was to update `_lastMetrics`. I tried three approaches: 
1) As shown in this PR, trigger `ScrollMetricsNotification` and update `_lastMetrics` on every scroll; 

2) Cancel triggering `ScrollMetricsNotification` during `CustomScrollView` scrolling, keep `applyContentDimensions` unchanged, and update only the `pixels` property in `_lastMetrics` during scrolling without sending notifications. Since pixels is already updated, `applyContentDimensions` will not trigger notifications either. This will cause more test failures.

3) Maintain the current `ScrollMetricsNotification` triggering, similar to #102339. 

I prefer the first approach, which keeps the behavior of `SingleChildScrollView` and `CustomScrollView` consistent.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
