### PR TITLE
Migrate samples and docs to RadioGroup

### DIFF
--- a/examples/api/lib/material/time_picker/show_time_picker.0.dart
+++ b/examples/api/lib/material/time_picker/show_time_picker.0.dart
@@ -281,7 +281,6 @@ class ChoiceCard<T extends Object?> extends StatelessWidget {
                   for (final T choice in choices)
                     RadioSelection<T>(
                       value: choice,
-                      onChanged: onChanged,
                       child: Text(choiceLabels[choice]!),
                     ),
                 ],
@@ -324,23 +323,16 @@ class EnumCard<T extends Enum> extends StatelessWidget {
 
 // A button that has a radio button on one side and a label child. Tapping on
 // the label or the radio button selects the item.
-class RadioSelection<T extends Object?> extends StatefulWidget {
+class RadioSelection<T extends Object?> extends StatelessWidget {
   const RadioSelection({
     super.key,
     required this.value,
-    required this.onChanged,
     required this.child,
   });
 
   final T value;
-  final ValueChanged<T?> onChanged;
   final Widget child;
 
-  @override
-  State<RadioSelection<T>> createState() => _RadioSelectionState<T>();
-}
-
-class _RadioSelectionState<T extends Object?> extends State<RadioSelection<T>> {
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -348,11 +340,11 @@ class _RadioSelectionState<T extends Object?> extends State<RadioSelection<T>> {
       children: <Widget>[
         Padding(
           padding: const EdgeInsetsDirectional.only(end: 8),
-          child: Radio<T>(value: widget.value),
+          child: Radio<T>(value: value),
         ),
         GestureDetector(
-          onTap: () => widget.onChanged(widget.value),
-          child: widget.child,
+          onTap: () => RadioGroup.maybeOf<T>(context)?.onChanged(value),
+          child: child,
         ),
       ],
     );

--- a/examples/api/lib/material/time_picker/show_time_picker.0.dart
+++ b/examples/api/lib/material/time_picker/show_time_picker.0.dart
@@ -268,18 +268,24 @@ class ChoiceCard<T extends Object?> extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           child: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Padding(padding: const EdgeInsets.all(8.0), child: Text(title)),
-                for (final T choice in choices)
-                  RadioSelection<T>(
-                    value: choice,
-                    groupValue: value,
-                    onChanged: onChanged,
-                    child: Text(choiceLabels[choice]!),
+            child: RadioGroup<T>(
+              groupValue: value,
+              onChanged: onChanged,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(title),
                   ),
-              ],
+                  for (final T choice in choices)
+                    RadioSelection<T>(
+                      value: choice,
+                      onChanged: onChanged,
+                      child: Text(choiceLabels[choice]!),
+                    ),
+                ],
+              ),
             ),
           ),
         ),
