### PR TITLE
Add DropdownMenuFormField.errorBuilder

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'dropdown_menu.dart';
+import 'input_decorator.dart';
 import 'menu_style.dart';
 
 /// A [FormField] that contains a [DropdownMenu].
@@ -71,11 +72,35 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     super.validator,
     super.forceErrorText,
+    super.errorBuilder,
   }) : super(
          initialValue: initialSelection,
          autovalidateMode: autovalidateMode,
          builder: (FormFieldState<T> field) {
            final state = field as _DropdownMenuFormFieldState<T>;
+
+           // Delegate label, hintText and helperText definition to a decoration builder.
+           InputDecoration defaultDecorationBuilder(
+             BuildContext context,
+             MenuController menuController,
+           ) {
+             final InputDecoration decoration =
+                 decorationBuilder?.call(context, menuController) ?? const InputDecoration();
+             return decoration.copyWith(label: label, hintText: hintText, helperText: helperText);
+           }
+
+           DropdownMenuDecorationBuilder effectiveDecorationBuilder = defaultDecorationBuilder;
+
+           final String? errorText = state.errorText;
+           if (errorText != null) {
+             effectiveDecorationBuilder = (BuildContext context, MenuController menuController) {
+               final InputDecoration decoration = defaultDecorationBuilder(context, menuController);
+               return errorBuilder != null
+                   ? decoration.copyWith(error: errorBuilder(state.context, errorText))
+                   : decoration.copyWith(errorText: errorText);
+             };
+           }
+
            return UnmanagedRestorationScope(
              bucket: field.bucket,
              child: DropdownMenu<T>(
@@ -85,10 +110,6 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
                menuHeight: menuHeight,
                leadingIcon: leadingIcon,
                trailingIcon: trailingIcon,
-               label: label,
-               hintText: hintText,
-               helperText: helperText,
-               errorText: state.errorText,
                selectedTrailingIcon: selectedTrailingIcon,
                enableFilter: enableFilter,
                enableSearch: enableSearch,
@@ -96,7 +117,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
                textStyle: textStyle,
                textAlign: textAlign,
                inputDecorationTheme: inputDecorationTheme,
-               decorationBuilder: decorationBuilder,
+               decorationBuilder: effectiveDecorationBuilder,
                menuStyle: menuStyle,
                controller: state.textFieldController,
                initialSelection: state.value,

--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -79,26 +79,26 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
          builder: (FormFieldState<T> field) {
            final state = field as _DropdownMenuFormFieldState<T>;
 
-           // Delegate label, hintText and helperText definition to a decoration builder.
-           InputDecoration defaultDecorationBuilder(
+           InputDecoration effectiveDecorationBuilder(
              BuildContext context,
              MenuController menuController,
            ) {
              final InputDecoration decoration =
                  decorationBuilder?.call(context, menuController) ?? const InputDecoration();
-             return decoration.copyWith(label: label, hintText: hintText, helperText: helperText);
-           }
+             final InputDecoration decorationWithLabels = decoration.copyWith(
+               label: label,
+               hintText: hintText,
+               helperText: helperText,
+             );
 
-           DropdownMenuDecorationBuilder effectiveDecorationBuilder = defaultDecorationBuilder;
+             final String? errorText = state.errorText;
+             if (errorText == null) {
+               return decorationWithLabels;
+             }
 
-           final String? errorText = state.errorText;
-           if (errorText != null) {
-             effectiveDecorationBuilder = (BuildContext context, MenuController menuController) {
-               final InputDecoration decoration = defaultDecorationBuilder(context, menuController);
-               return errorBuilder != null
-                   ? decoration.copyWith(error: errorBuilder(state.context, errorText))
-                   : decoration.copyWith(errorText: errorText);
-             };
+             return errorBuilder != null
+                 ? decorationWithLabels.copyWith(error: errorBuilder(state.context, errorText))
+                 : decorationWithLabels.copyWith(errorText: errorText);
            }
 
            return UnmanagedRestorationScope(

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -1164,7 +1164,6 @@ void main() {
           body: DropdownMenuFormField<MenuItem>(
             key: fieldKey,
             dropdownMenuEntries: menuEntries,
-            autovalidateMode: AutovalidateMode.always,
             validator: (MenuItem? item) => validationError,
             errorBuilder: (context, errorText) {
               errorBuilderCalled = true;
@@ -1174,6 +1173,9 @@ void main() {
         ),
       ),
     );
+
+    expect(errorBuilderCalled, false);
+    expect(find.byKey(errorKey), findsNothing);
 
     fieldKey.currentState!.validate();
     await tester.pump();

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -198,7 +198,7 @@ void main() {
     expect(dropdownMenu.trailingIcon, trailingIcon);
   });
 
-  testWidgets('Passes label to underlying DropdownMenu', (WidgetTester tester) async {
+  testWidgets('Passes label to underlying InputDecoration', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries)),
@@ -206,8 +206,8 @@ void main() {
     );
 
     // Check default value.
-    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.label, null);
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.label, null);
 
     const Widget label = Text('Label');
     await tester.pumpWidget(
@@ -218,11 +218,11 @@ void main() {
       ),
     );
 
-    dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.label, label);
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.label, label);
   });
 
-  testWidgets('Passes hintText to underlying DropdownMenu', (WidgetTester tester) async {
+  testWidgets('Passes hintText to underlying InputDecoration', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries)),
@@ -230,8 +230,8 @@ void main() {
     );
 
     // Check default value.
-    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.hintText, null);
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.hintText, null);
 
     const hintText = 'Hint';
     await tester.pumpWidget(
@@ -245,11 +245,11 @@ void main() {
       ),
     );
 
-    dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.hintText, hintText);
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.hintText, hintText);
   });
 
