### PR TITLE
[ Tool ] Don't try to reattach when attach target disappears

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -888,7 +888,7 @@ class RunCommand extends RunCommandBase {
       }),
     );
     try {
-      final int? result = await runner.run(
+      final int result = await runner.run(
         appStartedCompleter: appStartedTimeRecorder,
         route: route,
       );

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1215,7 +1215,7 @@ abstract class ResidentRunner extends ResidentHandlers {
   ///
   /// Returns the exit code that we should use for the flutter tool process; 0
   /// for success, 1 for user error (e.g. bad arguments), 2 for other failures.
-  Future<int?> run({
+  Future<int> run({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
     String? route,
@@ -1225,7 +1225,7 @@ abstract class ResidentRunner extends ResidentHandlers {
   ///
   /// [needsFullRestart] defaults to `true`, and controls if the frontend server should
   /// compile a full dill. This should be set to `false` if this is called in [ResidentRunner.run], since that method already performs an initial compilation.
-  Future<int?> attach({
+  Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
     bool needsFullRestart = true,

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2170,7 +2170,7 @@ flutter:
         nativeAssetsYamlFile: 'foo.yaml',
       );
 
-      final int? result = await residentRunner.run();
+      final int result = await residentRunner.run();
       expect(result, 0);
 
       expect(residentCompiler.recompileCalled, true);

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1405,20 +1405,20 @@ class TestRunner extends Fake implements ResidentRunner {
   }
 
   @override
-  Future<int?> run({
+  Future<int> run({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
     bool enableDevTools = false,
     String? route,
-  }) async => null;
+  }) async => -1;
 
   @override
-  Future<int?> attach({
+  Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
     bool enableDevTools = false,
     bool needsFullRestart = true,
-  }) async => null;
+  }) async => -1;
 }
 
 class _TestSignals implements Signals {


### PR DESCRIPTION
Before this change, there was logic in `flutter attach` that would try and listen for a new application to attach to in the scenario the current target application disappeared. This behavior isn't documented, and has resulted in a `StateError` being thrown due to the VM service URIs stream being listened to multiple times.

This change removes this behavior, which also prevents the `StateError` from being thrown.

Fixes https://github.com/flutter/flutter/issues/156692, which is a top-10 crasher for the tool.