@@ -322,13 +328,11 @@ class RadioSelection<T extends Object?> extends StatefulWidget {
   const RadioSelection({
     super.key,
     required this.value,
-    required this.groupValue,
     required this.onChanged,
     required this.child,
   });
 
   final T value;
-  final T? groupValue;
   final ValueChanged<T?> onChanged;
   final Widget child;
 
@@ -344,17 +348,7 @@ class _RadioSelectionState<T extends Object?> extends State<RadioSelection<T>> {
       children: <Widget>[
         Padding(
           padding: const EdgeInsetsDirectional.only(end: 8),
-          child: Radio<T>(
-            // TODO(loic-sharma): Migrate to RadioGroup.
-            // https://github.com/flutter/flutter/issues/179088
-            // ignore: deprecated_member_use
-            groupValue: widget.groupValue,
-            value: widget.value,
-            // TODO(loic-sharma): Migrate to RadioGroup.
-            // https://github.com/flutter/flutter/issues/179088
-            // ignore: deprecated_member_use
-            onChanged: widget.onChanged,
-          ),
+          child: Radio<T>(value: widget.value),
         ),
         GestureDetector(
           onTap: () => widget.onChanged(widget.value),

--- a/examples/api/lib/material/time_picker/show_time_picker.0.dart
+++ b/examples/api/lib/material/time_picker/show_time_picker.0.dart
@@ -324,11 +324,7 @@ class EnumCard<T extends Enum> extends StatelessWidget {
 // A button that has a radio button on one side and a label child. Tapping on
 // the label or the radio button selects the item.
 class RadioSelection<T extends Object?> extends StatelessWidget {
-  const RadioSelection({
-    super.key,
-    required this.value,
-    required this.child,
-  });
+  const RadioSelection({super.key, required this.value, required this.child});
 
   final T value;
   final Widget child;

--- a/examples/api/lib/painting/axis_direction/axis_direction.0.dart
+++ b/examples/api/lib/painting/axis_direction/axis_direction.0.dart
@@ -107,62 +107,26 @@ class _MyWidgetState extends State<MyWidget> {
         ),
         child: Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              Radio<AxisDirection>(
-                value: AxisDirection.up,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('up'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.down,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('down'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.left,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('left'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.right,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('right'),
-              _spacer,
-            ],
+          child: RadioGroup<AxisDirection>(
+            groupValue: _axisDirection,
+            onChanged: _onAxisDirectionChanged,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                Radio<AxisDirection>(value: AxisDirection.up),
+                const Text('up'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.down),
+                const Text('down'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.left),
+                const Text('left'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.right),
+                const Text('right'),
+                _spacer,
+              ],
+            ),
           ),
         ),
       ),

--- a/examples/api/lib/rendering/growth_direction/growth_direction.0.dart
+++ b/examples/api/lib/rendering/growth_direction/growth_direction.0.dart
@@ -115,62 +115,26 @@ class _MyWidgetState extends State<MyWidget> {
         ),
         child: Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              Radio<AxisDirection>(
-                value: AxisDirection.up,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('up'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.down,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('down'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.left,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('left'),
-              _spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.right,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-shaQrma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('right'),
-              _spacer,
-            ],
+          child: RadioGroup<AxisDirection>(
+            groupValue: _axisDirection,
+            onChanged: _onAxisDirectionChanged,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                Radio<AxisDirection>(value: AxisDirection.up),
+                const Text('up'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.down),
+                const Text('down'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.left),
+                const Text('left'),
+                _spacer,
+                Radio<AxisDirection>(value: AxisDirection.right),
+                const Text('right'),
+                _spacer,
+              ],
+            ),
           ),
         ),
       ),

--- a/examples/api/lib/rendering/scroll_direction/scroll_direction.0.dart
+++ b/examples/api/lib/rendering/scroll_direction/scroll_direction.0.dart
@@ -111,62 +111,26 @@ class _MyWidgetState extends State<MyWidget> {
         ),
         child: Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: <Widget>[
-              Radio<AxisDirection>(
-                value: AxisDirection.up,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('up'),
-              spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.down,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('down'),
-              spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.left,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('left'),
-              spacer,
-              Radio<AxisDirection>(
-                value: AxisDirection.right,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                groupValue: _axisDirection,
-                // TODO(loic-sharma): Migrate to RadioGroup.
-                // https://github.com/flutter/flutter/issues/179088
-                // ignore: deprecated_member_use
-                onChanged: _onAxisDirectionChanged,
-              ),
-              const Text('right'),
-              spacer,
-            ],
+          child: RadioGroup<AxisDirection>(
+            groupValue: _axisDirection,
+            onChanged: _onAxisDirectionChanged,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                Radio<AxisDirection>(value: AxisDirection.up),
+                const Text('up'),
+                spacer,
+                Radio<AxisDirection>(value: AxisDirection.down),
+                const Text('down'),
+                spacer,
+                Radio<AxisDirection>(value: AxisDirection.left),
+                const Text('left'),
+                spacer,
+                Radio<AxisDirection>(value: AxisDirection.right),
+                const Text('right'),
+                spacer,
+              ],
+            ),
           ),
         ),
       ),

