### PR TITLE
Support removing the ability to expand/collapse ExpansionPanel (#179167)

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -404,14 +404,14 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       final Widget headerWidget = child.headerBuilder(context, _isChildExpanded(index));
 
       Widget expandIconPadded = Visibility(
-        visible: child.expandable,
+        visible: child.expandable || _isChildExpanded(index),
         maintainSize: true,
         maintainAnimation: true,
         maintainState: true,
         child: Padding(
           padding: const EdgeInsetsDirectional.only(end: 8.0),
           child: IgnorePointer(
-            ignoring: child.canTapOnHeader || !child.expandable,
+            ignoring: child.canTapOnHeader || (!child.expandable && !_isChildExpanded(index)),
             child: ExpandIcon(
               color: widget.expandIconColor,
               isExpanded: _isChildExpanded(index),
@@ -450,7 +450,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           expandIconPadded,
         ],
       );
-      if (child.canTapOnHeader && child.expandable) {
+      if (child.canTapOnHeader && (child.expandable || _isChildExpanded(index))) {
         header = MergeSemantics(
           child: InkWell(
             splashColor: child.splashColor,

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -80,6 +80,7 @@ class ExpansionPanel {
     required this.headerBuilder,
     required this.body,
     this.isExpanded = false,
+    this.expandable = true,
     this.canTapOnHeader = false,
     this.backgroundColor,
     this.splashColor,
@@ -98,6 +99,14 @@ class ExpansionPanel {
   ///
   /// Defaults to false.
   final bool isExpanded;
+
+  /// Whether the panel is expandable.
+  ///
+  /// When true, the expand/collapse icon is shown.
+  /// When false, the expand/collapse icon is hidden.
+  ///
+  /// Defaults to true.
+  final bool expandable;
 
   /// Defines the splash color of the panel if [canTapOnHeader] is true,
   /// or the splash color of the expand/collapse IconButton if [canTapOnHeader]
@@ -394,17 +403,23 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       final ExpansionPanel child = widget.children[index];
       final Widget headerWidget = child.headerBuilder(context, _isChildExpanded(index));
 
-      Widget expandIconPadded = Padding(
-        padding: const EdgeInsetsDirectional.only(end: 8.0),
-        child: IgnorePointer(
-          ignoring: child.canTapOnHeader,
-          child: ExpandIcon(
-            color: widget.expandIconColor,
-            isExpanded: _isChildExpanded(index),
-            padding: _kExpandIconPadding,
-            splashColor: child.splashColor,
-            highlightColor: child.highlightColor,
-            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+      Widget expandIconPadded = Visibility(
+        visible: child.expandable,
+        maintainSize: true,
+        maintainAnimation: true,
+        maintainState: true,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(end: 8.0),
+          child: IgnorePointer(
+            ignoring: child.canTapOnHeader || !child.expandable,
+            child: ExpandIcon(
+              color: widget.expandIconColor,
+              isExpanded: _isChildExpanded(index),
+              padding: _kExpandIconPadding,
+              splashColor: child.splashColor,
+              highlightColor: child.highlightColor,
+              onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+            ),
           ),
         ),
       );
@@ -435,7 +450,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           expandIconPadded,
         ],
       );
-      if (child.canTapOnHeader) {
+      if (child.canTapOnHeader && child.expandable) {
         header = MergeSemantics(
           child: InkWell(
             splashColor: child.splashColor,

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -2075,7 +2075,7 @@ void main() {
     await tester.pumpWidget(buildWidget());
 
     final Finder ignorePointerFinder = find
-        .descendant(of: find.byType(ExpansionPanelList), matching: find.byType(IgnorePointer))
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(IgnorePointer))
         .first;
 
     final IgnorePointer ignorePointerFalse = tester.widget(ignorePointerFinder);
@@ -2086,5 +2086,54 @@ void main() {
 
     final IgnorePointer ignorePointerTrue = tester.widget(ignorePointerFinder);
     expect(ignorePointerTrue.ignoring, isTrue);
+  });
+
+  testWidgets('ExpansionPanel hides ExpandIcon when expandable is false', (
+    WidgetTester tester,
+  ) async {
+    Widget buildWidget({bool expandable = true}) {
+      return MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                expandable: expandable,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content for Panel')),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Test default behavior (expandable: true).
+    await tester.pumpWidget(buildWidget());
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+    expect(visibility.maintainSize, isTrue);
+    expect(visibility.maintainAnimation, isTrue);
+    expect(visibility.maintainState, isTrue);
+
+    // Test with expandable: false.
+    await tester.pumpWidget(buildWidget(expandable: false));
+    await tester.pumpAndSettle();
+
+    visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    // Verify that space is still maintained for consistent layout.
+    expect(visibility.maintainSize, isTrue);
+    expect(visibility.maintainAnimation, isTrue);
+    expect(visibility.maintainState, isTrue);
+
+    // Verify that ExpandIcon is still in the tree (just not visible).
+    expect(find.byType(ExpandIcon), findsOneWidget);
   });
 }


### PR DESCRIPTION
Some items in my ExpansionPanelList have no body. SizedBox will be the status quo for this situation, but it displays the expand/collapse icon, which is misleading.

Allow ExpansionPanel null body which hides expand/collapse icon. 

Fixes #179167