### PR TITLE
Fix draggable scrollable sheet example drag speed is off 

### DIFF
--- a/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
+++ b/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
@@ -36,12 +36,13 @@ class DraggableScrollableSheetExample extends StatefulWidget {
 
 class _DraggableScrollableSheetExampleState
     extends State<DraggableScrollableSheetExample> {
-  double _sheetPosition = 0.5;
-  final double _dragSensitivity = 600;
+  double _dragPosition = 0.5;
+  late double _sheetPosition = _dragPosition;
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final double screenHeight = MediaQuery.sizeOf(context).height;
 
     return DraggableScrollableSheet(
       initialChildSize: _sheetPosition,
@@ -53,12 +54,13 @@ class _DraggableScrollableSheetExampleState
               Grabber(
                 onVerticalDragUpdate: (DragUpdateDetails details) {
                   setState(() {
-                    _sheetPosition -= details.delta.dy / _dragSensitivity;
-                    if (_sheetPosition < 0.25) {
+                    _dragPosition -= details.delta.dy / screenHeight;
+                    if (_dragPosition < 0.25) {
                       _sheetPosition = 0.25;
-                    }
-                    if (_sheetPosition > 1.0) {
+                    } else if (_dragPosition > 1.0) {
                       _sheetPosition = 1.0;
+                    } else {
+                      _sheetPosition = _dragPosition;
                     }
                   });
                 },
@@ -98,7 +100,7 @@ class _DraggableScrollableSheetExampleState
 }
 
 /// A draggable widget that accepts vertical drag gestures
-/// and this is only visible on desktop and web platforms.
+/// and is only visible on desktop and web platforms.
 class Grabber extends StatelessWidget {
   const Grabber({
     super.key,

--- a/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
+++ b/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
@@ -38,6 +38,8 @@ class _DraggableScrollableSheetExampleState
     extends State<DraggableScrollableSheetExample> {
   double _dragPosition = 0.5;
   late double _sheetPosition = _dragPosition;
+  final minChildSize = 0.25;
+  final maxChildSize = 1.0;
 
   @override
   Widget build(BuildContext context) {
@@ -51,21 +53,18 @@ class _DraggableScrollableSheetExampleState
           color: colorScheme.primary,
           child: Column(
             children: <Widget>[
-              Grabber(
-                onVerticalDragUpdate: (DragUpdateDetails details) {
-                  setState(() {
-                    _dragPosition -= details.delta.dy / screenHeight;
-                    if (_dragPosition < 0.25) {
-                      _sheetPosition = 0.25;
-                    } else if (_dragPosition > 1.0) {
-                      _sheetPosition = 1.0;
-                    } else {
-                      _sheetPosition = _dragPosition;
-                    }
-                  });
-                },
-                isOnDesktopAndWeb: _isOnDesktopAndWeb,
-              ),
+              if (_isOnDesktopAndWeb)
+                Grabber(
+                  onVerticalDragUpdate: (DragUpdateDetails details) {
+                    setState(() {
+                      _dragPosition -= details.delta.dy / screenHeight;
+                      _sheetPosition = _dragPosition.clamp(
+                        minChildSize,
+                        maxChildSize,
+                      );
+                    });
+                  },
+                ),
               Flexible(
                 child: ListView.builder(
                   controller: _isOnDesktopAndWeb ? null : scrollController,
@@ -102,20 +101,12 @@ class _DraggableScrollableSheetExampleState
 /// A draggable widget that accepts vertical drag gestures
 /// and is only visible on desktop and web platforms.
 class Grabber extends StatelessWidget {
-  const Grabber({
-    super.key,
-    required this.onVerticalDragUpdate,
-    required this.isOnDesktopAndWeb,
-  });
+  const Grabber({super.key, required this.onVerticalDragUpdate});
 
   final ValueChanged<DragUpdateDetails> onVerticalDragUpdate;
-  final bool isOnDesktopAndWeb;
 
   @override
   Widget build(BuildContext context) {
-    if (!isOnDesktopAndWeb) {
-      return const SizedBox.shrink();
-    }
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
 
     return GestureDetector(

--- a/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
+++ b/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
@@ -36,6 +36,9 @@ class DraggableScrollableSheetExample extends StatefulWidget {
 
 class _DraggableScrollableSheetExampleState
     extends State<DraggableScrollableSheetExample> {
+  // This variable is used to restore the draggable sheet drag position
+  // for the purpose of handling over-dragging beyond bounds when
+  // the dragging mouse pointer re-enters the window on web and desktop platforms.
   double _dragPosition = 0.5;
   late double _sheetPosition = _dragPosition;
   final minChildSize = 0.25;

--- a/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
+++ b/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
@@ -47,43 +47,48 @@ class _DraggableScrollableSheetExampleState
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    final double screenHeight = MediaQuery.sizeOf(context).height;
 
-    return DraggableScrollableSheet(
-      initialChildSize: _sheetPosition,
-      builder: (BuildContext context, ScrollController scrollController) {
-        return ColoredBox(
-          color: colorScheme.primary,
-          child: Column(
-            children: <Widget>[
-              if (_isOnDesktopAndWeb)
-                Grabber(
-                  onVerticalDragUpdate: (DragUpdateDetails details) {
-                    setState(() {
-                      _dragPosition -= details.delta.dy / screenHeight;
-                      _sheetPosition = _dragPosition.clamp(
-                        minChildSize,
-                        maxChildSize,
-                      );
-                    });
-                  },
-                ),
-              Flexible(
-                child: ListView.builder(
-                  controller: _isOnDesktopAndWeb ? null : scrollController,
-                  itemCount: 25,
-                  itemBuilder: (BuildContext context, int index) {
-                    return ListTile(
-                      title: Text(
-                        'Item $index',
-                        style: TextStyle(color: colorScheme.surface),
-                      ),
-                    );
-                  },
-                ),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double viewHeight = constraints.maxHeight;
+
+        return DraggableScrollableSheet(
+          initialChildSize: _sheetPosition,
+          builder: (BuildContext context, ScrollController scrollController) {
+            return ColoredBox(
+              color: colorScheme.primary,
+              child: Column(
+                children: <Widget>[
+                  if (_isOnDesktopAndWeb)
+                    Grabber(
+                      onVerticalDragUpdate: (DragUpdateDetails details) {
+                        setState(() {
+                          _dragPosition -= details.delta.dy / viewHeight;
+                          _sheetPosition = _dragPosition.clamp(
+                            minChildSize,
+                            maxChildSize,
+                          );
+                        });
+                      },
+                    ),
+                  Flexible(
+                    child: ListView.builder(
+                      controller: _isOnDesktopAndWeb ? null : scrollController,
+                      itemCount: 25,
+                      itemBuilder: (BuildContext context, int index) {
+                        return ListTile(
+                          title: Text(
+                            'Item $index',
+                            style: TextStyle(color: colorScheme.surface),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            );
+          },
         );
       },
     );

--- a/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
+++ b/examples/api/lib/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0.dart
@@ -106,8 +106,9 @@ class _DraggableScrollableSheetExampleState
       };
 }
 
-/// A draggable widget that accepts vertical drag gestures
-/// and is only visible on desktop and web platforms.
+/// A draggable widget that accepts vertical drag gestures.
+///
+/// This is typically only used in desktop or web platforms.
 class Grabber extends StatelessWidget {
   const Grabber({super.key, required this.onVerticalDragUpdate});
 

--- a/examples/api/test/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0_test.dart
+++ b/examples/api/test/widgets/draggable_scrollable_sheet/draggable_scrollable_sheet.0_test.dart
@@ -74,4 +74,92 @@ void main() {
     },
     variant: TargetPlatformVariant.desktop(),
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/179102.
+  testWidgets(
+    'Test DraggableScrollableSheet should move (with mouse pointer) proportionally to view height',
+    (WidgetTester tester) async {
+      // Simulate a viewport size with an exaggerated height.
+      tester.view.physicalSize = const Size(800.0, 1000.0);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const example.DraggableScrollableSheetExampleApp(),
+      );
+
+      final Finder grabberFinder = find.byType(example.Grabber);
+      expect(grabberFinder, findsOneWidget);
+
+      // Get initial sheet size.
+      final DraggableScrollableSheet initialSheet = tester.widget(
+        find.byType(DraggableScrollableSheet),
+      );
+      expect(initialSheet.initialChildSize, 0.5);
+
+      // Drag up by 100 pixels.
+      // Since initial size is 0.5, dragging up should increase the sheet height.
+      await tester.drag(grabberFinder, const Offset(0.0, -100.0));
+      await tester.pump();
+
+      final DraggableScrollableSheet draggedSheet = tester.widget(
+        find.byType(DraggableScrollableSheet),
+      );
+
+      // Verify that the sheet moved proportionally.
+      // It should be greater than initial (0.5).
+      expect(draggedSheet.initialChildSize, greaterThan(0.5));
+    },
+    variant: TargetPlatformVariant.desktop(),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/179102.
+  testWidgets(
+    'Test DraggableScrollableSheet respects max bounds',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.DraggableScrollableSheetExampleApp(),
+      );
+
+      final Finder grabberFinder = find.byType(example.Grabber);
+      expect(grabberFinder, findsOneWidget);
+
+      // Drag far up to exceed max bounds (1.0).
+      await tester.drag(grabberFinder, const Offset(0.0, -1000.0));
+      await tester.pump();
+
+      final DraggableScrollableSheet draggableSheet = tester.widget(
+        find.byType(DraggableScrollableSheet),
+      );
+
+      // Verify that the sheet is clamped to max (1.0).
+      expect(draggableSheet.initialChildSize, 1.0);
+    },
+    variant: TargetPlatformVariant.desktop(),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/179102.
+  testWidgets(
+    'Test DraggableScrollableSheet respects min bounds',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.DraggableScrollableSheetExampleApp(),
+      );
+
+      final Finder grabberFinder = find.byType(example.Grabber);
+      expect(grabberFinder, findsOneWidget);
+
+      // Drag far down to exceed min bounds (0.25).
+      await tester.drag(grabberFinder, const Offset(0.0, 1000.0));
+      await tester.pump();
+
+      final DraggableScrollableSheet draggableSheet = tester.widget(
+        find.byType(DraggableScrollableSheet),
+      );
+
+      // Verify that the sheet is clamped to min (0.25).
+      expect(draggableSheet.initialChildSize, 0.25);
+    },
+    variant: TargetPlatformVariant.desktop(),
+  );
 }


### PR DESCRIPTION
- Fix https://github.com/flutter/flutter/issues/179102
- In this PR:
    - Fix the sheet position so that it will follow the pointer, even when dragging mouse beyond the window then returns inside.
    - Some improvement for coding convention:
        -  declare minChildSize and maxChildSize const(s) then use them in the hardcoded positions
        - move `_isOnDesktopAndWeb` out of Grabber, so it's easier to see Grabber widget purpose when reading the code

<details open>
<summary>Demo</summary>

| before | after |
| --------------- | --------------- |
<img width="360" src="https://github.com/user-attachments/assets/5f4f507d-1491-47a2-90a6-c2a32ecdf6b5"> | <img width="360" src="https://github.com/user-attachments/assets/b2eb9ede-572e-4fcb-81c1-2269b8db2140">

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
