### PR TITLE
Replace use of eglCreateImage with eglCreateImageKHR to reduce EGL requirement

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer.cc
@@ -44,7 +44,7 @@ static EGLImage create_egl_image(GLuint texture_id) {
     return nullptr;
   }
 
-  return eglCreateImage(
+  return eglCreateImageKHR(
       egl_display, egl_context, EGL_GL_TEXTURE_2D,
       reinterpret_cast<EGLClientBuffer>(static_cast<intptr_t>(texture_id)),
       nullptr);

--- a/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_framebuffer_test.cc
@@ -43,7 +43,7 @@ TEST(FlFramebufferTest, ResourcesRemoved) {
 TEST(FlFramebufferTest, Sibling) {
   ::testing::NiceMock<flutter::testing::MockEpoxy> epoxy;
 
-  EXPECT_CALL(epoxy, eglCreateImage);
+  EXPECT_CALL(epoxy, eglCreateImageKHR);
   g_autoptr(FlFramebuffer) framebuffer =
       fl_framebuffer_new(GL_RGB, 100, 100, TRUE);
   g_autoptr(FlFramebuffer) sibling = fl_framebuffer_create_sibling(framebuffer);

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.cc
@@ -375,12 +375,12 @@ EGLBoolean _eglSwapBuffers(EGLDisplay dpy, EGLSurface surface) {
   return bool_success();
 }
 
-EGLImage _eglCreateImage(EGLDisplay dpy,
-                         EGLContext ctx,
-                         EGLenum target,
-                         EGLClientBuffer buffer,
-                         const EGLAttrib* attrib_list) {
-  mock->eglCreateImage(dpy, ctx, target, buffer, attrib_list);
+EGLImageKHR _eglCreateImageKHR(EGLDisplay dpy,
+                               EGLContext ctx,
+                               EGLenum target,
+                               EGLClientBuffer buffer,
+                               const EGLint* attrib_list) {
+  mock->eglCreateImageKHR(dpy, ctx, target, buffer, attrib_list);
   return &mock_image;
 }
 
@@ -658,11 +658,11 @@ EGLBoolean (*epoxy_eglMakeCurrent)(EGLDisplay dpy,
                                    EGLSurface read,
                                    EGLContext ctx);
 EGLBoolean (*epoxy_eglSwapBuffers)(EGLDisplay dpy, EGLSurface surface);
-EGLImage (*epoxy_eglCreateImage)(EGLDisplay dpy,
-                                 EGLContext ctx,
-                                 EGLenum target,
-                                 EGLClientBuffer buffer,
-                                 const EGLAttrib* attrib_list);
+EGLImageKHR (*epoxy_eglCreateImageKHR)(EGLDisplay dpy,
+                                       EGLContext ctx,
+                                       EGLenum target,
+                                       EGLClientBuffer buffer,
+                                       const EGLint* attrib_list);
 
 void (*epoxy_glAttachShader)(GLuint program, GLuint shader);
 void (*epoxy_glBindFramebuffer)(GLenum target, GLuint framebuffer);
@@ -738,7 +738,7 @@ static void library_init() {
   epoxy_eglMakeCurrent = _eglMakeCurrent;
   epoxy_eglQueryContext = _eglQueryContext;
   epoxy_eglSwapBuffers = _eglSwapBuffers;
-  epoxy_eglCreateImage = _eglCreateImage;
+  epoxy_eglCreateImageKHR = _eglCreateImageKHR;
 
   epoxy_glAttachShader = _glAttachShader;
   epoxy_glBindFramebuffer = _glBindFramebuffer;

--- a/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_epoxy.h
@@ -22,12 +22,12 @@ class MockEpoxy {
   MOCK_METHOD(bool, epoxy_is_desktop_gl, ());
   MOCK_METHOD(int, epoxy_gl_version, ());
   MOCK_METHOD(void,
-              eglCreateImage,
+              eglCreateImageKHR,
               (EGLDisplay dpy,
                EGLContext ctx,
                EGLenum target,
                EGLClientBuffer buffer,
-               const EGLAttrib* attrib_list));
+               const EGLint* attrib_list));
   MOCK_METHOD(void, glClearColor, (GLfloat r, GLfloat g, GLfloat b, GLfloat a));
   MOCK_METHOD(void,
               glBlitFramebuffer,


### PR DESCRIPTION
This otherwise required EGL 1.5. This matches the Android embedder which also uses the extension version.

Fixes https://github.com/flutter/flutter/issues/178462
