### PR TITLE
Move target_cpu into use_rbe block in Fuchsia build

### DIFF
--- a/engine/src/build/toolchain/fuchsia/BUILD.gn
+++ b/engine/src/build/toolchain/fuchsia/BUILD.gn
@@ -7,15 +7,15 @@ import("//build/toolchain/clang.gni")
 import("//build/toolchain/rbe.gni")
 import("//build/toolchain/toolchain.gni")
 
-if (target_cpu == "x64") {
-  target_triple = "x86_64-unknown-fuchsia"
-} else if (target_cpu == "arm64") {
-  target_triple = "aarch64-unknown-fuchsia"
-} else {
-  assert(false, "Unsupported target_cpu: $target_cpu")
-}
-
 if (use_rbe) {
+  if (target_cpu == "x64") {
+    target_triple = "x86_64-unknown-fuchsia"
+  } else if (target_cpu == "arm64") {
+    target_triple = "aarch64-unknown-fuchsia"
+  } else {
+    assert(false, "Unsupported target_cpu: $target_cpu")
+  }
+
   remote_wrapper =
       rebase_path("//flutter/build/rbe/remote_wrapper_linux.sh", root_build_dir)
   local_wrapper =


### PR DESCRIPTION
The `target_cpu` local is only used if `use_rbe` is true. Move its definition into the `use_rbe` block to avoid local build issues like

```
$ ninja -C engine/src/out/ci/fuchsia_debug_arm64
ERROR at //build/toolchain/fuchsia/BUILD.gn:13:19: Assignment had no effect.
  target_triple = "aarch64-unknown-fuchsia"
                  ^------------------------
You set the variable "target_triple" here and it was unused before it went
out of scope.
```