### PR TITLE
make sysroot build variable an absolute path

### DIFF
--- a/engine/src/build/config/sysroot.gni
+++ b/engine/src/build/config/sysroot.gni
@@ -19,18 +19,18 @@ if (current_toolchain == default_toolchain && target_sysroot != "") {
   sysroot = target_sysroot
 } else if (is_android) {
   import("//build/config/android/config.gni")
-  sysroot = rebase_path("$android_toolchain_root/sysroot", root_build_dir)
+  sysroot = rebase_path("$android_toolchain_root/sysroot")
 } else if (is_linux && !is_chromeos) {
   if (use_default_linux_sysroot && !is_fuchsia) {
     if (current_cpu == "x64") {
       sysroot =
-          rebase_path("//build/linux/debian_bullseye_amd64-sysroot", root_build_dir)
+          rebase_path("//build/linux/debian_bullseye_amd64-sysroot")
     } else if (current_cpu == "arm64") {
       sysroot =
-          rebase_path("//build/linux/debian_bullseye_arm64-sysroot", root_build_dir)
+          rebase_path("//build/linux/debian_bullseye_arm64-sysroot")
     } else if (current_cpu == "riscv64") {
       sysroot =
-          rebase_path("//build/linux/debian_trixie_riscv64-sysroot", root_build_dir)
+          rebase_path("//build/linux/debian_trixie_riscv64-sysroot")
     }
     assert(
         exec_script("//build/dir_exists.py", [ sysroot ], "string") == "True",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Make the `sysroot` build variable introduced by `sysroot.gni` an absolute path. It is described as such in the comments, but is actually converted to a relative path when returned by the `rebase_path` function.

Making it an absolute path makes it easier to pass as an argument to build tools located in other folders.

Did a local linux and android build to smoke test that there are no breakages.

Fixes #179255 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
