### PR TITLE
[ Widget Preview ] Ignore changes under `ios/.symlinks`

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -252,6 +252,7 @@ class FlutterProject {
     android.ephemeralDirectory,
     ios.ephemeralDirectory,
     ios.ephemeralModuleDirectory,
+    ios.symlinks,
     linux.ephemeralDirectory,
     macos.ephemeralDirectory,
     windows.ephemeralDirectory,

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
@@ -66,6 +66,7 @@ void main() {
     }
 
     test('regression test https://github.com/flutter/flutter/issues/178317', () async {
+      // Also regression test for https://github.com/flutter/flutter/issues/179008
       await previewDetector.initialize();
       expect(project.ephemeralDirectories, isNotEmpty);
       for (final Directory dir in project.ephemeralDirectories) {


### PR DESCRIPTION
This directory should have been filtered as part of the fix for https://github.com/flutter/flutter/issues/178317

Fixes https://github.com/flutter/flutter/issues/179008