### PR TITLE
【WIP】Add arrow key repeat movement

### DIFF
--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -1046,6 +1046,47 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(offset: 19));
           }, variant: TargetPlatformVariant.all());
 
+          testWidgets('arrow key repeat movement', (WidgetTester tester) async {
+            controller.text = testText;
+            controller.selection = const TextSelection.collapsed(offset: 20);
+            await tester.pumpWidget(buildEditableText());
+
+            // Press arrow key down
+            await tester.sendKeyDownEvent(trigger);
+            await tester.pump();
+
+            // Initial movement should happen immediately
+            expect(controller.selection, const TextSelection.collapsed(offset: 19));
+
+            // Wait for initial delay (500ms) and then some repeat intervals (50ms each)
+            // Timeline:
+            // - 0ms: initial movement (19)
+            // - 500ms: periodic timer starts
+            // - 550ms: first repeat (18)
+            // - 600ms: second repeat (17)
+            // - 650ms: third repeat (16)
+            await tester.pump(const Duration(milliseconds: 600));
+            // After 600ms, should have moved at least 2 times: 19 -> 18 -> 17
+            expect(controller.selection.baseOffset, lessThanOrEqualTo(17));
+            final int positionAfter600ms = controller.selection.baseOffset;
+
+            // Continue holding and wait for more repeats
+            await tester.pump(const Duration(milliseconds: 100));
+            // Should have moved further (at least 1 more repeat)
+            expect(controller.selection.baseOffset, lessThan(positionAfter600ms));
+
+            // Release the key
+            await tester.sendKeyUpEvent(trigger);
+            await tester.pump();
+
+            final int positionAfterRelease = controller.selection.baseOffset;
+
+            // Wait a bit to ensure timer stops
+            await tester.pump(const Duration(milliseconds: 200));
+            // Cursor should not move after key release
+            expect(controller.selection.baseOffset, positionAfterRelease);
+          }, variant: TargetPlatformVariant.all());
+
           testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
             controller.selection = const TextSelection.collapsed(
@@ -1097,6 +1138,47 @@ void main() {
             await tester.pump();
 
             expect(controller.selection, const TextSelection.collapsed(offset: 21));
+          }, variant: TargetPlatformVariant.all());
+
+          testWidgets('arrow key repeat movement', (WidgetTester tester) async {
+            controller.text = testText;
+            controller.selection = const TextSelection.collapsed(offset: 20);
+            await tester.pumpWidget(buildEditableText());
+
+            // Press arrow key down
+            await tester.sendKeyDownEvent(trigger);
+            await tester.pump();
+
+            // Initial movement should happen immediately
+            expect(controller.selection, const TextSelection.collapsed(offset: 21));
+
+            // Wait for initial delay (500ms) and then some repeat intervals (50ms each)
+            // Timeline:
+            // - 0ms: initial movement (21)
+            // - 500ms: periodic timer starts
+            // - 550ms: first repeat (22)
+            // - 600ms: second repeat (23)
+            // - 650ms: third repeat (24)
+            await tester.pump(const Duration(milliseconds: 600));
+            // After 600ms, should have moved at least 2 times: 21 -> 22 -> 23
+            expect(controller.selection.baseOffset, greaterThanOrEqualTo(23));
+            final int positionAfter600ms = controller.selection.baseOffset;
+
+            // Continue holding and wait for more repeats
+            await tester.pump(const Duration(milliseconds: 100));
+            // Should have moved further (at least 1 more repeat)
+            expect(controller.selection.baseOffset, greaterThan(positionAfter600ms));
+
+            // Release the key
+            await tester.sendKeyUpEvent(trigger);
+            await tester.pump();
+
+            final int positionAfterRelease = controller.selection.baseOffset;
+
+            // Wait a bit to ensure timer stops
+            await tester.pump(const Duration(milliseconds: 200));
+            // Cursor should not move after key release
+            expect(controller.selection.baseOffset, positionAfterRelease);
           }, variant: TargetPlatformVariant.all());
 
           testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Description

Adds continuous cursor movement when arrow keys are held down, matching the behavior of the delete key.

Previously, arrow keys would only move the cursor once per key press, even when held down. This change implements a timer-based repeat mechanism that continuously moves the cursor after an initial delay.


https://github.com/user-attachments/assets/1606cf6f-aa1b-49f1-a39c-287a3aae8620



## Problem

On some platforms (particularly Linux), `KeyRepeatEvent` for arrow keys are not reliably sent to the Flutter framework, causing arrow keys to only move the cursor once per press even when held down. This is inconsistent with Android behavior, where arrow keys work correctly with continuous movement.

## Solution

Implemented a timer-based repeat mechanism in `EditableTextState` that:
- Moves the cursor immediately on first key press
- Waits 500ms before starting repeat movement
- Repeats cursor movement every 50ms while the key is held
- Stops immediately when the key is released (detected via `HardwareKeyboard`)
- Properly cleans up timers on widget disposal

This approach is platform-independent and ensures consistent behavior across all platforms.

## Changes

### `packages/flutter/lib/src/widgets/editable_text.dart`
- Added timer-related state variables:
  - `_arrowKeyRepeatTimer`: Timer for periodic cursor movement
  - `_arrowKeyRepeatIntent`: Current intent being repeated
  - `_lastArrowKeyInvokeTime`: Timestamp of last invoke
- Added `_startArrowKeyRepeat()`: Starts/continues the repeat timer
- Added `_stopArrowKeyRepeat()`: Stops the repeat timer
- Added `_calculateNewSelection()`: Helper to calculate new selection for timer callbacks
- Modified `_UpdateTextSelectionAction.invoke()`: Calls `_startArrowKeyRepeat()` after cursor movement
- Modified `dispose()`: Cleans up the repeat timer

### `packages/flutter/test/widgets/editable_text_shortcuts_test.dart`
- Added test for left arrow key repeat movement
- Added test for right arrow key repeat movement
- Tests verify:
  - Initial movement happens immediately
  - Continuous movement after 500ms delay
  - Timer stops when key is released

## Testing

- ✅ Added tests for both left and right arrow key repeat behavior
- ✅ Tests verify continuous movement and proper timer cleanup
- ✅ All existing tests pass

## Related Issues

Fixes: #172741

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