-  testWidgets('Passes helperText to underlying DropdownMenu', (WidgetTester tester) async {
+  testWidgets('Passes helperText to underlying InputDecoration', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries)),
@@ -257,8 +257,8 @@ void main() {
     );
 
     // Check default value.
-    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.helperText, null);
+    TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.helperText, null);
 
     const helperText = 'Hint';
     await tester.pumpWidget(
@@ -272,8 +272,8 @@ void main() {
       ),
     );
 
-    dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.helperText, helperText);
+    textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.helperText, helperText);
   });
 
   testWidgets('Passes selectedTrailingIcon to underlying DropdownMenu', (
@@ -469,18 +469,18 @@ void main() {
     expect(dropdownMenu.inputDecorationTheme, inputDecorationTheme);
   });
 
-  testWidgets('Passes decorationBuilder to underlying DropdownMenu', (WidgetTester tester) async {
+  testWidgets('Calls the decoration builder to create the InputDecoration', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(body: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries)),
       ),
     );
 
-    // Check default value.
-    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.decorationBuilder, null);
-
+    var decorationBuilderCalled = false;
     InputDecoration buildDecoration(BuildContext context, MenuController controller) {
+      decorationBuilderCalled = true;
       return const InputDecoration(labelText: 'labelText');
     }
 
@@ -495,8 +495,12 @@ void main() {
       ),
     );
 
-    dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.decorationBuilder, buildDecoration);
+    // The decoration builder should have been called.
+    expect(decorationBuilderCalled, true);
+
+    // The decoration label is the one provided by the decoration builder.
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.labelText, 'labelText');
   });
 
   testWidgets('Passes menuStyle to underlying DropdownMenu', (WidgetTester tester) async {
@@ -1139,10 +1143,46 @@ void main() {
     fieldKey.currentState!.validate();
     await tester.pump();
 
-    expect(find.text('Required'), findsOneWidget);
+    expect(find.text(validationError), findsOneWidget);
 
-    final DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.errorText, validationError);
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.errorText, validationError);
+  });
+
+  testWidgets('Validation result is shown as error widget created by errorBuilder', (
+    WidgetTester tester,
+  ) async {
+    final fieldKey = GlobalKey<FormFieldState<MenuItem>>();
+
+    const validationError = 'Required';
+    final errorKey = UniqueKey();
+    var errorBuilderCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            key: fieldKey,
+            dropdownMenuEntries: menuEntries,
+            autovalidateMode: AutovalidateMode.always,
+            validator: (MenuItem? item) => validationError,
+            errorBuilder: (context, errorText) {
+              errorBuilderCalled = true;
+              return Text(errorText, key: errorKey);
+            },
+          ),
+        ),
+      ),
+    );
+
+    fieldKey.currentState!.validate();
+    await tester.pump();
+
+    expect(errorBuilderCalled, true);
+    expect(find.byKey(errorKey), findsOneWidget);
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    expect(textField.decoration?.error?.key, errorKey);
   });
 
   testWidgets('Initial selection is applied', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR adds the `DropdownMenuFormField.errorBuilder` property which makes it possible to customize the widget used to display the error message.

This is a follow-up to https://github.com/flutter/flutter/pull/162255 which added the `errorBuilder` property to other form fields.

## Related Issue

Fixes [DropdownMenuFormField is missing an errorBuilder property](https://github.com/flutter/flutter/issues/172416)

## Tests

Updates 5 tests.
Adds 1 test.