### PR TITLE
Fix TabBar.image does not render at initialIndex for the first time

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -468,8 +468,51 @@ class _DividerPainter extends CustomPainter {
   }
 }
 
+// A ChangeNotifier for triggering repaints when async resources load.
+class _IndicatorPainterNotifier extends ChangeNotifier {
+  void notify() {
+    notifyListeners();
+  }
+
+  @override
+  String toString() => describeIdentity(this);
+}
+
 class _IndicatorPainter extends CustomPainter {
-  _IndicatorPainter({
+  factory _IndicatorPainter({
+    required TabController controller,
+    required Decoration indicator,
+    required TabBarIndicatorSize indicatorSize,
+    required List<GlobalKey> tabKeys,
+    required _IndicatorPainter? old,
+    required EdgeInsetsGeometry indicatorPadding,
+    required List<EdgeInsetsGeometry> labelPaddings,
+    Color? dividerColor,
+    double? dividerHeight,
+    required bool showDivider,
+    double? devicePixelRatio,
+    required TabIndicatorAnimation indicatorAnimation,
+    required TextDirection textDirection,
+  }) {
+    return _IndicatorPainter._(
+      controller: controller,
+      indicator: indicator,
+      indicatorSize: indicatorSize,
+      tabKeys: tabKeys,
+      old: old,
+      indicatorPadding: indicatorPadding,
+      labelPaddings: labelPaddings,
+      dividerColor: dividerColor,
+      dividerHeight: dividerHeight,
+      showDivider: showDivider,
+      devicePixelRatio: devicePixelRatio,
+      indicatorAnimation: indicatorAnimation,
+      textDirection: textDirection,
+      repaint: _IndicatorPainterNotifier(),
+    );
+  }
+
+  _IndicatorPainter._({
     required this.controller,
     required this.indicator,
     required this.indicatorSize,
@@ -483,7 +526,9 @@ class _IndicatorPainter extends CustomPainter {
     this.devicePixelRatio,
     required this.indicatorAnimation,
     required this.textDirection,
-  }) : super(repaint: controller.animation) {
+    required _IndicatorPainterNotifier repaint,
+  }) : _repaint = repaint,
+       super(repaint: Listenable.merge(<Listenable?>[controller.animation, repaint])) {
     assert(debugMaybeDispatchCreated('material', '_IndicatorPainter', this));
     if (old != null) {
       saveTabOffsets(old._currentTabOffsets, old._currentTextDirection);
@@ -502,6 +547,7 @@ class _IndicatorPainter extends CustomPainter {
   final double? devicePixelRatio;
   final TabIndicatorAnimation indicatorAnimation;
   final TextDirection textDirection;
+  final _IndicatorPainterNotifier _repaint;
 
   // _currentTabOffsets and _currentTextDirection are set each time TabBar
   // layout is completed. These values can be null when TabBar contains no
@@ -514,11 +560,13 @@ class _IndicatorPainter extends CustomPainter {
   bool _needsPaint = false;
   void markNeedsPaint() {
     _needsPaint = true;
+    _repaint.notify();
   }
 
   void dispose() {
     assert(debugMaybeDispatchDisposed(this));
     _painter?.dispose();
+    _repaint.dispose();
   }
 
   void saveTabOffsets(List<double>? tabOffsets, TextDirection? textDirection) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -494,6 +494,12 @@ class _IndicatorPainter extends CustomPainter {
     required TabIndicatorAnimation indicatorAnimation,
     required TextDirection textDirection,
   }) {
+    /// Initializing [_IndicatorPainterNotifier] here that allows the
+    /// repaint notifier to be used in the super constructor call
+    /// (within [Listenable.merge]) while also being stored as a private field.
+    ///
+    /// The notifier is to trigger a repaint when asynchronous resources,
+    /// like images in the indicator [Decoration], are finished loading.
     return _IndicatorPainter._(
       controller: controller,
       indicator: indicator,

--- a/packages/flutter/test/material/tabs_utils.dart
+++ b/packages/flutter/test/material/tabs_utils.dart
@@ -281,3 +281,60 @@ RRect tabIndicatorRRectElasticAnimation(
     topRight: const Radius.circular(indicatorWeight),
   );
 }
+
+// This decoration is used to test async image loading in indicator.
+class TabBarAsyncImageIndicatorDecoration extends Decoration {
+  TabBarAsyncImageIndicatorDecoration() : _paintCounter = _TabBarPaintCounter();
+
+  final _TabBarPaintCounter _paintCounter;
+
+  /// The number of times the indicator has been painted.
+  int get paintCount => _paintCounter.count;
+
+  @override
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
+    return TabBarAsyncImageIndicatorBoxPainter(
+      onChanged: onChanged,
+      onPaint: _paintCounter.increment,
+    );
+  }
+}
+
+// Helper class to track paint counts.
+class _TabBarPaintCounter {
+  int count = 0;
+
+  void increment() {
+    count++;
+  }
+}
+
+// Box painter that simulates async image loading for testing TabBar indicators.
+class TabBarAsyncImageIndicatorBoxPainter extends BoxPainter {
+  TabBarAsyncImageIndicatorBoxPainter({VoidCallback? onChanged, this.onPaint}) : super(onChanged);
+
+  final VoidCallback? onPaint;
+  bool _imagePainted = false;
+
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
+    onPaint?.call();
+
+    // Simulate async image loading on first paint.
+    if (!_imagePainted && onChanged != null) {
+      _imagePainted = true;
+      Future.delayed(Duration.zero, () {
+        onChanged!();
+      });
+    }
+
+    // Paint a simple rectangle to indicate the indicator was painted.
+    final paint = Paint()
+      ..color = Colors.blue
+      ..style = PaintingStyle.fill;
+    canvas.drawRect(
+      Rect.fromLTWH(offset.dx, configuration.size!.height - 2.0, configuration.size!.width, 2.0),
+      paint,
+    );
+  }
+}


### PR DESCRIPTION
- Fix https://github.com/flutter/flutter/issues/59143
- The investigation is at https://github.com/flutter/flutter/issues/59143#issuecomment-3626318406
- Describe the fix: 
    - Make `_IndicatorPainter` listen to both the controller animation and a new painter notifier triggered when the indicator image finishes fetching.
    - Added some regression tests

<details open>
<summary>Demo</summary>

| before | after |
| --------------- | --------------- |
<video src="https://github.com/user-attachments/assets/10bb68f7-1c65-422b-b87f-c2b2dd602e70"/> | <video src="https://github.com/user-attachments/assets/bd5a9d8a-97c8-4a8d-ba43-44242f50ec94"/>

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
