### PR TITLE
docs: Impeller usage requirements for ImageFilter.shader and isShader…

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4408,7 +4408,7 @@ abstract class ImageFilter {
   ///
   /// > [!WARNING]
   /// > This property indicates whether the Impeller rendering engine is enabled.
-  /// > If `false`, attempting to use [ImageFilter.shader] will throw an [UnsupportedError].
+  /// > Attempting to create an [ImageFilter.shader] when this property is `false` will throw an [UnsupportedError].
   static bool get isShaderFilterSupported => _impellerEnabled;
 
   // Converts this to a native DlImageFilter. See the comments of this method in

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4338,10 +4338,10 @@ abstract class ImageFilter {
   /// > This API is only supported when using the Impeller rendering engine.
   /// > On other backends, an [UnsupportedError] will be thrown.
   ///
-  /// To check at runtime whether this API is supported, use [isShaderFilterSupported].
+  /// > To check at runtime whether this API is supported, use [isShaderFilterSupported].
   ///
   /// Example usage:
-  /// 
+  ///
   /// ```dart
   /// if (ui.ImageFilter.isShaderFilterSupported) {
   ///   // Use the filter...

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4407,7 +4407,7 @@ abstract class ImageFilter {
   /// Whether [ImageFilter.shader] is supported on the current backend.
   ///
   /// > [!WARNING]
-  /// > This property indicates whether the Impeller rendering engine is enabled.
+  /// > This property will only return true when the Impeller rendering engine is enabled.
   /// > Attempting to create an [ImageFilter.shader] when this property is `false` will throw an [UnsupportedError].
   static bool get isShaderFilterSupported => _impellerEnabled;
 

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4341,9 +4341,9 @@ abstract class ImageFilter {
   /// To check at runtime whether this API is supported, use [isShaderFilterSupported].
   ///
   /// Example usage:
+  /// 
   /// ```dart
-  /// if (ImageFilter.isShaderFilterSupported) {
-  ///   final filter = ImageFilter.shader(myShader);
+  /// if (ui.ImageFilter.isShaderFilterSupported) {
   ///   // Use the filter...
   /// }
   /// ```

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4334,7 +4334,7 @@ abstract class ImageFilter {
 
   /// Creates an image filter from a [FragmentShader].
   ///
-  ////// > [!WARNING]
+  /// > [!WARNING]
   /// > This API is only supported when using the Impeller rendering engine.
   /// > On other backends, an [UnsupportedError] will be thrown.
   ///

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4334,6 +4334,20 @@ abstract class ImageFilter {
 
   /// Creates an image filter from a [FragmentShader].
   ///
+  ////// > [!WARNING]
+  /// > This API is only supported when using the Impeller rendering engine.
+  /// > On other backends, an [UnsupportedError] will be thrown.
+  ///
+  /// To check at runtime whether this API is supported, use [isShaderFilterSupported].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// if (ImageFilter.isShaderFilterSupported) {
+  ///   final filter = ImageFilter.shader(myShader);
+  ///   // Use the filter...
+  /// }
+  /// ```
+  ///
   /// The fragment shader provided here has additional requirements to be used
   /// by the engine for filtering. The first uniform value must be a vec2, this
   /// will be set by the engine to the size of the bound texture. There must
@@ -4369,10 +4383,6 @@ abstract class ImageFilter {
   /// }
   ///
   /// ```
-  ///
-  /// This API is only supported when using the Impeller rendering engine. On
-  /// other backends a [UnsupportedError] will be thrown. To check at runtime
-  /// whether this API is suppored use [isShaderFilterSupported].
   factory ImageFilter.shader(FragmentShader shader) {
     if (!_impellerEnabled) {
       throw UnsupportedError('ImageFilter.shader only supported with Impeller rendering engine.');
@@ -4395,6 +4405,10 @@ abstract class ImageFilter {
   }
 
   /// Whether [ImageFilter.shader] is supported on the current backend.
+  ///
+  /// > [!WARNING]
+  /// > This property indicates whether the Impeller rendering engine is enabled.
+  /// > If `false`, attempting to use [ImageFilter.shader] will throw an [UnsupportedError].
   static bool get isShaderFilterSupported => _impellerEnabled;
 
   // Converts this to a native DlImageFilter. See the comments of this method in


### PR DESCRIPTION
Summary

This PR improves the API documentation for ImageFilter.shader and isShaderFilterSupported by making the Impeller requirement more explicit and visible.

What was changed

Added an “Important” notice to clearly state that these APIs are only supported with Impeller.
Updated the doc comments to front-load this detail instead of placing it later in the text.
Added cross-reference notes explaining how isShaderFilterSupported relates to Impeller.
Why this change is helpful

Developers frequently run into confusion when using shader-based filters without realizing they require Impeller. This change makes the requirement obvious and easier to discover.

Issue reference

Fixes #178767