### PR TITLE
Add project-specific analysis and suggestions to flutter doctor

### DIFF
--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -4,7 +4,11 @@
 
 import '../android/android_workflow.dart';
 import '../base/common.dart';
+import '../base/file_system.dart';
+import '../doctor_project_validators.dart';
+import '../doctor_validator.dart';
 import '../globals.dart' as globals;
+import '../project.dart';
 import '../runner/flutter_command.dart';
 
 class DoctorCommand extends FlutterCommand {
@@ -21,6 +25,17 @@ class DoctorCommand extends FlutterCommand {
           'Used to determine if Flutter engine artifacts for all platforms '
           'are available for download.',
       valueHelp: 'engine revision git hash',
+    );
+    argParser.addOption(
+      'project-path',
+      abbr: 'p',
+      help: 'The path to the current Flutter project.',
+      valueHelp: 'path',
+    );
+    argParser.addFlag(
+      'disable-project-validators',
+      negatable: false,
+      help: 'Disable project-specific validators.',
     );
   }
 
@@ -55,13 +70,67 @@ class DoctorCommand extends FlutterCommand {
         );
       }
     }
-    final bool success =
-        await globals.doctor?.diagnose(
-          androidLicenses: boolArg('android-licenses'),
-          verbose: verbose,
-          androidLicenseValidator: androidLicenseValidator,
-        ) ??
-        false;
+
+    var success = false; // Initialize success here
+
+    final String? projectPath = stringArg('project-path');
+    final Directory projectDir = projectPath != null
+        ? globals.fs.directory(projectPath)
+        : globals.fs.currentDirectory;
+    final FlutterProject project = FlutterProject.fromDirectory(projectDir);
+    final bool isProject = project.manifest.appName.isNotEmpty;
+    final bool disableProjectValidators = boolArg('disable-project-validators');
+
+    if (isProject && !disableProjectValidators) {
+      final projectAnalysisValidator = ProjectAnalysisValidator(
+        project: project,
+        fileSystem: globals.fs,
+        platform: globals.platform,
+        processManager: globals.processManager,
+        terminal: globals.terminal,
+        artifacts: globals.artifacts!,
+      );
+      // final projectSuggestionsValidator = ProjectSuggestionsValidator(
+      //   project: project,
+      //   fileSystem: globals.fs,
+      //   allProjectValidators: <ProjectValidator>[
+      //     // Add default validators here or get them from somewhere
+      //     // For now, let's assume we want GeneralInfoProjectValidator
+      //     GeneralInfoProjectValidator(),
+      //   ],
+      //   processManager: globals.processManager,
+      //   terminal: globals.terminal,
+      // );
+      final projectValidatorTasks = <ValidatorTask>[
+        ValidatorTask(projectAnalysisValidator, projectAnalysisValidator.validate()),
+        // TODO(jwren): ProjectSuggestionsValidator takes too long, should we include with a flag, include it anyways...?
+        // ValidatorTask(projectSuggestionsValidator, projectSuggestionsValidator.validate()),
+      ];
+      final List<ValidatorTask> defaultTasks = globals.doctor!.startValidatorTasks();
+      final combinedTasks = <ValidatorTask>[...defaultTasks, ...projectValidatorTasks];
+      success =
+          await globals.doctor?.diagnose(
+            androidLicenses: boolArg('android-licenses'),
+            verbose: verbose,
+            androidLicenseValidator: androidLicenseValidator,
+            startedValidatorTasks: combinedTasks,
+          ) ??
+          false;
+    } else {
+      success =
+          await globals.doctor?.diagnose(
+            androidLicenses: boolArg('android-licenses'),
+            verbose: verbose,
+            androidLicenseValidator: androidLicenseValidator,
+          ) ??
+          false;
+      if (projectPath == null) {
+        globals.logger.printStatus(
+          'To see project-specific issues, run doctor in some project or specify with "flutter doctor --project-path <path>"',
+        );
+      }
+    }
+
     return FlutterCommandResult(success ? ExitStatus.success : ExitStatus.warning);
   }
 }

