### PR TITLE
[CP-stable] Build hooks: Don't require toolchain for unit tests

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -9,10 +9,16 @@ import '../../../base/file_system.dart';
 import '../../../base/io.dart';
 import '../../../globals.dart' as globals;
 
-/// Flutter expects `clang++` to be on the path on Linux hosts.
+/// Returns a [CCompilerConfig] matching a toolchain that would be used to compile the main app with
+/// CMake on Linux.
 ///
-/// Search for the accompanying `clang`, `ar`, and `ld`.
-Future<CCompilerConfig> cCompilerConfigLinux() async {
+/// Flutter expects `clang++` to be on the path on Linux hosts, which this uses to search for the
+/// accompanying `clang`, `ar`, and `ld`.
+///
+/// If [throwIfNotFound] is false, this is allowed to fail (in which case `null`) is returned. This
+/// is used for `flutter test` setups, where no main app is compiled and we thus don't want a
+/// `clang` toolchain to be a requirement.
+Future<CCompilerConfig?> cCompilerConfigLinux({required bool throwIfNotFound}) async {
   const kClangPlusPlusBinary = 'clang++';
   // NOTE: these binaries sometimes have different names depending on the installation;
   // thus, we check for a few possible options (in order of preference).
@@ -25,30 +31,53 @@ Future<CCompilerConfig> cCompilerConfigLinux() async {
     kClangPlusPlusBinary,
   ]);
   if (whichResult.exitCode != 0) {
-    throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
+    if (throwIfNotFound) {
+      throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
+    } else {
+      return null;
+    }
   }
   File clangPpFile = globals.fs.file((whichResult.stdout as String).trim());
   clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
 
   final Directory clangDir = clangPpFile.parent;
-  return CCompilerConfig(
-    linker: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kLdBinaryOptions),
-    compiler: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kClangBinaryOptions),
-    archiver: _findExecutableIfExists(path: clangDir, possibleExecutableNames: kArBinaryOptions),
+  Uri? findExecutable({required List<String> possibleExecutableNames, required Directory path}) {
+    final Uri? found = _findExecutableIfExists(
+      possibleExecutableNames: possibleExecutableNames,
+      path: path,
+    );
+
+    if (found == null && throwIfNotFound) {
+      throwToolExit('Failed to find any of $possibleExecutableNames in $path');
+    }
+
+    return found;
+  }
+
+  final Uri? linker = findExecutable(path: clangDir, possibleExecutableNames: kLdBinaryOptions);
+  final Uri? compiler = findExecutable(
+    path: clangDir,
+    possibleExecutableNames: kClangBinaryOptions,
   );
+  final Uri? archiver = findExecutable(path: clangDir, possibleExecutableNames: kArBinaryOptions);
+
+  if (linker == null || compiler == null || archiver == null) {
+    assert(!throwIfNotFound); // otherwise, findExecutable would have thrown
+    return null;
+  }
+  return CCompilerConfig(linker: linker, compiler: compiler, archiver: archiver);
 }
 
 /// Searches for an executable with a name in [possibleExecutableNames]
 /// at [path] and returns the first one it finds, if one is found.
-/// Otherwise, throws an error.
-Uri _findExecutableIfExists({
+/// Otherwise, returns `null`.
+Uri? _findExecutableIfExists({
   required List<String> possibleExecutableNames,
   required Directory path,
 }) {
   return possibleExecutableNames
-          .map((execName) => path.childFile(execName))
-          .where((file) => file.existsSync())
-          .map((file) => file.uri)
-          .firstOrNull ??
-      throwToolExit('Failed to find any of $possibleExecutableNames in $path');
+      .map((execName) => path.childFile(execName))
+      .where((file) => file.existsSync())
+      .map((file) => file.uri)
+      .firstOrNull;
 }

--- a/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/linux/native_assets_test.dart
@@ -93,7 +93,7 @@ void main() {
       await fileSystem.file('/some/path/to/llvm-ar').create();
       await fileSystem.file('/some/path/to/ld.lld').create();
 
-      final CCompilerConfig result = await cCompilerConfigLinux();
+      final CCompilerConfig result = (await cCompilerConfigLinux(throwIfNotFound: true))!;
       expect(result.compiler, Uri.file('/some/path/to/clang'));
     },
   );
@@ -115,7 +115,7 @@ void main() {
         await fileSystem.file('/path/to/$execName').create(recursive: true);
       }
 
-      final CCompilerConfig result = await cCompilerConfigLinux();
+      final CCompilerConfig result = (await cCompilerConfigLinux(throwIfNotFound: true))!;
       expect(result.linker, Uri.file('/path/to/ld'));
       expect(result.compiler, Uri.file('/path/to/clang'));
       expect(result.archiver, Uri.file('/path/to/ar'));
@@ -123,7 +123,7 @@ void main() {
   );
 
   testUsingContext(
-    'cCompilerConfigLinux with missing binaries',
+    'cCompilerConfigLinux with missing binaries when required',
     overrides: <Type, Generator>{
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <Pattern>['which', 'clang++'], stdout: '/a/path/to/clang++'),
@@ -137,7 +137,25 @@ void main() {
 
       await fileSystem.file('/a/path/to/clang++').create(recursive: true);
 
-      expect(cCompilerConfigLinux(), throwsA(isA<ToolExit>()));
+      expect(cCompilerConfigLinux(throwIfNotFound: true), throwsA(isA<ToolExit>()));
+    },
+  );
+
+  testUsingContext(
+    'cCompilerConfigLinux with missing binaries when not required',
+    overrides: <Type, Generator>{
+      ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(command: <Pattern>['which', 'clang++'], stdout: '/a/path/to/clang++'),
+      ]),
+      FileSystem: () => fileSystem,
+    },
+    () async {
+      if (!const LocalPlatform().isLinux) {
+        return;
+      }
+
+      await fileSystem.file('/a/path/to/clang++').create(recursive: true);
+      expect(cCompilerConfigLinux(throwIfNotFound: false), completes);
     },
   );
 }


### PR DESCRIPTION
### Issue Link:

https://github.com/flutter/flutter/pull/178954

(beta CP: https://github.com/flutter/flutter/pull/179211)

### Impact Description:

Running `flutter test` on Linux  or MacOS which does not have a `clang` starts failing on projects that target only Android otherwise (and do not require a Linux or MacOS toolchain) when there are build hooks anywhere in the dependencies.

This PR changes the behavior for `flutter test` to only pass `clang` and friends if they are installed. This means that _if_ a Linux/MacOS toolchain is installed on the system, it will be used for both `flutter run -d Linux`/`MacOS` and `flutter test` (so that the same native compiler is used), but if it's not installed on the system both `flutter run -d AndroidDevice` and `flutter test` run successfully.

This means end users don't have to go modify their systems/CIs to install Linux/MacOS toolchains for Android projects.

### Changelog Description:

[flutter/178954] Fixes running `flutter test` on Linux/MacOS for Android projects with build hooks without the desktop native tooling installed.

### Workaround:

All end users have to install `clang` and `ldd` on Linux/MacOS hosts and CI bots.

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

It changes the flow in Flutter tools from throwing an error to returning a nullable value.

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

On a Linux  and MacOS system, make a Flutter app that only targets Android. Add a build hook. And ensure there's no `clang` on the `PATH` (Can be verified by `flutter doctor -v` finding no tooling for Flutter desktop). Run `flutter test` and it shouldn't fail due to `clang` not being installed. For MacOS, XCode needs to not be installed.