--- a/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
@@ -48,45 +48,37 @@ class _UnfocusExampleState extends State<UnfocusExample> {
                 );
               }),
             ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: <Widget>[
-                ...List<Widget>.generate(UnfocusDisposition.values.length, (
-                  int index,
-                ) {
-                  return Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Radio<UnfocusDisposition>(
-                        // TODO(loic-sharma): Migrate to RadioGroup.
-                        // https://github.com/flutter/flutter/issues/179088
-                        // ignore: deprecated_member_use
-                        groupValue: disposition,
-                        // TODO(loic-sharma): Migrate to RadioGroup.
-                        // https://github.com/flutter/flutter/issues/179088
-                        // ignore: deprecated_member_use
-                        onChanged: (UnfocusDisposition? value) {
-                          setState(() {
-                            if (value != null) {
-                              disposition = value;
-                            }
-                          });
-                        },
-                        value: UnfocusDisposition.values[index],
-                      ),
-                      Text(UnfocusDisposition.values[index].name),
-                    ],
-                  );
-                }),
-                OutlinedButton(
-                  child: const Text('UNFOCUS'),
-                  onPressed: () {
-                    setState(() {
-                      primaryFocus!.unfocus(disposition: disposition);
-                    });
-                  },
-                ),
-              ],
+            RadioGroup<UnfocusDisposition>(
+              groupValue: disposition,
+              onChanged: (UnfocusDisposition? value) {
+                setState(() {
+                  if (value != null) {
+                    disposition = value;
+                  }
+                });
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: <Widget>[
+                  for (final UnfocusDisposition unfocusDisposition
+                      in UnfocusDisposition.values)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Radio<UnfocusDisposition>(value: unfocusDisposition),
+                        Text(unfocusDisposition.name),
+                      ],
+                    ),
+                  OutlinedButton(
+                    child: const Text('UNFOCUS'),
+                    onPressed: () {
+                      setState(() {
+                        primaryFocus!.unfocus(disposition: disposition);
+                      });
+                    },
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
@@ -48,37 +48,45 @@ class _UnfocusExampleState extends State<UnfocusExample> {
                 );
               }),
             ),
-            RadioGroup<UnfocusDisposition>(
-              groupValue: disposition,
-              onChanged: (UnfocusDisposition? value) {
-                setState(() {
-                  if (value != null) {
-                    disposition = value;
-                  }
-                });
-              },
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: <Widget>[
-                  for (final UnfocusDisposition unfocusDisposition
-                      in UnfocusDisposition.values)
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        Radio<UnfocusDisposition>(value: unfocusDisposition),
-                        Text(unfocusDisposition.name),
-                      ],
-                    ),
-                  OutlinedButton(
-                    child: const Text('UNFOCUS'),
-                    onPressed: () {
-                      setState(() {
-                        primaryFocus!.unfocus(disposition: disposition);
-                      });
-                    },
-                  ),
-                ],
-              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: <Widget>[
+                ...List<Widget>.generate(UnfocusDisposition.values.length, (
+                  int index,
+                ) {
+                  return Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Radio<UnfocusDisposition>(
+                        // TODO(loic-sharma): Migrate to RadioGroup.
+                        // https://github.com/flutter/flutter/issues/179088
+                        // ignore: deprecated_member_use
+                        groupValue: disposition,
+                        // TODO(loic-sharma): Migrate to RadioGroup.
+                        // https://github.com/flutter/flutter/issues/179088
+                        // ignore: deprecated_member_use
+                        onChanged: (UnfocusDisposition? value) {
+                          setState(() {
+                            if (value != null) {
+                              disposition = value;
+                            }
+                          });
+                        },
+                        value: UnfocusDisposition.values[index],
+                      ),
+                      Text(UnfocusDisposition.values[index].name),
+                    ],
+                  );
+                }),
+                OutlinedButton(
+                  child: const Text('UNFOCUS'),
+                  onPressed: () {
+                    setState(() {
+                      primaryFocus!.unfocus(disposition: disposition);
+                    });
+                  },
+                ),
+              ],
             ),
           ],
         ),