--- a/packages/flutter_tools/lib/src/doctor_project_validators.dart
+++ b/packages/flutter_tools/lib/src/doctor_project_validators.dart
@@ -1,0 +1,199 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:args/args.dart';
+
+import 'package:process/process.dart';
+
+import 'artifacts.dart';
+import 'base/common.dart';
+import 'base/file_system.dart';
+import 'base/logger.dart';
+import 'base/platform.dart';
+import 'base/terminal.dart';
+import 'commands/analyze_once.dart';
+import 'commands/validate_project.dart';
+import 'doctor_validator.dart';
+import 'project.dart';
+import 'project_validator.dart';
+import 'runner/flutter_command.dart';
+
+/// A validator that runs project analysis using `dart analyze`.
+class ProjectAnalysisValidator extends DoctorValidator {
+  ProjectAnalysisValidator({
+    required FlutterProject project,
+    required FileSystem fileSystem,
+    required Platform platform,
+    required ProcessManager processManager,
+    required Terminal terminal,
+    required Artifacts artifacts,
+  }) : _project = project,
+       _fileSystem = fileSystem,
+       _platform = platform,
+       _processManager = processManager,
+       _terminal = terminal,
+       _artifacts = artifacts,
+       super('Project Analysis');
+
+  final FlutterProject _project;
+  final FileSystem _fileSystem;
+  final Platform _platform;
+  final ProcessManager _processManager;
+  final Terminal _terminal;
+  final Artifacts _artifacts;
+
+  @override
+  Future<ValidationResult> validateImpl() async {
+    final argParser = ArgParser();
+    argParser.addFlag('congratulate', defaultsTo: true);
+    argParser.addFlag('preamble', defaultsTo: true);
+    argParser.addFlag('fatal-infos', defaultsTo: true);
+    argParser.addFlag('fatal-warnings', defaultsTo: true);
+    argParser.addOption('write');
+    argParser.addFlag('pub', defaultsTo: true);
+    argParser.addFlag('current-package', defaultsTo: true);
+    argParser.addFlag('flutter-repo');
+    argParser.addOption('dart-sdk');
+    argParser.addFlag('developer');
+    argParser.addFlag('machine');
+    argParser.addFlag('benchmark');
+    argParser.addOption('protocol-traffic-log');
+
+    final ArgResults argResults = argParser.parse(<String>[]);
+
+    final bufferLogger = BufferLogger.test(
+      terminal: _terminal,
+      outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 80),
+    );
+
+    final analyzeOnce = AnalyzeOnce(
+      argResults,
+      <Directory>[], // repoPackages
+      workingDirectory: _project.directory,
+      fileSystem: _fileSystem,
+      logger: bufferLogger,
+      platform: _platform,
+      processManager: _processManager,
+      terminal: _terminal,
+      artifacts: _artifacts,
+      suppressAnalytics: true,
+    );
+
+    try {
+      await analyzeOnce.analyze();
+      final messages = <ValidationMessage>[];
+      if (bufferLogger.statusText.isNotEmpty) {
+        messages.add(ValidationMessage(bufferLogger.statusText));
+      }
+      await _runPubOutdated(messages);
+      return ValidationResult(ValidationType.success, messages, statusInfo: 'No issues found');
+    } on ToolExit catch (e) {
+      final messages = <ValidationMessage>[];
+      if (e.message != null) {
+        messages.add(ValidationMessage.error('${e.message!} Run `flutter analyze` for details.'));
+      }
+      // Also include any output from the buffer logger
+      if (bufferLogger.statusText.isNotEmpty) {
+        messages.add(ValidationMessage(bufferLogger.statusText));
+      }
+      await _runPubOutdated(messages);
+      return ValidationResult(ValidationType.partial, messages, statusInfo: 'Issues found');
+    } on Exception catch (e) {
+      return ValidationResult(ValidationType.partial, <ValidationMessage>[
+        ValidationMessage.error(e.toString()),
+      ], statusInfo: 'Issues found');
+    }
+  }
+
+  Future<void> _runPubOutdated(List<ValidationMessage> messages) async {
+    try {
+      final String dartSdkPath = _artifacts.getArtifactPath(Artifact.engineDartSdkPath);
+      final String dartBinary = _fileSystem.path.join(
+        dartSdkPath,
+        'bin',
+        _platform.isWindows ? 'dart.exe' : 'dart',
+      );
+      final io.ProcessResult pubOutdatedResult = await _processManager.run(<String>[
+        dartBinary,
+        'pub',
+        'outdated',
+        '--json',
+      ], workingDirectory: _project.directory.path);
+
+      if (pubOutdatedResult.exitCode == 0) {
+        final output = pubOutdatedResult.stdout as String;
+        final jsonOutput = json.decode(output) as Map<String, dynamic>;
+        final List<dynamic> packages = (jsonOutput['packages'] as List<dynamic>)
+            .where((dynamic p) => p is Map<String, dynamic> && p['current'] != null)
+            .toList();
+        final int outdatedCount = packages.length;
+        if (outdatedCount > 0) {
+          messages.add(
+            ValidationMessage.error(
+              '$outdatedCount outdated package${outdatedCount == 1 ? '' : 's'} found. Run `flutter pub outdated` for details.',
+            ),
+          );
+        }
+      }
+    } on Exception {
+      // ignore
+    }
+  }
+}
+
+/// A validator that runs project suggestions using `flutter analyze --suggestions`.
+class ProjectSuggestionsValidator extends DoctorValidator {
+  ProjectSuggestionsValidator({
+    required FlutterProject project,
+    required FileSystem fileSystem,
+    required List<ProjectValidator> allProjectValidators,
+    required ProcessManager processManager,
+    required Terminal terminal,
+  }) : _project = project,
+       _fileSystem = fileSystem,
+       _allProjectValidators = allProjectValidators,
+       _processManager = processManager,
+       _terminal = terminal,
+       super('Project Validation');
+
+  final FlutterProject _project;
+  final FileSystem _fileSystem;
+  final List<ProjectValidator> _allProjectValidators;
+  final ProcessManager _processManager;
+  final Terminal _terminal;
+
+  @override
+  Future<ValidationResult> validateImpl() async {
+    final bufferLogger = BufferLogger.test(
+      terminal: _terminal,
+      outputPreferences: OutputPreferences.test(wrapText: true, wrapColumn: 80),
+    );
+
+    final validator = ValidateProject(
+      fileSystem: _fileSystem,
+      logger: bufferLogger,
+      allProjectValidators: _allProjectValidators,
+      userPath: _project.directory.path,
+      processManager: _processManager,
+    );
+
+    final FlutterCommandResult result = await validator.run();
+    if (result.exitStatus == ExitStatus.success) {
+      return ValidationResult(
+        ValidationType.success,
+        <ValidationMessage>[],
+        statusInfo: 'No issues found',
+      );
+    } else {
+      return ValidationResult(
+        ValidationType.partial,
+        <ValidationMessage>[],
+        statusInfo: 'Issues found',
+      );
+    }
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_project_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_project_test.dart
@@ -163,20 +163,7 @@ void main() {
         );
 
         // Mock analysis server success
-        fakeProcessManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
-            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
-          ),
-        );
+        fakeProcessManager.addCommand(_createAnalysisServerCommand());
 
         final ValidationResult result = await validator.validate();
         expect(result.type, ValidationType.success);
