### PR TITLE
Add DropdownMenu.selectOnly

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -672,7 +672,7 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
 }
 
 class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
-  static const Map<ShortcutActivator, Intent> _commonShortcuts = <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _editableShortcuts = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowLeft): ExtendSelectionByCharacterIntent(
       forward: false,
       collapseSelection: true,
@@ -683,6 +683,14 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
     ),
     SingleActivator(LogicalKeyboardKey.arrowUp): _ArrowUpIntent(),
     SingleActivator(LogicalKeyboardKey.arrowDown): _ArrowDownIntent(),
+  };
+
+  static const Map<ShortcutActivator, Intent> _selectOnlyShortcuts = <ShortcutActivator, Intent>{
+    SingleActivator(LogicalKeyboardKey.arrowUp): _ArrowUpIntent(),
+    SingleActivator(LogicalKeyboardKey.arrowDown): _ArrowDownIntent(),
+    // When selectOnly is true, a shortcut for the enter key is needed because
+    // the text field won't provide one.
+    SingleActivator(LogicalKeyboardKey.enter): _EnterIntent(),
   };
 
   final GlobalKey _anchorKey = GlobalKey();
@@ -1320,12 +1328,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
               );
 
         return Shortcuts(
-          shortcuts: <ShortcutActivator, Intent>{
-            ..._commonShortcuts,
-            // When selectOnly is true, a shortcut for the enter key is needed because
-            // the text field won't provide one.
-            if (selectOnly) const SingleActivator(LogicalKeyboardKey.enter): const _EnterIntent(),
-          },
+          shortcuts: selectOnly ? _selectOnlyShortcuts : _editableShortcuts,
           child: body,
         );
       },

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1021,7 +1021,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
     return result;
   }
 
-  void handleUpKeyInvoke(_ArrowUpIntent _) {
+  void handleUpKey(_ArrowUpIntent _) {
     setState(() {
       if (!widget.enabled || !_menuHasEnabledItem || !_controller.isOpen) {
         return;
@@ -1041,7 +1041,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
     });
   }
 
-  void handleDownKeyInvoke(_ArrowDownIntent _) {
+  void handleDownKey(_ArrowDownIntent _) {
     setState(() {
       if (!widget.enabled || !_menuHasEnabledItem || !_controller.isOpen) {
         return;
@@ -1367,8 +1367,8 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
 
     return Actions(
       actions: <Type, Action<Intent>>{
-        _ArrowUpIntent: CallbackAction<_ArrowUpIntent>(onInvoke: handleUpKeyInvoke),
-        _ArrowDownIntent: CallbackAction<_ArrowDownIntent>(onInvoke: handleDownKeyInvoke),
+        _ArrowUpIntent: CallbackAction<_ArrowUpIntent>(onInvoke: handleUpKey),
+        _ArrowDownIntent: CallbackAction<_ArrowDownIntent>(onInvoke: handleDownKey),
         _EnterIntent: CallbackAction<_EnterIntent>(onInvoke: handleEnterKey),
         DismissIntent: DismissMenuAction(controller: _controller),
       },

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -509,10 +509,16 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
 
   /// Determines if the dropdown menu behaves as a 'select' component.
   ///
-  /// When true the inner text field is read only. If [requestFocusOnTap] is also true,
-  /// the text field is focusable and the current behaviors are activated:
+  /// This is useful for mobile platforms where a dropdown menu is commonly used as
+  /// a 'select' widget (i.e., the user can only select from the list, not edit
+  /// the text field to search or filter).
   ///
-  ///  * Enter key opens the menu if it is closed.
+  /// When true, the inner text field is read-only.
+  ///
+  /// If the text field is also focusable (see [requestFocusOnTap]), the following
+  /// behaviors are also activated:
+  ///
+  ///  * Pressing Enter when the menu is closed opens it.
   ///
   ///  * The decoration reflects the focus state.
   ///

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -519,7 +519,6 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
   /// behaviors are also activated:
   ///
   ///  * Pressing Enter when the menu is closed opens it.
-  ///
   ///  * The decoration reflects the focus state.
   ///
   /// Defaults to false.


### PR DESCRIPTION
## Description

This PR adds `DropdownMenu.selectOnly`. This property allows users to get the DropdownMenu behave as a 'select' component.
It is meant as a future replacement for `DropdownMenu.requestFocusOnTap`.

## Motivation

On mobile, a dropdown menu widget is usually used as a ‘select’ widget because opening the keyboard for searching/filtering is not convenient.

In Flutter, this is currently implemented through `DropdownMenu.requestFocusOnTap` which defaults to false on mobile and true on desktop.
The `DropdownMenu.requestFocusOnTap` property is currently used to set `FocusNode.canRequestFocus`. This leads do difficulties mainly related to focus traversal:
- Keyboard traversal requires workarounds (for instance relying on the trailing icon to be focusable).
- Keyboard shortcuts require also a workaround (currently relying on a Focus widget in a Stack).
- The `DropdownMenu` decoration does not reflect the focus state.

This PR proposes a new property named `DropdownMenu.selectOnly` which does not require `DropdownMenu.requestFocusOnTap` to be false to make the `DropdownMenu` behave like a select widget.

With this property the `DropdownMenu`:
- Supports keyboard navigation on mobile and desktop.
- Has a correct decoration when focused.
- Does not rely on the trailing icon to be focusable (see https://github.com/flutter/flutter/issues/174096).

In the future this property could be used as a replacement for `DropdownMenu.requestFocusOnTap`. For the moment, for compatibility, it does not replace `DropdownMenu.requestFocusOnTap`.

## Related Issue

Fixes [Allow DropdownMenu to be non-editable and focusable (select control) ](https://github.com/flutter/flutter/issues/178009)
Also related to [Make DropdownMenu's trailing icon not focusable by default](https://github.com/flutter/flutter/issues/174096)  and [[Material3] DropdownMenu Keyboard Accessibility](https://github.com/flutter/flutter/issues/123797).


## Tests

- Adds 9 tests.
