### PR TITLE
Unpin `package:dwds` dependency

### DIFF
--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -87,7 +87,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       flutterRunProcess.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
         String line,
       ) {
-        if (line.startsWith('This app is linked to the debug service')) {
+        if (line.startsWith('Debug service listening on')) {
           ddcAppReady.complete();
         }
         print('[CHROME STDOUT]: $line');

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -87,7 +87,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       flutterRunProcess.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
         String line,
       ) {
-        if (line.startsWith('Debug service listening on')) {
+        if (!ddcAppReady.isCompleted && line.startsWith('Debug service listening on')) {
           ddcAppReady.complete();
         }
         print('[CHROME STDOUT]: $line');

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -23,8 +23,6 @@ const kManuallyPinnedDependencies = <String, String>{
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'dds':
       '5.0.3', // 5.0.4 contains bugs described in https://github.com/Dart-Code/Dart-Code/issues/4678.
-  'dwds':
-      '26.1.0', // 26.2.2 contains bugs that cause failures, see https://github.com/flutter/flutter/issues/178326
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
-  dwds: 26.1.0
+  dwds: 26.2.2
   code_builder: 4.11.0
   collection: 1.19.1
   completion: 1.0.2
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: olublc
+# PUBSPEC CHECKSUM: llegm7


### PR DESCRIPTION
Refactoring of code in `package:dwds` `26.2.1` changed execution ordering enough for a race condition in the web benchmark harness to be hit. This change updates the web benchmark harness to not rely on waiting for console output from the spawned browser which can be missed.

Fixes https://github.com/flutter/flutter/issues/178326