@@ -202,20 +189,7 @@ void main() {
         );
 
         // Mock analysis server success
-        fakeProcessManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
-            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
-          ),
-        );
+        fakeProcessManager.addCommand(_createAnalysisServerCommand());
         // Mock dart pub outdated with JSON output
         fakeProcessManager.addCommand(
           const FakeCommand(
@@ -253,20 +227,7 @@ void main() {
         );
 
         // Mock analysis server success
-        fakeProcessManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
-            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
-          ),
-        );
+        fakeProcessManager.addCommand(_createAnalysisServerCommand());
         // Mock dart pub outdated with up to date message (empty packages list in JSON)
         fakeProcessManager.addCommand(
           const FakeCommand(
@@ -300,20 +261,7 @@ void main() {
         );
 
         // Mock analysis server success
-        fakeProcessManager.addCommand(
-          const FakeCommand(
-            command: <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
-            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
-          ),
-        );
+        fakeProcessManager.addCommand(_createAnalysisServerCommand());
         // Mock dart pub outdated failure
         fakeProcessManager.addCommand(
           const FakeCommand(
@@ -349,16 +297,7 @@ void main() {
 
         // Mock analysis server with errors
         fakeProcessManager.addCommand(
-          FakeCommand(
-            command: const <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
+          _createAnalysisServerCommand(
             stdout: <String>[
               '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
               '{"id":"1","result":{}}', // Response to setAnalysisRoots
@@ -413,16 +352,7 @@ void main() {
 
         // Mock analysis server with warnings
         fakeProcessManager.addCommand(
-          FakeCommand(
-            command: const <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
+          _createAnalysisServerCommand(
             stdout: <String>[
               '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
               '{"id":"1","result":{}}', // Response to setAnalysisRoots
@@ -477,16 +407,7 @@ void main() {
 
         // Mock analysis server with lints (INFO)
         fakeProcessManager.addCommand(
-          FakeCommand(
-            command: const <String>[
-              'Artifact.engineDartSdkPath/bin/dart',
-              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
-              '--disable-server-feature-completion',
-              '--disable-server-feature-search',
-              '--sdk',
-              'Artifact.engineDartSdkPath',
-              '--suppress-analytics',
-            ],
+          _createAnalysisServerCommand(
             stdout: <String>[
               '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
               '{"id":"1","result":{}}', // Response to setAnalysisRoots
@@ -572,6 +493,23 @@ class FakeDoctorValidatorsProvider implements DoctorValidatorsProvider {
 
   @override
   List<Workflow> get workflows => <Workflow>[];
+}
+
+FakeCommand _createAnalysisServerCommand({
+  String stdout = '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+}) {
+  return FakeCommand(
+    command: const <String>[
+      'Artifact.engineDartSdkPath/bin/dart',
+      'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+      '--disable-server-feature-completion',
+      '--disable-server-feature-search',
+      '--sdk',
+      'Artifact.engineDartSdkPath',
+      '--suppress-analytics',
+    ],
+    stdout: stdout,
+  );
 }
 
 class FakeValidator extends DoctorValidator {

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_project_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_project_test.dart
@@ -1,0 +1,584 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/doctor.dart';
+
+import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/doctor_project_validators.dart';
+import 'package:flutter_tools/src/doctor_validator.dart';
+import 'package:flutter_tools/src/project.dart';
+
+import '../../src/context.dart';
+import '../../src/test_flutter_command_runner.dart';
+
+void main() {
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+  late BufferLogger logger;
+  late FakeProcessManager fakeProcessManager;
+  late MemoryFileSystem fs;
+
+  setUp(() {
+    logger = BufferLogger.test();
+    fakeProcessManager = FakeProcessManager.empty();
+    fs = MemoryFileSystem.test();
+    fs.directory('/flutter/bin/cache').createSync(recursive: true);
+    fs.currentDirectory = '/';
+    Cache.flutterRoot = '/flutter';
+  });
+
+  testUsingContext(
+    'flutter doctor --project-path runs analysis on valid project',
+    () async {
+      final Directory projectDir = fs.directory('my_project')..createSync();
+      projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+      projectDir.childFile('.packages').createSync();
+      projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+      final command = DoctorCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['mdfind', 'kMDItemCFBundleIdentifier="com.google.android.studio*"'],
+        ),
+      );
+
+      await runner.run(<String>['doctor', '--project-path', 'my_project']);
+
+      expect(logger.statusText, contains('Project Analysis'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => fakeProcessManager,
+      DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
+      Logger: () => logger,
+      Cache: () => Cache.test(
+        rootOverride: fs.directory('/flutter'),
+        fileSystem: fs,
+        processManager: fakeProcessManager,
+      ),
+    },
+  );
+
+  testUsingContext(
+    'flutter doctor implicitly runs analysis in project directory',
+    () async {
+      final Directory projectDir = fs.directory('my_project')..createSync();
+      projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+      projectDir.childFile('.packages').createSync();
+      projectDir.childFile('lib/main.dart').createSync(recursive: true);
+      fs.currentDirectory = projectDir;
+
+      final command = DoctorCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['mdfind', 'kMDItemCFBundleIdentifier="com.google.android.studio*"'],
+        ),
+      );
+
+      await runner.run(<String>['doctor']);
+
+      expect(logger.statusText, contains('Project Analysis'));
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => fakeProcessManager,
+      DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
+      Logger: () => logger,
+      Cache: () => Cache.test(
+        rootOverride: fs.directory('/flutter'),
+        fileSystem: fs,
+        processManager: fakeProcessManager,
+      ),
+    },
+  );
+
+  testUsingContext(
+    'flutter doctor shows suggestion when not in project directory',
+    () async {
+      final Directory nonProjectDir = fs.directory('non_project')..createSync();
+      fs.currentDirectory = nonProjectDir;
+
+      final command = DoctorCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['mdfind', 'kMDItemCFBundleIdentifier="com.google.android.studio*"'],
+        ),
+      );
+
+      await runner.run(<String>['doctor']);
+
+      expect(logger.statusText, isNot(contains('Project Analysis')));
+      expect(
+        logger.statusText,
+        contains(
+          'To see project-specific issues, run doctor in some project or specify with "flutter doctor --project-path <path>"',
+        ),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => fakeProcessManager,
+      DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
+      Logger: () => logger,
+      Cache: () => Cache.test(
+        rootOverride: fs.directory('/flutter'),
+        fileSystem: fs,
+        processManager: fakeProcessManager,
+      ),
+    },
+  );
+
+  group('ProjectAnalysisValidator', () {
+    testUsingContext(
+      'reports success when no issues found',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server success
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.success);
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'reports pub outdated results',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server success
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+          ),
+        );
+        // Mock dart pub outdated with JSON output
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>['Artifact.engineDartSdkPath/bin/dart', 'pub', 'outdated', '--json'],
+            stdout:
+                '{"packages": [{"current": {"version": "1.0.0"}}, {"current": {"version": "1.0.0"}}]}',
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.success);
+        expect(
+          result.messages.map((m) => m.message),
+          contains('2 outdated packages found. Run `flutter pub outdated` for details.'),
+        );
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'does not report pub outdated results when up to date',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server success
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+          ),
+        );
+        // Mock dart pub outdated with up to date message (empty packages list in JSON)
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>['Artifact.engineDartSdkPath/bin/dart', 'pub', 'outdated', '--json'],
+            stdout: '{"packages": []}',
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.success);
+        expect(result.messages.map((m) => m.message), isNot(contains('outdated package')));
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'does not report pub outdated results when command fails',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server success
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+          ),
+        );
+        // Mock dart pub outdated failure
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>['Artifact.engineDartSdkPath/bin/dart', 'pub', 'outdated', '--json'],
+            exitCode: 1,
+            stdout: 'error',
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.success);
+        expect(result.messages.map((m) => m.message), isNot(contains('error')));
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'reports partial success when issues found',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server with errors
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: const <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: <String>[
+              '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
+              '{"id":"1","result":{}}', // Response to setAnalysisRoots
+              '{"event":"analysis.errors","params":{"file":"/my_project/lib/main.dart","errors":[{"severity":"ERROR","type":"SYNTAX_ERROR","location":{"file":"/my_project/lib/main.dart","offset":0,"length":1,"startLine":1,"startColumn":1},"message":"Syntax error","code":"syntax_error","hasFix":false}]}}',
+              '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+            ].join('\n'),
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.partial);
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Syntax error'),
+            ),
+          ),
+        );
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Run `flutter analyze` for details.'),
+            ),
+          ),
+        );
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'reports partial success when warnings found',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server with warnings
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: const <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: <String>[
+              '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
+              '{"id":"1","result":{}}', // Response to setAnalysisRoots
+              '{"event":"analysis.errors","params":{"file":"/my_project/lib/main.dart","errors":[{"severity":"WARNING","type":"UNUSED_IMPORT","location":{"file":"/my_project/lib/main.dart","offset":0,"length":1,"startLine":1,"startColumn":1},"message":"Unused import","code":"unused_import","hasFix":true}]}}',
+              '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+            ].join('\n'),
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.partial);
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Unused import'),
+            ),
+          ),
+        );
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Run `flutter analyze` for details.'),
+            ),
+          ),
+        );
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+
+    testUsingContext(
+      'reports partial success when lints found',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final validator = ProjectAnalysisValidator(
+          project: FlutterProject.fromDirectory(projectDir),
+          fileSystem: fs,
+          platform: FakePlatform(),
+          processManager: fakeProcessManager,
+          terminal: Terminal.test(),
+          artifacts: Artifacts.test(),
+        );
+
+        // Mock analysis server with lints (INFO)
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: const <String>[
+              'Artifact.engineDartSdkPath/bin/dart',
+              'Artifact.engineDartSdkPath/bin/snapshots/analysis_server.dart.snapshot',
+              '--disable-server-feature-completion',
+              '--disable-server-feature-search',
+              '--sdk',
+              'Artifact.engineDartSdkPath',
+              '--suppress-analytics',
+            ],
+            stdout: <String>[
+              '{"event":"server.connected","params":{"version":"1.0.0","pid":123}}',
+              '{"id":"1","result":{}}', // Response to setAnalysisRoots
+              '{"event":"analysis.errors","params":{"file":"/my_project/lib/main.dart","errors":[{"severity":"INFO","type":"LINT","location":{"file":"/my_project/lib/main.dart","offset":0,"length":1,"startLine":1,"startColumn":1},"message":"Lint rule violated","code":"lint_rule","hasFix":true}]}}',
+              '{"event":"server.status","params":{"analysis":{"isAnalyzing":false}}}',
+            ].join('\n'),
+          ),
+        );
+
+        final ValidationResult result = await validator.validate();
+        expect(result.type, ValidationType.partial);
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Lint rule violated'),
+            ),
+          ),
+        );
+        expect(
+          result.messages,
+          contains(
+            isA<ValidationMessage>().having(
+              (ValidationMessage m) => m.message,
+              'message',
+              contains('Run `flutter analyze` for details.'),
+            ),
+          ),
+        );
+      },
+      overrides: <Type, Generator>{FileSystem: () => fs, ProcessManager: () => fakeProcessManager},
+    );
+  });
+
+  group('ValidateProject', () {
+    testUsingContext(
+      'flutter doctor --project-path --disable-project-validators skips project analysis',
+      () async {
+        final Directory projectDir = fs.directory('my_project')..createSync();
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: my_project\n');
+        projectDir.childFile('.packages').createSync();
+        projectDir.childFile('lib/main.dart').createSync(recursive: true);
+
+        final command = DoctorCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+
+        fakeProcessManager.addCommand(
+          const FakeCommand(
+            command: <String>['mdfind', 'kMDItemCFBundleIdentifier="com.google.android.studio*"'],
+          ),
+        );
+
+        await runner.run(<String>[
+          'doctor',
+          '--project-path',
+          'my_project',
+          '--disable-project-validators',
+        ]);
+
+        expect(logger.statusText, isNot(contains('Project Analysis')));
+        expect(logger.statusText, isNot(contains('Project Validation')));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => fakeProcessManager,
+        DoctorValidatorsProvider: () => FakeDoctorValidatorsProvider(),
+        Logger: () => logger,
+        Cache: () => Cache.test(
+          rootOverride: fs.directory('/flutter'),
+          fileSystem: fs,
+          processManager: fakeProcessManager,
+        ),
+      },
+    );
+  });
+}
+
+class FakeDoctorValidatorsProvider implements DoctorValidatorsProvider {
+  @override
+  List<DoctorValidator> get validators => <DoctorValidator>[FakeValidator('Fake Validator')];
+
+  @override
+  List<Workflow> get workflows => <Workflow>[];
+}
+
+class FakeValidator extends DoctorValidator {
+  FakeValidator(super.title);
+
+  @override
+  Future<ValidationResult> validateImpl() async {
+    return ValidationResult(ValidationType.success, <ValidationMessage>[]);
+  }
+}


### PR DESCRIPTION
- Adds `ProjectAnalysisValidator` to run `dart analyze` on the current project.
- Integrates `dart pub outdated` to check for outdated dependencies.
  - Uses `--json` output to parse and report the exact count of outdated packages.
  - Displays actionable errors when outdated packages are found.
- Adds comprehensive tests for success, errors, warnings, lints, and outdated package checks.