### PR TITLE
add default-linux-sysroot to gn frontend args

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -634,6 +634,7 @@ def to_gn_args(args):
   if args.target_sysroot:
     gn_args['target_sysroot'] = args.target_sysroot
     gn_args['custom_sysroot'] = args.target_sysroot
+  gn_args['use_default_linux_sysroot'] = args.default_linux_sysroot
 
   if args.target_toolchain:
     gn_args['custom_toolchain'] = args.target_toolchain
@@ -1094,6 +1095,22 @@ def parse_args(args):
   )
 
   parser.add_argument('--target-sysroot', type=str)
+
+  # Python 3.9 has `action=argparse.BooleanOptionalAction`
+  # to do this more concisely.
+  parser.add_argument(
+      '--no-default-linux-sysroot',
+      action='store_false',
+      dest='default_linux_sysroot',
+  )
+  parser.add_argument(
+      '--default-linux-sysroot',
+      action='store_true',
+      help='Use the flutter provided default sysroot if building for linux'
+      ' and no other sysroot is specified (default is true)'
+  )
+  parser.set_defaults(default_linux_sysroot=True)
+
   parser.add_argument('--target-toolchain', type=str)
   parser.add_argument('--target-triple', type=str)
   parser.add_argument(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Adds `[no-]default-linux-sysroot` to the `gn` frontend to control the `use_default_linux_sysroot` argument.

Closes #179298

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