--- a/examples/api/lib/widgets/scroll_position/scroll_controller_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_position/scroll_controller_notification.0.dart
@@ -107,35 +107,19 @@ class _ScrollNotificationDemoState extends State<ScrollNotificationDemo> {
                 if (!_useController)
                   Text('Last notification: ${_lastNotification.runtimeType}'),
                 if (!_useController) const SizedBox.square(dimension: 10),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    const Text('with:'),
-                    Radio<bool>(
-                      value: true,
-                      // TODO(loic-sharma): Migrate to RadioGroup.
-                      // https://github.com/flutter/flutter/issues/179088
-                      // ignore: deprecated_member_use
-                      groupValue: _useController,
-                      // TODO(loic-sharma): Migrate to RadioGroup.
-                      // https://github.com/flutter/flutter/issues/179088
-                      // ignore: deprecated_member_use
-                      onChanged: _handleRadioChange,
-                    ),
-                    const Text('ScrollController'),
-                    Radio<bool>(
-                      value: false,
-                      // TODO(loic-sharma): Migrate to RadioGroup.
-                      // https://github.com/flutter/flutter/issues/179088
-                      // ignore: deprecated_member_use
-                      groupValue: _useController,
-                      // TODO(loic-sharma): Migrate to RadioGroup.
-                      // https://github.com/flutter/flutter/issues/179088
-                      // ignore: deprecated_member_use
-                      onChanged: _handleRadioChange,
-                    ),
-                    const Text('NotificationListener'),
-                  ],
+                RadioGroup<bool>(
+                  groupValue: _useController,
+                  onChanged: _handleRadioChange,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      const Text('with:'),
+                      Radio<bool>(value: true),
+                      const Text('ScrollController'),
+                      Radio<bool>(value: false),
+                      const Text('NotificationListener'),
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
@@ -61,11 +61,8 @@ void main() {
 
     expect(
       tester
-          .widget<Radio<Color>>(
-            find.descendant(
-              of: find.byType(RadioMenuButton<Color>).at(0),
-              matching: find.byType(Radio<Color>),
-            ),
+          .widget<RadioMenuButton<Color>>(
+            find.byType(RadioMenuButton<Color>).at(0),
           )
           // TODO(loic-sharma): Migrate to RadioGroup.
           // https://github.com/flutter/flutter/issues/179088
@@ -86,11 +83,8 @@ void main() {
 
     expect(
       tester
-          .widget<Radio<Color>>(
-            find.descendant(
-              of: find.byType(RadioMenuButton<Color>).at(1),
-              matching: find.byType(Radio<Color>),
-            ),
+          .widget<RadioMenuButton<Color>>(
+            find.byType(RadioMenuButton<Color>).at(0),
           )
           // TODO(loic-sharma): Migrate to RadioGroup.
           // https://github.com/flutter/flutter/issues/179088
@@ -111,11 +105,8 @@ void main() {
 
     expect(
       tester
-          .widget<Radio<Color>>(
-            find.descendant(
-              of: find.byType(RadioMenuButton<Color>).at(2),
-              matching: find.byType(Radio<Color>),
-            ),
+          .widget<RadioMenuButton<Color>>(
+            find.byType(RadioMenuButton<Color>).at(0),
           )
           // TODO(loic-sharma): Migrate to RadioGroup.
           // https://github.com/flutter/flutter/issues/179088

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -8360,19 +8360,17 @@ typedef StatefulWidgetBuilder = Widget Function(BuildContext context, StateSette
 ///     return AlertDialog(
 ///       content: StatefulBuilder(
 ///         builder: (BuildContext context, StateSetter setState) {
-///           return Column(
-///             mainAxisSize: MainAxisSize.min,
-///             children: List<Widget>.generate(4, (int index) {
-///               return Radio<int>(
-///                 value: index,
-///                 // ignore: deprecated_member_use
-///                 groupValue: selectedRadio,
-///                 // ignore: deprecated_member_use
-///                 onChanged: (int? value) {
-///                   setState(() => selectedRadio = value);
-///                 },
-///               );
-///             }),
+///           return RadioGroup<int>(
+///             groupValue: selectedRadio,
+///             onChanged: (int? value) {
+///               setState(() => selectedRadio = value);
+///             },
+///             child: Column(
+///               mainAxisSize: MainAxisSize.min,
+///               children: List<Widget>.generate(4, (int index) {
+///                 return Radio<int>(value: index);
+///               }),
+///             ),
 ///           );
 ///         },
 ///       ),


### PR DESCRIPTION
Migrates some - but not all - samples to use the new `RadioGroup` widget.

See: [https://docs.flutter.dev/release/breaking-changes/radio-api-redesign](https://docs.flutter.dev/release/breaking-changes/radio-api-redesign)

Part of: https://github.com/flutter/flutter/issues/179088

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
