### PR TITLE
Check for a null cached image in SingleFrameCodec::getNextFrame

### DIFF
--- a/engine/src/flutter/lib/ui/fixtures/ui_test.dart
+++ b/engine/src/flutter/lib/ui/fixtures/ui_test.dart
@@ -111,6 +111,46 @@ Future<void> createSingleFrameCodec() async {
   _finish();
 }
 
+@pragma('vm:entry-point')
+Future<void> singleFrameCodecHandlesNoGpu() async {
+  final ImmutableBuffer buffer = await ImmutableBuffer.fromUint8List(
+    Uint8List.fromList(List<int>.filled(4, 100)),
+  );
+  final ImageDescriptor descriptor = ImageDescriptor.raw(
+    buffer,
+    width: 1,
+    height: 1,
+    pixelFormat: PixelFormat.rgba8888,
+  );
+  _turnOffGPU(true);
+  Timer flusher = Timer.periodic(Duration(milliseconds: 1), (timer) {
+    _flushGpuAwaitingTasks();
+  });
+  try {
+    final Codec codec = await descriptor.instantiateCodec();
+
+    // Call getNextFrame twice.  The first call will throw because the GPU has
+    // been disabled.  The second call will throw because SingleFrameCodec does
+    // not have a cached image.
+    for (int i = 0; i < 2; i++) {
+      bool didThrow = false;
+      try {
+        final FrameInfo info = await codec.getNextFrame();
+      } catch (e) {
+        didThrow = true;
+      }
+      assert(didThrow);
+    }
+
+    codec.dispose();
+    descriptor.dispose();
+    buffer.dispose();
+    _finish();
+  } finally {
+    flusher.cancel();
+  }
+}
+
 @pragma('vm:external-name', 'ValidateCodec')
 external void _validateCodec(Codec codec);
 

--- a/engine/src/flutter/lib/ui/painting/single_frame_codec.cc
+++ b/engine/src/flutter/lib/ui/painting/single_frame_codec.cc
@@ -35,6 +35,9 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   }
 
   if (status_ == Status::kComplete) {
+    if (!cached_image_) {
+      return tonic::ToDart("Image failed to decode");
+    }
     if (!cached_image_->image()) {
       return tonic::ToDart("Decoded image has been disposed");
     }

--- a/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
@@ -13,6 +13,9 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/testing.h"
 
+// CREATE_NATIVE_ENTRY is leaky by design
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+
 #pragma GCC diagnostic ignored "-Wunreachable-code"
 
 namespace flutter {
@@ -118,3 +121,5 @@ TEST_F(ShellTest, SingleFrameCodecHandlesNoGpu) {
 
 }  // namespace testing
 }  // namespace flutter
+
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)

--- a/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
@@ -56,6 +56,10 @@ TEST_F(ShellTest, SingleFrameCodecAccuratelyReportsSize) {
 }
 
 TEST_F(ShellTest, SingleFrameCodecHandlesNoGpu) {
+#ifndef FML_OS_MACOSX
+  GTEST_SKIP() << "Only works on macOS currently.";
+#endif
+
   Settings settings = CreateSettingsForFixture();
   settings.enable_impeller = true;
   TaskRunners task_runners("test",                  // label
@@ -78,7 +82,7 @@ TEST_F(ShellTest, SingleFrameCodecHandlesNoGpu) {
     bool value = true;
     ASSERT_TRUE(Dart_IsBoolean(handle));
     Dart_BooleanValue(handle, &value);
-    TurnOffGPU(shell.get(), true);
+    TurnOffGPU(shell.get(), value);
   };
   AddNativeCallback("TurnOffGPU", CREATE_NATIVE_ENTRY(turn_off_gpu));
 

--- a/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
@@ -55,5 +55,60 @@ TEST_F(ShellTest, SingleFrameCodecAccuratelyReportsSize) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+TEST_F(ShellTest, SingleFrameCodecHandlesNoGpu) {
+  Settings settings = CreateSettingsForFixture();
+  settings.enable_impeller = true;
+  TaskRunners task_runners("test",                  // label
+                           GetCurrentTaskRunner(),  // platform
+                           CreateNewThread(),       // raster
+                           CreateNewThread(),       // ui
+                           CreateNewThread()        // io
+  );
+  std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
+  ASSERT_TRUE(shell->IsSetup());
+
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+  auto finish = [message_latch](Dart_NativeArguments args) {
+    message_latch->Signal();
+  };
+  AddNativeCallback("Finish", CREATE_NATIVE_ENTRY(finish));
+
+  auto turn_off_gpu = [&](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    bool value = true;
+    ASSERT_TRUE(Dart_IsBoolean(handle));
+    Dart_BooleanValue(handle, &value);
+    TurnOffGPU(shell.get(), true);
+  };
+  AddNativeCallback("TurnOffGPU", CREATE_NATIVE_ENTRY(turn_off_gpu));
+
+  auto flush_awaiting_tasks = [&](Dart_NativeArguments args) {
+    fml::WeakPtr io_manager = shell->GetIOManager();
+    task_runners.GetIOTaskRunner()->PostTask([io_manager] {
+      if (io_manager) {
+        std::shared_ptr<impeller::Context> impeller_context =
+            io_manager->GetImpellerContext();
+        // This will cause the stored tasks to overflow and start throwing them
+        // away.
+        for (int i = 0; i < impeller::Context::kMaxTasksAwaitingGPU; i++) {
+          impeller_context->StoreTaskForGPU([] {}, [] {});
+        }
+      }
+    });
+  };
+  AddNativeCallback("FlushGpuAwaitingTasks",
+                    CREATE_NATIVE_ENTRY(flush_awaiting_tasks));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("singleFrameCodecHandlesNoGpu");
+
+  shell->RunEngine(std::move(configuration), [](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
+
+  message_latch->Wait();
+  DestroyShell(std::move(shell), task_runners);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/single_frame_codec_unittests.cc
@@ -13,6 +13,8 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/testing.h"
 
+#pragma GCC diagnostic ignored "-Wunreachable-code"
+
 namespace flutter {
 namespace testing {
 


### PR DESCRIPTION
This could happen if the image decoder invoked its callback with a null image to signal an error.  The SingleFrameCodec's status will be kComplete but its cached image will not be set.

Fixes https://github.com/flutter/flutter/issues/161031