### PR TITLE
[ios][pv] accept/reject gesture based on hitTest (with new widget API)

### DIFF
--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -151,6 +151,7 @@ source_set("ui") {
     "window/platform_message_response_dart.h",
     "window/platform_message_response_dart_port.cc",
     "window/platform_message_response_dart_port.h",
+    "window/point_data.h",
     "window/pointer_data.cc",
     "window/pointer_data.h",
     "window/pointer_data_packet.cc",

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -308,6 +308,11 @@ void _dispatchPointerDataPacket(ByteData packet) {
 }
 
 @pragma('vm:entry-point')
+bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
+  return PlatformDispatcher.instance._platformViewShouldAcceptGesture(viewId, x, y);
+}
+
+@pragma('vm:entry-point')
 void _dispatchSemanticsAction(int viewId, int nodeId, int action, ByteData? args) {
   PlatformDispatcher.instance._dispatchSemanticsAction(viewId, nodeId, action, args);
 }
@@ -414,6 +419,24 @@ void _invoke3<A1, A2, A3>(
     zone.runGuarded(() {
       callback(arg1, arg2, arg3);
     });
+  }
+}
+
+R? _invoke3WithReturn<A1, A2, A3, R>(
+  R Function(A1 a1, A2 a2, A3 a3)? callback,
+  Zone zone,
+  A1 arg1,
+  A2 arg2,
+  A3 arg3,
+) {
+  if (callback == null) {
+    return null;
+  }
+  if (identical(zone, Zone.current)) {
+    return callback(arg1, arg2, arg3);
+  } else {
+    // TODO: how to handle synchronous return? Should we assume zone is always current?
+    return null;
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -422,6 +422,12 @@ void _invoke3<A1, A2, A3>(
   }
 }
 
+/// Invokes [callback] inside the given [zone] passing it [arg1], [arg2], and [arg3],
+/// and returns a nullable result of the specified type.
+///
+/// The 3 in the name refers to the number of arguments expected by
+/// the callback (and thus passed to this function, in addition to the
+/// callback itself and the zone in which the callback is executed).
 R? _invoke3WithReturn<A1, A2, A3, R>(
   R Function(A1 a1, A2 a2, A3 a3)? callback,
   Zone zone,
@@ -435,8 +441,15 @@ R? _invoke3WithReturn<A1, A2, A3, R>(
   if (identical(zone, Zone.current)) {
     return callback(arg1, arg2, arg3);
   } else {
-    // TODO: how to handle synchronous return? Should we assume zone is always current?
-    return null;
+    // TODO(hellohuanlin): add `zone.runGuardedWithReturn` API.
+    try {
+      return zone.run(() {
+        return callback(arg1, arg2, arg3);
+      });
+    } catch (e, s) {
+      zone.handleUncaughtError(e, s);
+      return null;
+    }
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -307,11 +307,12 @@ void _dispatchPointerDataPacket(ByteData packet) {
   PlatformDispatcher.instance._dispatchPointerDataPacket(packet);
 }
 
+// TODO(hellohuanlin): rename function to _onHitTest.
 @pragma('vm:entry-point')
 bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
-  Offset offset = Offset(x, y);
-  // Engine must pass in a valid viewId.
-  FlutterView view = PlatformDispatcher.instance._views[viewId]!;
+  assert(PlatformDispatcher.instance._views.containsKey(viewId), 'View $viewId does not exist.');
+  final FlutterView view = PlatformDispatcher.instance._views[viewId]!;
+  final offset = Offset(x, y);
   final HitTestRequest request = HitTestRequest(view: view, offset: offset);
   final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
   return response.isPlatformView;
@@ -440,15 +441,9 @@ R? _invoke1WithReturn<A1, R>(R Function(A1 a1)? callback, Zone zone, A1 arg1) {
   if (identical(zone, Zone.current)) {
     return callback(arg1);
   } else {
-    // TODO(hellohuanlin): add `zone.runGuardedWithReturn` API.
-    try {
-      return zone.run(() {
-        return callback(arg1);
-      });
-    } catch (e, s) {
-      zone.handleUncaughtError(e, s);
-      return null;
-    }
+    return zone.runZonedGuarded(() {
+      return callback(arg1);
+    });
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -308,8 +308,8 @@ void _dispatchPointerDataPacket(ByteData packet) {
 }
 
 @pragma('vm:entry-point')
-bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
-  return PlatformDispatcher.instance._platformViewShouldAcceptGesture(viewId, x, y);
+bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
+  return PlatformDispatcher.instance._platformViewShouldAcceptTouch(viewId, x, y);
 }
 
 @pragma('vm:entry-point')

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -313,7 +313,7 @@ bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
   assert(PlatformDispatcher.instance._views.containsKey(viewId), 'View $viewId does not exist.');
   final FlutterView view = PlatformDispatcher.instance._views[viewId]!;
   final offset = Offset(x, y);
-  final HitTestRequest request = HitTestRequest(view: view, offset: offset);
+  final request = HitTestRequest(view: view, offset: offset);
   final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
   return response.isPlatformView;
 }

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -441,9 +441,14 @@ R? _invoke1WithReturn<A1, R>(R Function(A1 a1)? callback, Zone zone, A1 arg1) {
   if (identical(zone, Zone.current)) {
     return callback(arg1);
   } else {
-    return zone.runZonedGuarded(() {
-      return callback(arg1);
-    });
+    return runZonedGuarded(
+      () {
+        return callback(arg1);
+      },
+      (e, s) {
+        zone.handleUncaughtError(e, s);
+      },
+    );
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -310,7 +310,7 @@ void _dispatchPointerDataPacket(ByteData packet) {
 @pragma('vm:entry-point')
 bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
   Offset offset = Offset(x, y);
-  // TODO(hellohuanlin) investigate how to handle invalid id.
+  // Engine must pass in a valid viewId.
   FlutterView view = PlatformDispatcher.instance._views[viewId]!;
   final HitTestRequest request = HitTestRequest(view: view, offset: offset);
   final HitTestResponse response = PlatformDispatcher.instance._hitTest(request);
@@ -427,10 +427,10 @@ void _invoke3<A1, A2, A3>(
   }
 }
 
-/// Invokes [callback] inside the given [zone] passing it [arg1], [arg2], and [arg3],
+/// Invokes [callback] inside the given [zone] passing it [arg1],
 /// and returns a nullable result of the specified type.
 ///
-/// The 3 in the name refers to the number of arguments expected by
+/// The 1 in the name refers to the number of arguments expected by
 /// the callback (and thus passed to this function, in addition to the
 /// callback itself and the zone in which the callback is executed).
 R? _invoke1WithReturn<A1, R>(R Function(A1 a1)? callback, Zone zone, A1 arg1) {

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -308,6 +308,7 @@ void _dispatchPointerDataPacket(ByteData packet) {
 }
 
 // TODO(hellohuanlin): rename function to _onHitTest.
+// See: https://github.com/flutter/flutter/issues/179762.
 @pragma('vm:entry-point')
 bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
   assert(PlatformDispatcher.instance._views.containsKey(viewId), 'View $viewId does not exist.');

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,6 +43,7 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
+/// Signature for [PlatformDispatcher.onPlatformViewShouldAcceptGesture].
 typedef PlatformViewShouldAcceptGestureCallback = bool Function(int viewId, double x, double y);
 
 /// Signature for responses to platform messages.

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -1391,11 +1391,14 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  /// A callback is invoked when a platform view performs hitTest and queries
+  /// the framework if the platform view should receive the touches.
   HitTestCallback? get onHitTest => _onHitTest;
   HitTestCallback? _onHitTest;
   Zone _onHitTestZone = Zone.root;
   set onHitTest(HitTestCallback? callback) {
     _onHitTest = callback;
+    _onHitTestZone = Zone.current;
   }
 
   // Called from the engine via hooks.dart.

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,8 +43,8 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
-/// Signature for [PlatformDispatcher.onPlatformViewShouldAcceptTouch].
-typedef PlatformViewShouldAcceptTouchCallback = bool Function(int viewId, double x, double y);
+/// Signature for [PlatformDispatcher.onHitTest].
+typedef HitTestCallback = HitTestResponse Function(HitTestRequest);
 
 /// Signature for responses to platform messages.
 ///
@@ -1391,12 +1391,11 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
-  PlatformViewShouldAcceptTouchCallback? get onPlatformViewShouldAcceptTouch =>
-      _onPlatformViewShouldAcceptTouch;
-  PlatformViewShouldAcceptTouchCallback? _onPlatformViewShouldAcceptTouch;
-  Zone _onPlatformViewShouldAcceptTouchZone = Zone.root;
-  set onPlatformViewShouldAcceptTouch(PlatformViewShouldAcceptTouchCallback? callback) {
-    _onPlatformViewShouldAcceptTouch = callback;
+  HitTestCallback? get onHitTest => _onHitTest;
+  HitTestCallback? _onHitTest;
+  Zone _onHitTestZone = Zone.root;
+  set onHitTest(HitTestCallback? callback) {
+    _onHitTest = callback;
   }
 
   // Called from the engine via hooks.dart.
@@ -1436,15 +1435,13 @@ class PlatformDispatcher {
     );
   }
 
-  bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
-    return _invoke3WithReturn<int, double, double, bool>(
-          onPlatformViewShouldAcceptTouch,
-          _onPlatformViewShouldAcceptTouchZone,
-          viewId,
-          x,
-          y,
+  HitTestResponse _hitTest(HitTestRequest request) {
+    return _invoke1WithReturn<HitTestRequest, HitTestResponse>(
+          onHitTest,
+          _onHitTestZone,
+          request,
         ) ??
-        false;
+        const HitTestResponse();
   }
 
   ErrorCallback? _onError;
@@ -3210,4 +3207,17 @@ enum ViewFocusDirection {
   ///
   /// This is typically result of the user pressing shift + tab.
   backward,
+}
+
+class HitTestRequest {
+  const HitTestRequest({required this.view, required this.offset});
+
+  final FlutterView view;
+  final Offset offset;
+}
+
+class HitTestResponse {
+  const HitTestResponse({this.isPlatformView = false});
+
+  final bool isPlatformView;
 }

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -3209,15 +3209,21 @@ enum ViewFocusDirection {
   backward,
 }
 
+/// The request containing all the information required to perform framework hitTest.
 class HitTestRequest {
   const HitTestRequest({required this.view, required this.offset});
 
+  /// The flutter view.
   final FlutterView view;
+
+  /// The touch location on screen.
   final Offset offset;
 }
 
+/// The response from the framework hitTest.
 class HitTestResponse {
   const HitTestResponse({this.isPlatformView = false});
 
+  // whether the top-most hit target is a platform view.
   final bool isPlatformView;
 }

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,6 +43,8 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
+typedef PlatformViewShouldAcceptGestureCallback = bool Function(int viewId, double x, double y);
+
 /// Signature for responses to platform messages.
 ///
 /// Used as a parameter to [PlatformDispatcher.sendPlatformMessage] and
@@ -1388,6 +1390,14 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  PlatformViewShouldAcceptGestureCallback? get onPlatformViewShouldAcceptGesture =>
+      _onPlatformViewShouldAcceptGesture;
+  PlatformViewShouldAcceptGestureCallback? _onPlatformViewShouldAcceptGesture;
+  Zone _onPlatformViewShouldAcceptGestureZone = Zone.root;
+  set onPlatformViewShouldAcceptGesture(PlatformViewShouldAcceptGestureCallback? callback) {
+    _onPlatformViewShouldAcceptGesture = callback;
+  }
+
   // Called from the engine via hooks.dart.
   void _updateFrameData(int frameNumber) {
     final FrameData previous = _frameData;
@@ -1423,6 +1433,17 @@ class PlatformDispatcher {
         arguments: args,
       ),
     );
+  }
+
+  bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
+    return _invoke3WithReturn<int, double, double, bool>(
+          onPlatformViewShouldAcceptGesture,
+          _onPlatformViewShouldAcceptGestureZone,
+          viewId,
+          x,
+          y,
+        ) ??
+        false;
   }
 
   ErrorCallback? _onError;

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -1391,12 +1391,10 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
-  /// A callback invoked when platform wants to perform a hittest on a [FlutterView].
+  /// A callback invoked when platform wants to hit test a [FlutterView].
   ///
-  /// The callback are expected to return value contains the top-most hittest target that are hit at the
-  /// [HitTestRequest.offset] in the [HitTestRequest.view].
-  ///
-  /// This is typically used by iOS to determine whether a hittest will hit a [UIKitView].
+  /// For example, this is used by iOS to determine if a gesture hits a
+  /// [UIKitView].
   HitTestCallback? get onHitTest => _onHitTest;
   HitTestCallback? _onHitTest;
   Zone _onHitTestZone = Zone.root;

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,8 +43,8 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
-/// Signature for [PlatformDispatcher.onPlatformViewShouldAcceptGesture].
-typedef PlatformViewShouldAcceptGestureCallback = bool Function(int viewId, double x, double y);
+/// Signature for [PlatformDispatcher.onPlatformViewShouldAcceptTouch].
+typedef PlatformViewShouldAcceptTouchCallback = bool Function(int viewId, double x, double y);
 
 /// Signature for responses to platform messages.
 ///
@@ -1391,12 +1391,12 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
-  PlatformViewShouldAcceptGestureCallback? get onPlatformViewShouldAcceptGesture =>
-      _onPlatformViewShouldAcceptGesture;
-  PlatformViewShouldAcceptGestureCallback? _onPlatformViewShouldAcceptGesture;
-  Zone _onPlatformViewShouldAcceptGestureZone = Zone.root;
-  set onPlatformViewShouldAcceptGesture(PlatformViewShouldAcceptGestureCallback? callback) {
-    _onPlatformViewShouldAcceptGesture = callback;
+  PlatformViewShouldAcceptTouchCallback? get onPlatformViewShouldAcceptTouch =>
+      _onPlatformViewShouldAcceptTouch;
+  PlatformViewShouldAcceptTouchCallback? _onPlatformViewShouldAcceptTouch;
+  Zone _onPlatformViewShouldAcceptTouchZone = Zone.root;
+  set onPlatformViewShouldAcceptTouch(PlatformViewShouldAcceptTouchCallback? callback) {
+    _onPlatformViewShouldAcceptTouch = callback;
   }
 
   // Called from the engine via hooks.dart.
@@ -1436,10 +1436,10 @@ class PlatformDispatcher {
     );
   }
 
-  bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
+  bool _platformViewShouldAcceptTouch(int viewId, double x, double y) {
     return _invoke3WithReturn<int, double, double, bool>(
-          onPlatformViewShouldAcceptGesture,
-          _onPlatformViewShouldAcceptGestureZone,
+          onPlatformViewShouldAcceptTouch,
+          _onPlatformViewShouldAcceptTouchZone,
           viewId,
           x,
           y,

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -77,6 +77,9 @@ void PlatformConfiguration::DidCreateIsolate() {
   dispatch_pointer_data_packet_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
+  // The embedded platform view (e.g. UIView on iOS) is called "platform view"
+  // on framework side, but "embedded view" on engine side. On the other hand,
+  // "platform view" refers to the whole flutter view on engine side.
   embedded_view_should_accept_gesture_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library,
@@ -406,6 +409,9 @@ bool PlatformConfiguration::EmbeddedViewShouldAcceptGesture(
       embedded_view_should_accept_gesture_.Get(),
       {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
        tonic::ToDart(touch_began_location.y)});
+  if (tonic::CheckAndHandleError(dart_result)) {
+    return false;
+  }
   return tonic::DartConverter<bool>::FromDart(dart_result);
 }
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -395,7 +395,7 @@ void PlatformConfiguration::DispatchPointerDataPacket(
       tonic::DartInvoke(dispatch_pointer_data_packet_.Get(), {data_handle}));
 }
 
-bool PlatformConfiguration::EmbeddedViewShouldAcceptGesture(
+bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -80,7 +80,7 @@ void PlatformConfiguration::DidCreateIsolate() {
   // The embedded platform view (e.g. UIView on iOS) is called "platform view"
   // on framework side, but "embedded view" on engine side. On the other hand,
   // "platform view" refers to the whole flutter view on engine side.
-  embedded_view_should_accept_touch.Set(
+  embedded_view_should_accept_touch_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
@@ -398,14 +398,14 @@ bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =
-      embedded_view_should_accept_touch.dart_state().lock();
+      embedded_view_should_accept_touch_.dart_state().lock();
   if (!dart_state) {
     return false;
   }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle dart_result = tonic::DartInvoke(
-      embedded_view_should_accept_touch.Get(),
+      embedded_view_should_accept_touch_.Get(),
       {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
        tonic::ToDart(touch_began_location.y)});
   if (tonic::CheckAndHandleError(dart_result)) {

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -396,7 +396,7 @@ void PlatformConfiguration::DispatchPointerDataPacket(
 
 bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
-    const flutter::PointData& touch_began_location) {
+    const flutter::PointData touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =
       embedded_native_view_should_accept_touch_.dart_state().lock();
   if (!dart_state) {

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -82,8 +82,7 @@ void PlatformConfiguration::DidCreateIsolate() {
   // "platform view" refers to the whole flutter view on engine side.
   embedded_view_should_accept_gesture_.Set(
       tonic::DartState::Current(),
-      Dart_GetField(library,
-                    tonic::ToDart("_platformViewShouldAcceptTouch")));
+      Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchSemanticsAction")));

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -80,7 +80,7 @@ void PlatformConfiguration::DidCreateIsolate() {
   // The embedded platform view (e.g. UIView on iOS) is called "platform view"
   // on framework side, but "embedded view" on engine side. On the other hand,
   // "platform view" refers to the whole flutter view on engine side.
-  embedded_view_should_accept_gesture_.Set(
+  embedded_view_should_accept_touch.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
@@ -398,14 +398,14 @@ bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =
-      embedded_view_should_accept_gesture_.dart_state().lock();
+      embedded_view_should_accept_touch.dart_state().lock();
   if (!dart_state) {
     return false;
   }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle dart_result = tonic::DartInvoke(
-      embedded_view_should_accept_gesture_.Get(),
+      embedded_view_should_accept_touch.Get(),
       {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
        tonic::ToDart(touch_began_location.y)});
   if (tonic::CheckAndHandleError(dart_result)) {

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -77,10 +77,10 @@ void PlatformConfiguration::DidCreateIsolate() {
   dispatch_pointer_data_packet_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
-  // The embedded platform view (e.g. UIView on iOS) is called "platform view"
-  // on framework side, but "embedded view" on engine side. On the other hand,
+  // The embedded native view (e.g. UIView on iOS) is called "platform view"
+  // on framework side, but "embedded native view" on engine side. On the other hand,
   // "platform view" refers to the whole flutter view on engine side.
-  embedded_view_should_accept_touch_.Set(
+  embedded_native_view_should_accept_touch_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
@@ -398,14 +398,14 @@ bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =
-      embedded_view_should_accept_touch_.dart_state().lock();
+      embedded_native_view_should_accept_touch_.dart_state().lock();
   if (!dart_state) {
     return false;
   }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle dart_result = tonic::DartInvoke(
-      embedded_view_should_accept_touch_.Get(),
+      embedded_native_view_should_accept_touch_.Get(),
       {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
        tonic::ToDart(touch_began_location.y)});
   if (tonic::CheckAndHandleError(dart_result)) {

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -78,8 +78,8 @@ void PlatformConfiguration::DidCreateIsolate() {
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
   // The embedded native view (e.g. UIView on iOS) is called "platform view"
-  // on framework side, but "embedded native view" on engine side. On the other hand,
-  // "platform view" refers to the whole flutter view on engine side.
+  // on framework side, but "embedded native view" on engine side. On the other
+  // hand, "platform view" refers to the whole flutter view on engine side.
   embedded_native_view_should_accept_touch_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_platformViewShouldAcceptTouch")));

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -83,7 +83,7 @@ void PlatformConfiguration::DidCreateIsolate() {
   embedded_view_should_accept_gesture_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library,
-                    tonic::ToDart("_platformViewShouldAcceptGesture")));
+                    tonic::ToDart("_platformViewShouldAcceptTouch")));
   dispatch_semantics_action_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchSemanticsAction")));
@@ -395,7 +395,7 @@ void PlatformConfiguration::DispatchPointerDataPacket(
       tonic::DartInvoke(dispatch_pointer_data_packet_.Get(), {data_handle}));
 }
 
-bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptGesture(
+bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/semantics/semantics_update.h"
 #include "flutter/lib/ui/window/platform_message_response.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/view_focus.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
@@ -461,6 +462,10 @@ class PlatformConfiguration final {
   ///
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
+
   //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an
   ///             accessibility related action on the specified node. This call
@@ -584,6 +589,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
+  tonic::DartPersistentValue embedded_view_should_accept_gesture_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -463,7 +463,8 @@ class PlatformConfiguration final {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -474,7 +475,7 @@ class PlatformConfiguration final {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -462,6 +462,18 @@ class PlatformConfiguration final {
   ///
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -601,7 +601,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
-  tonic::DartPersistentValue embedded_view_should_accept_touch_;
+  tonic::DartPersistentValue embedded_native_view_should_accept_touch_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -475,7 +475,7 @@ class PlatformConfiguration final {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedNativeViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -601,7 +601,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
-  tonic::DartPersistentValue embedded_view_should_accept_touch;
+  tonic::DartPersistentValue embedded_view_should_accept_touch_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -476,7 +476,7 @@ class PlatformConfiguration final {
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location);
+      const flutter::PointData touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -464,15 +464,14 @@ class PlatformConfiguration final {
 
   //----------------------------------------------------------------------------
   /// @brief      Requests from the engine if an embedded native view should
-  /// accept
-  ///             gesture at a given touch location.
+  ///             accept touch at a given touch location.
   ///
   ///
   /// @param[in]  view_id               The identifier of the flutter view that
   ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  /// @param[in]  touch_began_location  The touch began location.
   ///
-  /// @return     true if the embedded view should accept gesture; false
+  /// @return     true if the embedded view should accept touch; false
   /// otherwise.
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(
@@ -602,7 +601,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
-  tonic::DartPersistentValue embedded_view_should_accept_gesture_;
+  tonic::DartPersistentValue embedded_view_should_accept_touch;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/point_data.h
+++ b/engine/src/flutter/lib/ui/window/point_data.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+#define FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+
+namespace flutter {
+
+// Represents a point on screen.
+struct PointData {
+  double x;
+  double y;
+};
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -601,3 +601,22 @@ final class ViewFocusEvent {
 enum ViewFocusState { unfocused, focused }
 
 enum ViewFocusDirection { undefined, forward, backward }
+
+/// The request containing all the information required to perform framework hitTest.
+class HitTestRequest {
+  const HitTestRequest({required this.view, required this.offset});
+
+  /// The flutter view.
+  final FlutterView view;
+
+  /// The touch location on screen.
+  final Offset offset;
+}
+
+/// The response from the framework hitTest.
+class HitTestResponse {
+  const HitTestResponse({this.isPlatformView = false});
+
+  // whether the top-most hit target is a platform view.
+  final bool isPlatformView;
+}

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -11,7 +11,7 @@ typedef TimingsCallback = void Function(List<FrameTiming> timings);
 typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 typedef KeyDataCallback = bool Function(KeyData data);
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
-typedef HitTestCallback = HitTestResponse Function(HitTestRequest);
+typedef HitTestCallback = HitTestResponse Function(HitTestRequest request);
 typedef PlatformMessageResponseCallback = void Function(ByteData? data);
 typedef PlatformMessageCallback =
     void Function(String name, ByteData? data, PlatformMessageResponseCallback? callback);
@@ -606,21 +606,14 @@ enum ViewFocusState { unfocused, focused }
 
 enum ViewFocusDirection { undefined, forward, backward }
 
-/// The request containing all the information required to perform framework hitTest.
 class HitTestRequest {
   const HitTestRequest({required this.view, required this.offset});
-
-  /// The flutter view.
   final FlutterView view;
-
-  /// The touch location on screen.
   final Offset offset;
 }
 
-/// The response from the framework hitTest.
 class HitTestResponse {
-  const HitTestResponse({this.isPlatformView = false});
-
-  // whether the top-most hit target is a platform view.
+  const HitTestResponse({required this.isPlatformView});
+  static const HitTestResponse empty = HitTestResponse(isPlatformView: false);
   final bool isPlatformView;
 }

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -11,6 +11,7 @@ typedef TimingsCallback = void Function(List<FrameTiming> timings);
 typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 typedef KeyDataCallback = bool Function(KeyData data);
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
+typedef HitTestCallback = HitTestResponse Function(HitTestRequest);
 typedef PlatformMessageResponseCallback = void Function(ByteData? data);
 typedef PlatformMessageCallback =
     void Function(String name, ByteData? data, PlatformMessageResponseCallback? callback);
@@ -153,6 +154,9 @@ abstract class PlatformDispatcher {
 
   SemanticsActionEventCallback? get onSemanticsActionEvent;
   set onSemanticsActionEvent(SemanticsActionEventCallback? callback);
+
+  HitTestCallback? get onHitTest;
+  set onHitTest(HitTestCallback? callback);
 
   ErrorCallback? get onError;
   set onError(ErrorCallback? callback);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1377,11 +1377,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   ui.HitTestCallback? get onHitTest => _onHitTest;
   ui.HitTestCallback? _onHitTest;
-  Zone _onHitTestZone = Zone.root;
   @override
   set onHitTest(ui.HitTestCallback? callback) {
     _onHitTest = callback;
-    _onHitTestZone = Zone.current;
   }
 
   /// Engine code should use this method instead of the callback directly.

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1368,6 +1368,18 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  /// A callback is invoked when a platform view performs hitTest and queries
+  /// the framework if the platform view should receive the touches.
+  @override
+  ui.HitTestCallback? get onHitTest => _onHitTest;
+  ui.HitTestCallback? _onHitTest;
+  Zone _onHitTestZone = Zone.root;
+  @override
+  set onHitTest(ui.HitTestCallback? callback) {
+    _onHitTest = callback;
+    _onHitTestZone = Zone.current;
+  }
+
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.
   void invokeOnSemanticsAction(int viewId, int nodeId, ui.SemanticsAction action, ByteData? args) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1368,8 +1368,12 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
-  /// A callback is invoked when a platform view performs hitTest and queries
-  /// the framework if the platform view should receive the touches.
+  /// A callback invoked when platform wants to perform a hittest on a [FlutterView].
+  ///
+  /// The callback are expected to return value contains the top-most hittest target that are hit at the
+  /// [HitTestRequest.offset] in the [HitTestRequest.view].
+  ///
+  /// This is typically used by iOS to determine whether a hittest will hit a [UIKitView].
   @override
   ui.HitTestCallback? get onHitTest => _onHitTest;
   ui.HitTestCallback? _onHitTest;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1368,19 +1368,12 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
-  /// A callback invoked when platform wants to perform a hittest on a [FlutterView].
+  /// A callback invoked when platform wants to hit test a [FlutterView].
   ///
-  /// The callback are expected to return value contains the top-most hittest target that are hit at the
-  /// [HitTestRequest.offset] in the [HitTestRequest.view].
-  ///
-  /// This is typically used by iOS to determine whether a hittest will hit a [UIKitView].
+  /// For example, this is used by iOS to determine if a gesture hits a
+  /// [UIKitView].
   @override
-  ui.HitTestCallback? get onHitTest => _onHitTest;
-  ui.HitTestCallback? _onHitTest;
-  @override
-  set onHitTest(ui.HitTestCallback? callback) {
-    _onHitTest = callback;
-  }
+  ui.HitTestCallback? onHitTest;
 
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,13 +374,13 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
-bool RuntimeController::EmbeddedViewShouldAcceptGesture(
+bool RuntimeController::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT0("flutter",
-                 "RuntimeController::EmbeddedViewShouldAcceptGesture");
-    return platform_configuration->EmbeddedViewShouldAcceptGesture(
+                 "RuntimeController::EmbeddedNativeViewShouldAcceptGesture");
+    return platform_configuration->EmbeddedNativeViewShouldAcceptGesture(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,6 +374,18 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
+bool RuntimeController::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
+    TRACE_EVENT0("flutter",
+                 "RuntimeController::EmbeddedViewShouldAcceptGesture");
+    return platform_configuration->EmbeddedViewShouldAcceptGesture(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 bool RuntimeController::DispatchSemanticsAction(int64_t view_id,
                                                 int32_t node_id,
                                                 SemanticsAction action,

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -376,7 +376,7 @@ bool RuntimeController::DispatchPointerDataPacket(
 
 bool RuntimeController::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
-    const flutter::PointData& touch_began_location) {
+    const flutter::PointData touch_began_location) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT0("flutter",
                  "RuntimeController::EmbeddedNativeViewShouldAcceptTouch");

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,13 +374,13 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
-bool RuntimeController::EmbeddedNativeViewShouldAcceptGesture(
+bool RuntimeController::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT0("flutter",
-                 "RuntimeController::EmbeddedNativeViewShouldAcceptGesture");
-    return platform_configuration->EmbeddedNativeViewShouldAcceptGesture(
+                 "RuntimeController::EmbeddedNativeViewShouldAcceptTouch");
+    return platform_configuration->EmbeddedNativeViewShouldAcceptTouch(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -478,7 +478,8 @@ class RuntimeController : public PlatformConfigurationClient,
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -489,7 +490,7 @@ class RuntimeController : public PlatformConfigurationClient,
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
 #include "flutter/lib/ui/window/view_focus.h"
@@ -475,6 +476,10 @@ class RuntimeController : public PlatformConfigurationClient,
   ///             an isolate is not running.
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
+
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the semantics action to the specified accessibility

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -477,6 +477,18 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -479,15 +479,14 @@ class RuntimeController : public PlatformConfigurationClient,
 
   //----------------------------------------------------------------------------
   /// @brief      Requests from the engine if an embedded native view should
-  /// accept
-  ///             gesture at a given touch location.
+  ///             accept touch at a given touch location.
   ///
   ///
   /// @param[in]  view_id               The identifier of the flutter view that
   ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  /// @param[in]  touch_began_location  The touch began location.
   ///
-  /// @return     true if the embedded view should accept gesture; false
+  /// @return     true if the embedded view should accept touch; false
   /// otherwise.
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -477,6 +477,7 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  // TODO(hellohuanlin): we should make make this a generic HitTest API.
   //----------------------------------------------------------------------------
   /// @brief      Requests from the engine if an embedded native view should
   ///             accept touch at a given touch location.

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -490,7 +490,7 @@ class RuntimeController : public PlatformConfigurationClient,
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedNativeViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -492,7 +492,7 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location);
+      const flutter::PointData touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the semantics action to the specified accessibility

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,6 +476,16 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
+bool Engine::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (runtime_controller_) {
+    return runtime_controller_->EmbeddedViewShouldAcceptGesture(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 void Engine::DispatchSemanticsAction(int64_t view_id,
                                      int node_id,
                                      SemanticsAction action,

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,11 +476,11 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
-bool Engine::EmbeddedViewShouldAcceptGesture(
+bool Engine::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (runtime_controller_) {
-    return runtime_controller_->EmbeddedViewShouldAcceptGesture(
+    return runtime_controller_->EmbeddedNativeViewShouldAcceptGesture(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -478,7 +478,7 @@ void Engine::DispatchPointerDataPacket(
 
 bool Engine::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
-    const flutter::PointData& touch_began_location) {
+    const flutter::PointData touch_began_location) {
   if (runtime_controller_) {
     return runtime_controller_->EmbeddedNativeViewShouldAcceptTouch(
         view_id, touch_began_location);

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,11 +476,11 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
-bool Engine::EmbeddedNativeViewShouldAcceptGesture(
+bool Engine::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (runtime_controller_) {
-    return runtime_controller_->EmbeddedNativeViewShouldAcceptGesture(
+    return runtime_controller_->EmbeddedNativeViewShouldAcceptTouch(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,6 +830,22 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
+  /// @brief      Requests the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder encountered an
   ///             accessibility related action on the specified node. This call
   ///             originates on the platform view and has been forwarded to the

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,7 +830,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded view should accept
   ///             gesture at a given touch location.
   ///
   ///

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,7 +830,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -841,7 +842,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -842,7 +842,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedNativeViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -843,7 +843,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location);
+      const flutter::PointData touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder encountered an

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -831,15 +831,14 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
 
   //----------------------------------------------------------------------------
   /// @brief      Requests from the engine if an embedded native view should
-  /// accept
-  ///             gesture at a given touch location.
+  ///             accept touch at a given touch location.
   ///
   ///
   /// @param[in]  view_id               The identifier of the flutter view that
   ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  /// @param[in]  touch_began_location  The touch began location.
   ///
-  /// @return     true if the embedded view should accept gesture; false
+  /// @return     true if the embedded view should accept touch; false
   /// otherwise.
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,10 +35,10 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
-bool PlatformView::EmbeddedViewShouldAcceptGesture(
+bool PlatformView::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
-  return delegate_.OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       view_id, touch_began_location);
 }
 

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,6 +35,13 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
+bool PlatformView::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  return delegate_.OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      view_id, touch_began_location);
+}
+
 void PlatformView::DispatchSemanticsAction(int64_t view_id,
                                            int32_t node_id,
                                            SemanticsAction action,

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,10 +35,10 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
-bool PlatformView::EmbeddedNativeViewShouldAcceptGesture(
+bool PlatformView::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
-  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       view_id, touch_began_location);
 }
 

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -37,7 +37,7 @@ void PlatformView::DispatchPointerDataPacket(
 
 bool PlatformView::EmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
-    const flutter::PointData& touch_began_location) {
+    const flutter::PointData touch_began_location) {
   return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       view_id, touch_began_location);
 }

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,7 +183,8 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
-    /// @brief      Requests the delegate if an embedded view should accept
+    /// @brief      Requests the delegate if an embedded native view should
+    /// accept
     ///             gesture at a given touch location.
     ///
     /// @param[in]  view_id               The identifier of the flutter view
@@ -194,7 +195,7 @@ class PlatformView {
     /// @return     true if the embedded view should accept gesture; false
     /// otherwise.
     ///
-    virtual bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
         int64_t view_id,
         const flutter::PointData& touch_began_location) = 0;
 
@@ -765,7 +766,7 @@ class PlatformView {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,6 +183,22 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
+    /// @brief      Requests the delegate if an embedded view should accept
+    ///             gesture at a given touch location.
+    ///
+    /// @param[in]  view_id               The identifier of the flutter view
+    /// that
+    ///                                   hosts the embedded view.
+    /// @param[in]  touch_began_location  The touch began location of a gesture.
+    ///
+    /// @return     true if the embedded view should accept gesture; false
+    /// otherwise.
+    ///
+    virtual bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+        int64_t view_id,
+        const flutter::PointData& touch_began_location) = 0;
+
+    //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
     ///             an accessibility related action on the specified node. This
     ///             event must be forwarded to the running root isolate hosted
@@ -736,6 +752,10 @@ class PlatformView {
   /// @param[in]  packet  The pointer data packet to dispatch to the framework.
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
+
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -753,6 +753,18 @@ class PlatformView {
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -184,15 +184,14 @@ class PlatformView {
 
     //--------------------------------------------------------------------------
     /// @brief      Requests the delegate if an embedded native view should
-    /// accept
-    ///             gesture at a given touch location.
+    ///             accept touch at a given touch location.
     ///
     /// @param[in]  view_id               The identifier of the flutter view
     /// that
     ///                                   hosts the embedded view.
-    /// @param[in]  touch_began_location  The touch began location of a gesture.
+    /// @param[in]  touch_began_location  The touch began location.
     ///
-    /// @return     true if the embedded view should accept gesture; false
+    /// @return     true if the embedded view should accept touch; false
     /// otherwise.
     ///
     virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
@@ -756,14 +755,14 @@ class PlatformView {
 
   //----------------------------------------------------------------------------
   /// @brief      Requests from the engine if an embedded view should accept
-  ///             gesture at a given touch location.
+  ///             touch at a given touch location.
   ///
   ///
   /// @param[in]  view_id               The identifier of the flutter view that
   ///                                   hosts the embedded view.
-  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  /// @param[in]  touch_began_location  The touch began location.
   ///
-  /// @return     true if the embedded view should accept gesture; false
+  /// @return     true if the embedded view should accept touch; false
   /// otherwise.
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -195,7 +195,7 @@ class PlatformView {
     /// @return     true if the embedded view should accept gesture; false
     /// otherwise.
     ///
-    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
         int64_t view_id,
         const flutter::PointData& touch_began_location) = 0;
 
@@ -766,7 +766,7 @@ class PlatformView {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedNativeViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -187,8 +187,7 @@ class PlatformView {
     ///             accept touch at a given touch location.
     ///
     /// @param[in]  view_id               The identifier of the flutter view
-    /// that
-    ///                                   hosts the embedded view.
+    ///                                   that hosts the embedded view.
     /// @param[in]  touch_began_location  The touch began location.
     ///
     /// @return     true if the embedded view should accept touch; false

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -195,7 +195,7 @@ class PlatformView {
     ///
     virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
         int64_t view_id,
-        const flutter::PointData& touch_began_location) = 0;
+        const flutter::PointData touch_began_location) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
@@ -766,7 +766,7 @@ class PlatformView {
   ///
   bool EmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location);
+      const flutter::PointData touch_began_location);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1221,6 +1221,16 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
+bool Shell::OnPlatformViewEmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (engine_) {
+    return engine_->EmbeddedViewShouldAcceptGesture(view_id,
+                                                    touch_began_location);
+  }
+  return false;
+}
+
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                                   int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1221,12 +1221,12 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
-bool Shell::OnPlatformViewEmbeddedViewShouldAcceptGesture(
+bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (engine_) {
-    return engine_->EmbeddedViewShouldAcceptGesture(view_id,
-                                                    touch_began_location);
+    return engine_->EmbeddedNativeViewShouldAcceptGesture(view_id,
+                                                          touch_began_location);
   }
   return false;
 }

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1221,11 +1221,11 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
-bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (engine_) {
-    return engine_->EmbeddedNativeViewShouldAcceptGesture(view_id,
+    return engine_->EmbeddedNativeViewShouldAcceptTouch(view_id,
                                                           touch_began_location);
   }
   return false;

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1223,7 +1223,8 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
 
 bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
     int64_t view_id,
-    const flutter::PointData& touch_began_location) {
+    const flutter::PointData touch_began_location) {
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   if (engine_) {
     return engine_->EmbeddedNativeViewShouldAcceptTouch(view_id,
                                                         touch_began_location);

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1226,7 +1226,7 @@ bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
     const flutter::PointData& touch_began_location) {
   if (engine_) {
     return engine_->EmbeddedNativeViewShouldAcceptTouch(view_id,
-                                                          touch_began_location);
+                                                        touch_began_location);
   }
   return false;
 }

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,6 +608,10 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override;
+
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,7 +608,7 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override;
 

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -610,7 +610,7 @@ class Shell final : public PlatformView::Delegate,
 
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override;
+      const flutter::PointData touch_began_location) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,7 +608,7 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override;
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -143,7 +143,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (override));
 
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -142,6 +142,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
 
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (override));
+
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -143,7 +143,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (override));
 
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -144,7 +144,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
 
   MOCK_METHOD(bool,
               OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
-              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (int64_t view_id, const flutter::PointData touch_began_location),
               (override));
 
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -268,6 +268,17 @@ typedef enum {
    * but never recognizing the gesture (and never invoking actions).
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
+
+  /**
+   * Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+   * decides they should be blocked.
+   *
+   * This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
+   * internally it performs hit test rather than a blocking gesture recognizer. This addresses
+   * a few bugs related to WKWebView being untappable. See
+   * https://github.com/flutter/flutter/issues/175099.
+   */
+  FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest,
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -270,8 +270,8 @@ typedef enum {
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
 
   /**
-   * Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
-   * decides they should be blocked.
+   * Flutter blocks all the touch event callbacks and UIGestureRecognizers on the platform view as
+   * soon as it decides they should be blocked.
    *
    * This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
    * internally it performs hit test rather than a blocking gesture recognizer. This addresses

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -278,7 +278,7 @@ typedef enum {
    * a few bugs related to WKWebView being untappable. See
    * https://github.com/flutter/flutter/issues/175099.
    */
-  FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest,
+  FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly,
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -386,6 +386,14 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   self.platformView->DispatchPointerDataPacket(std::move(packet));
 }
 
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+                                                     viewId:(uint64_t)viewId {
+  if (!self.platformView) {
+    return NO;
+  }
+  return self.platformView->EmbeddedViewShouldAcceptGesture(viewId, location);
+}
+
 - (void)installFirstFrameCallback:(void (^)(void))block {
   if (!self.platformView) {
     return;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -391,7 +391,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   if (!self.platformView) {
     return NO;
   }
-  return self.platformView->EmbeddedViewShouldAcceptGesture(viewId, location);
+  return self.platformView->EmbeddedNativeViewShouldAcceptGesture(viewId, location);
 }
 
 - (void)installFirstFrameCallback:(void (^)(void))block {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -386,12 +386,12 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   self.platformView->DispatchPointerDataPacket(std::move(packet));
 }
 
-- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
                                                      viewId:(uint64_t)viewId {
   if (!self.platformView) {
     return NO;
   }
-  return self.platformView->EmbeddedNativeViewShouldAcceptGesture(viewId, location);
+  return self.platformView->EmbeddedNativeViewShouldAcceptTouch(viewId, location);
 }
 
 - (void)installFirstFrameCallback:(void (^)(void))block {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -387,7 +387,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
 }
 
 - (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
-                                                     viewId:(uint64_t)viewId {
+                                                   viewId:(uint64_t)viewId {
   if (!self.platformView) {
     return NO;
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,6 +35,11 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,7 +35,7 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -37,7 +37,7 @@ class FakeDelegate : public PlatformView::Delegate {
   }
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override {
+      const flutter::PointData touch_began_location) override {
     return false;
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,7 +35,7 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+                                                     viewId:(uint64_t)viewId;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;
 - (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
-- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
                                                      viewId:(uint64_t)viewId;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
 - (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(flutter::PointData)location
-                                                     viewId:(uint64_t)viewId;
+                                                   viewId:(uint64_t)viewId;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;
 - (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -581,8 +581,7 @@ static BOOL _preparedOnce = NO;
 }
 
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest &&
-      event.type == UIEventTypeTouches) {
+  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest) {
     CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
     // Block gesture if the framework instructed so (after performing its own hitTest).
     if (![self.flutterViewController

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -589,7 +589,10 @@ static BOOL _preparedOnce = NO;
       _flutterViewController = self.platformViewsController.flutterViewController;
     }
     CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
-    // Block gesture if the framework instructed so (after performing its own hitTest).
+    // Consult the framework on if the touch should be handled by the platform view.
+    // If NO, the touch is handled by a Flutter widget and should be blocked (by returning self).
+    // If YES, the touch should continue to the standard hit-testing (through super), allowing the
+    // touch to be delivered to the underlying native platform view or one of its subviews.
     if (![self.flutterViewController
             platformViewShouldAcceptTouchAtTouchBeganLocation:pointInFlutterView]) {
       return self;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -583,7 +583,8 @@ static BOOL _preparedOnce = NO;
 
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
   if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
-    // In release mode, FlutterTouchInterceptingView's init is called before flutterViewController is set on platformViewsController.
+    // In release mode, FlutterTouchInterceptingView's init is called before flutterViewController
+    // is set on platformViewsController.
     if (self.flutterViewController == nil) {
       _flutterViewController = self.platformViewsController.flutterViewController;
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -761,6 +761,12 @@ static BOOL _preparedOnce = NO;
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
   FML_DCHECK(_currentTouchPointersCount >= 0);
   if (_currentTouchPointersCount == 0) {
+    // TODO(hellohuanlin): the following comment is likely incorrect and very misleading.
+    // The actual reason is a race condition when platform view is created before
+    // flutterViewController is set in platformViewsController in debug mode. We should clean up the
+    // code, either fix the race condition, or make flutterViewController a computed property rather
+    // than a stored property.
+    //
     // At the start of each gesture sequence, we reset the `_flutterViewController`,
     // so that all the touch events in the same sequence are forwarded to the same
     // `_flutterViewController`.

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -539,7 +539,7 @@ static BOOL _preparedOnce = NO;
     // For hit test, don't block gestures using delaying recognizer. However, we still
     // forward touches so Flutter can process it in its gesture arena (e.g. dismiss a
     // drop-down menu when tapping outside of the menu but inside the platform view).
-    if (blockingPolicy != FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest) {
+    if (blockingPolicy != FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
       [self addGestureRecognizer:_delayingRecognizer];
     }
     [self addGestureRecognizer:forwardingRecognizer];
@@ -581,7 +581,7 @@ static BOOL _preparedOnce = NO;
 }
 
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest) {
+  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly) {
     CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
     // Block gesture if the framework instructed so (after performing its own hitTest).
     if (![self.flutterViewController
@@ -595,7 +595,7 @@ static BOOL _preparedOnce = NO;
 
 - (void)blockGesture {
   switch (_blockingPolicy) {
-    case FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest:
+    case FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly:
       // No-op. Handled by hit test.
       break;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -355,8 +355,10 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                  isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
-    NSString* errorMessage = [NSString
-        stringWithFormat:@"Unsupported gesture blocking policy: %@, so we fallback to use the policy set via engine API.", gestureBlockingPolicyValue];
+    NSString* errorMessage =
+        [NSString stringWithFormat:@"Unsupported gesture blocking policy: %@, so we fallback to "
+                                   @"use the policy set via engine API.",
+                                   gestureBlockingPolicyValue];
     [FlutterLogger logError:errorMessage];
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -341,22 +341,25 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 
   NSString* gestureBlockingPolicyValue = args[@"gestureBlockingPolicy"];
   FlutterPlatformViewGestureRecognizersBlockingPolicy gestureBlockingPolicy;
-  if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyTouchBlockingOnly]) {
+  if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyTouchBlockingOnly]) {
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly;
-  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyEagerValue]) {
+  } else if ([gestureBlockingPolicyValue isEqualToString:kGestureBlockingPolicyEagerValue]) {
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
-  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyWaitUntilTouchesEndedValue]) {
-    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded;
-  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyFallbackToPluginDefault]) {
+  } else if ([gestureBlockingPolicyValue
+                 isEqualToString:kGestureBlockingPolicyWaitUntilTouchesEndedValue]) {
+    gestureBlockingPolicy =
+        FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded;
+  } else if ([gestureBlockingPolicyValue
+                 isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
   }
 
-  FlutterTouchInterceptingView* touchInterceptor = [[FlutterTouchInterceptingView alloc]
-                  initWithEmbeddedView:platformView
-               platformViewsController:self
-      gestureRecognizersBlockingPolicy: gestureBlockingPolicy];
+  FlutterTouchInterceptingView* touchInterceptor =
+      [[FlutterTouchInterceptingView alloc] initWithEmbeddedView:platformView
+                                         platformViewsController:self
+                                gestureRecognizersBlockingPolicy:gestureBlockingPolicy];
 
   ChildClippingView* clippingView = [[ChildClippingView alloc] initWithFrame:CGRectZero];
   [clippingView addSubview:touchInterceptor];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -22,6 +22,11 @@ using flutter::DlRoundRect;
 
 static constexpr NSUInteger kFlutterClippingMaskViewPoolCapacity = 5;
 
+static NSString* const kGestureBlockingPolicyEagerValue = @"eager";
+static NSString* const kGestureBlockingPolicyWaitUntilTouchesEndedValue = @"waitUntilTouchesEnded";
+static NSString* const kGestureBlockingPolicyFallbackToPluginDefault = @"fallbackToPluginDefault";
+static NSString* const kGestureBlockingPolicyTouchBlockingOnly = @"touchBlockingOnly";
+
 struct LayerData {
   DlRect rect;
   int64_t view_id;
@@ -101,7 +106,12 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 // The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
 @property(nonatomic, readonly)
     std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
-        gestureRecognizersBlockingPolicies;
+        gestureRecognizersBlockingPoliciesByType;
+
+// The FlutterPlatformViewGestureRecognizersBlockingPolicy for each instance of platform view.
+@property(nonatomic, readonly)
+    std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
+        gestureRecognizersBlockingPoliciesByViewId;
 
 /// The size of the current onscreen surface in physical pixels.
 @property(nonatomic, assign) DlISize frameSize;
@@ -236,7 +246,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::unordered_map<int64_t, std::unique_ptr<flutter::EmbedderViewSlice>> _slices;
   std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*> _factories;
   std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
-      _gestureRecognizersBlockingPolicies;
+      _gestureRecognizersBlockingPoliciesByType;
+  std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>
+      _gestureRecognizersBlockingPoliciesByViewId;
   fml::RefPtr<fml::TaskRunner> _platformTaskRunner;
   std::unordered_map<int64_t, PlatformViewData> _platformViews;
   std::unordered_map<int64_t, flutter::EmbeddedViewParams> _currentCompositionParams;
@@ -327,10 +339,24 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   // Set a unique view identifier, so the platform view can be identified in unit tests.
   platformView.accessibilityIdentifier = [NSString stringWithFormat:@"platform_view[%lld]", viewId];
 
+  NSString* gestureBlockingPolicyValue = args[@"gestureBlockingPolicy"];
+  FlutterPlatformViewGestureRecognizersBlockingPolicy gestureBlockingPolicy;
+  if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyTouchBlockingOnly]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly;
+  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyEagerValue]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
+  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyWaitUntilTouchesEndedValue]) {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded;
+  } else if ([gestureBlockingPolicyValue isEqualToString: kGestureBlockingPolicyFallbackToPluginDefault]) {
+    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
+  } else {
+    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
+  }
+
   FlutterTouchInterceptingView* touchInterceptor = [[FlutterTouchInterceptingView alloc]
                   initWithEmbeddedView:platformView
                platformViewsController:self
-      gestureRecognizersBlockingPolicy:self.gestureRecognizersBlockingPolicies[viewType]];
+      gestureRecognizersBlockingPolicy: gestureBlockingPolicy];
 
   ChildClippingView* clippingView = [[ChildClippingView alloc] initWithFrame:CGRectZero];
   [clippingView addSubview:touchInterceptor];
@@ -400,7 +426,7 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::string idString([factoryId UTF8String]);
   FML_CHECK(self.factories.count(idString) == 0);
   self.factories[idString] = factory;
-  self.gestureRecognizersBlockingPolicies[idString] = gestureRecognizerBlockingPolicy;
+  self.gestureRecognizersBlockingPoliciesByType[idString] = gestureRecognizerBlockingPolicy;
 }
 
 - (void)beginFrameWithSize:(DlISize)frameSize {
@@ -989,9 +1015,15 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 - (std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*>&)factories {
   return _factories;
 }
+
 - (std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
-    gestureRecognizersBlockingPolicies {
-  return _gestureRecognizersBlockingPolicies;
+    gestureRecognizersBlockingPoliciesByType {
+  return _gestureRecognizersBlockingPoliciesByType;
+}
+
+- (std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
+    gestureRecognizersBlockingPoliciesByViewId {
+  return _gestureRecognizersBlockingPoliciesByViewId;
 }
 
 - (std::unordered_map<int64_t, PlatformViewData>&)platformViews {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -9,9 +9,9 @@
 #include "flutter/flow/surface_frame.h"
 #include "flutter/flow/view_slicer.h"
 #include "flutter/fml/logging.h"
-#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h"
@@ -355,8 +355,8 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                  isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
-    NSString* errorMessage =
-        [NSString stringWithFormat:@"Unsupported gesture blocking policy: %@", gestureBlockingPolicyValue];
+    NSString* errorMessage = [NSString
+        stringWithFormat:@"Unsupported gesture blocking policy: %@", gestureBlockingPolicyValue];
     [FlutterLogger logError:errorMessage];
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
   }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -8,6 +8,8 @@
 #include "flutter/display_list/utils/dl_matrix_clip_tracker.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/flow/view_slicer.h"
+#include "flutter/fml/logging.h"
+#import "flutter/shell/platform/darwin/common/InternalFlutterSwiftCommon/InternalFlutterSwiftCommon.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
@@ -353,6 +355,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
                  isEqualToString:kGestureBlockingPolicyFallbackToPluginDefault]) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
+    NSString* errorMessage =
+        [NSString stringWithFormat:@"Unsupported gesture blocking policy: %@", gestureBlockingPolicyValue];
+    [FlutterLogger logError:errorMessage];
     gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
   }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -356,9 +356,9 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
     gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   } else {
     NSString* errorMessage = [NSString
-        stringWithFormat:@"Unsupported gesture blocking policy: %@", gestureBlockingPolicyValue];
+        stringWithFormat:@"Unsupported gesture blocking policy: %@, so we fallback to use the policy set via engine API.", gestureBlockingPolicyValue];
     [FlutterLogger logError:errorMessage];
-    gestureBlockingPolicy = FlutterPlatformViewGestureRecognizersBlockingPolicyEager;
+    gestureBlockingPolicy = self.gestureRecognizersBlockingPoliciesByType[viewType];
   }
 
   FlutterTouchInterceptingView* touchInterceptor =

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -110,11 +110,6 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
     std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
         gestureRecognizersBlockingPoliciesByType;
 
-// The FlutterPlatformViewGestureRecognizersBlockingPolicy for each instance of platform view.
-@property(nonatomic, readonly)
-    std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>&
-        gestureRecognizersBlockingPoliciesByViewId;
-
 /// The size of the current onscreen surface in physical pixels.
 @property(nonatomic, assign) DlISize frameSize;
 
@@ -249,8 +244,6 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
   std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*> _factories;
   std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
       _gestureRecognizersBlockingPoliciesByType;
-  std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>
-      _gestureRecognizersBlockingPoliciesByViewId;
   fml::RefPtr<fml::TaskRunner> _platformTaskRunner;
   std::unordered_map<int64_t, PlatformViewData> _platformViews;
   std::unordered_map<int64_t, flutter::EmbeddedViewParams> _currentCompositionParams;
@@ -1029,11 +1022,6 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
 - (std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
     gestureRecognizersBlockingPoliciesByType {
   return _gestureRecognizersBlockingPoliciesByType;
-}
-
-- (std::unordered_map<int64_t, FlutterPlatformViewGestureRecognizersBlockingPolicy>&)
-    gestureRecognizersBlockingPoliciesByViewId {
-  return _gestureRecognizersBlockingPoliciesByViewId;
 }
 
 - (std::unordered_map<int64_t, PlatformViewData>&)platformViews {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -252,7 +252,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -252,7 +252,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;
@@ -331,7 +331,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -389,7 +390,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -484,7 +486,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -566,7 +569,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -648,7 +652,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -731,7 +736,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -860,7 +866,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -1016,7 +1023,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -1320,8 +1328,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1651,8 +1659,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1715,8 +1723,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1824,8 +1832,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1902,8 +1910,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1978,8 +1986,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2053,8 +2061,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2133,8 +2141,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2233,8 +2241,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2341,8 +2349,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2466,8 +2474,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2574,8 +2582,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2699,8 +2707,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2768,8 +2776,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2894,8 +2902,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3009,8 +3017,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3075,8 +3083,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3181,7 +3189,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   [flutterPlatformViewsController
       onMethodCall:[FlutterMethodCall
                        methodCallWithMethodName:@"create"
-                                      arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+                                      arguments:@{@"id" : @2, @"viewType" : @"MockWebView", @"gestureBlockingPolicy": @"eager"     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3322,7 +3330,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockNestedWrapperWebView"
+                                                       @"viewType" : @"MockNestedWrapperWebView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -3381,8 +3390,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3439,8 +3448,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3489,8 +3498,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3545,8 +3554,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3566,7 +3575,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
 
   OCMStub([mockFlutterViewController
-              platformViewShouldAcceptGestureAtTouchBeganLocation:touchBeganLocation])
+              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
       .andReturn(YES);
   UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
   XCTAssert(hitTestResult == gMockPlatformView);
@@ -3607,8 +3616,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
-                                                     }]
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3628,11 +3637,110 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   OCMStub([mockEvent type]).andReturn(UIEventTypeTouches);
 
   OCMStub([mockFlutterViewController
-              platformViewShouldAcceptGestureAtTouchBeganLocation:touchBeganLocation])
+              platformViewShouldAcceptTouchAtTouchBeganLocation:touchBeganLocation])
       .andReturn(NO);
   UIView* hitTestResult = [touchInterceptorView hitTest:touchBeganLocation withEvent:mockEvent];
   XCTAssert(hitTestResult == touchInterceptorView);
 }
+
+- (void)testFlutterPlatformViewGestureBlockingPolicyMapping {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+
+  FlutterViewController* mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  flutterPlatformViewsController.flutterViewController = mockFlutterViewController;
+
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
+  [flutterPlatformViewsController
+                   registerViewFactory:factory
+                                withId:@"MockFlutterPlatformView"
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
+  FlutterResult result = ^(id result) {
+  };
+
+  // eager
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
+                                                     }]
+            result:result];
+  UIView* touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
+
+  // waitUntilTouchesEnded
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @3,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"waitUntilTouchesEnded"
+                                                     }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+
+
+  // touchBlockingOnly
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @4,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"
+                                                     }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly);
+
+  // fallbackToPluginDefault (which is waitUntilTouchesEnded)
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @5,
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"fallbackToPluginDefault"
+                                                     }]
+            result:result];
+  touchInterceptorView = gMockPlatformView;
+  while (touchInterceptorView != nil &&
+         ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInterceptorView = touchInterceptorView.superview;
+  }
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+}
+
 
 - (void)testFlutterPlatformViewControllerSubmitFrameWithoutFlutterViewNotCrashing {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
@@ -3665,7 +3773,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -3749,7 +3858,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
         onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                        arguments:@{
                                                          @"id" : @2,
-                                                         @"viewType" : @"MockFlutterPlatformView"
+                                                         @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                        }]
               result:result];
 
@@ -3804,7 +3914,9 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
+
                                                      }]
             result:result];
 
@@ -3872,7 +3984,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -3882,7 +3995,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -3979,7 +4093,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -3989,7 +4104,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4170,7 +4286,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4220,7 +4337,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4272,7 +4390,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4282,7 +4401,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4360,7 +4480,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4460,14 +4581,16 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   [flutterPlatformViewsController
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4574,7 +4697,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4644,7 +4768,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4716,7 +4841,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4817,7 +4943,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @0,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4826,7 +4953,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @1,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 
@@ -4898,7 +5026,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
                                                      arguments:@{
                                                        @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView"
+                                                       @"viewType" : @"MockFlutterPlatformView",
+                                                       @"gestureBlockingPolicy": @"eager"
                                                      }]
             result:result];
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -3490,7 +3490,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
 }
 
-- (void)testFlutterPlatformViewBlockGestureUnderNonHitTestPolicyShouldNotAddDelayingRecognizer {
+- (void)testFlutterPlatformViewBlockGestureUnderNonHitTestPolicyShouldAddDelayingRecognizer {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
 
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -3432,7 +3432,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   [flutterPlatformViewsController
                    registerViewFactory:factory
                                 withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest];
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
@@ -3538,7 +3538,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   [flutterPlatformViewsController
                    registerViewFactory:factory
                                 withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest];
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
@@ -3600,7 +3600,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   [flutterPlatformViewsController
                    registerViewFactory:factory
                                 withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest];
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -254,7 +254,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   }
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override {
+      const flutter::PointData touch_began_location) override {
     return false;
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -332,7 +332,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -391,7 +391,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -487,7 +487,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -570,7 +570,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -653,7 +653,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -737,7 +737,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -867,7 +867,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1024,7 +1024,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -1329,7 +1329,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1660,7 +1661,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1724,7 +1726,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1833,7 +1836,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1911,7 +1915,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -1987,7 +1992,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2062,7 +2068,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2142,7 +2149,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2242,7 +2250,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2350,7 +2359,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2475,7 +2485,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2583,7 +2594,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2708,7 +2720,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2777,7 +2790,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -2903,7 +2917,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3018,7 +3033,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3084,7 +3100,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3187,9 +3204,12 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall
-                       methodCallWithMethodName:@"create"
-                                      arguments:@{@"id" : @2, @"viewType" : @"MockWebView", @"gestureBlockingPolicy": @"eager"     }]
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockWebView",
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3331,7 +3351,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockNestedWrapperWebView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3391,7 +3411,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3438,18 +3459,20 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3499,7 +3522,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3544,10 +3568,10 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
@@ -3555,7 +3579,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"                                                     }]
+                                                       @"gestureBlockingPolicy" : @"eager"
+                                                     }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3606,18 +3631,20 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly];
   FlutterResult result = ^(id result) {
   };
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @2,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
             result:result];
 
   XCTAssertNotNil(gMockPlatformView);
@@ -3668,10 +3695,10 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockFlutterPlatformView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
+  [flutterPlatformViewsController registerViewFactory:factory
+                                               withId:@"MockFlutterPlatformView"
+                     gestureRecognizersBlockingPolicy:
+                         FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded];
   FlutterResult result = ^(id result) {
   };
 
@@ -3681,7 +3708,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* touchInterceptorView = gMockPlatformView;
@@ -3689,58 +3716,63 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
          ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
     touchInterceptorView = touchInterceptorView.superview;
   }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
 
   // waitUntilTouchesEnded
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @3,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"waitUntilTouchesEnded"
-                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @3,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"waitUntilTouchesEnded"
+                                      }]
             result:result];
   touchInterceptorView = gMockPlatformView;
   while (touchInterceptorView != nil &&
          ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
     touchInterceptorView = touchInterceptorView.superview;
   }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
-
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
 
   // touchBlockingOnly
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @4,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"touchBlockingOnly"
-                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @4,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"touchBlockingOnly"
+                                      }]
             result:result];
   touchInterceptorView = gMockPlatformView;
   while (touchInterceptorView != nil &&
          ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
     touchInterceptorView = touchInterceptorView.superview;
   }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly);
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyTouchBlockingOnly);
 
   // fallbackToPluginDefault (which is waitUntilTouchesEnded)
   [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @5,
-                                                       @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"fallbackToPluginDefault"
-                                                     }]
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{
+                                        @"id" : @5,
+                                        @"viewType" : @"MockFlutterPlatformView",
+                                        @"gestureBlockingPolicy" : @"fallbackToPluginDefault"
+                                      }]
             result:result];
   touchInterceptorView = gMockPlatformView;
   while (touchInterceptorView != nil &&
          ![touchInterceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
     touchInterceptorView = touchInterceptorView.superview;
   }
-  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy, FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
+  XCTAssertEqual(((FlutterTouchInterceptingView*)touchInterceptorView).blockingPolicy,
+                 FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded);
 }
-
 
 - (void)testFlutterPlatformViewControllerSubmitFrameWithoutFlutterViewNotCrashing {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
@@ -3774,7 +3806,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -3859,7 +3891,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                        arguments:@{
                                                          @"id" : @2,
                                                          @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                         @"gestureBlockingPolicy" : @"eager"
                                                        }]
               result:result];
 
@@ -3915,7 +3947,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @0,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
 
                                                      }]
             result:result];
@@ -3985,7 +4017,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @0,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -3996,7 +4028,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4094,7 +4126,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @0,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4105,7 +4137,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4287,7 +4319,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4338,7 +4370,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4391,7 +4423,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view1 = gMockPlatformView;
@@ -4402,7 +4434,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* view2 = gMockPlatformView;
@@ -4481,7 +4513,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4582,7 +4614,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @0,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   [flutterPlatformViewsController
@@ -4590,7 +4622,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4698,7 +4730,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4769,7 +4801,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4842,7 +4874,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
   UIView* flutterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 500, 500)];
@@ -4944,7 +4976,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @0,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -4954,7 +4986,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @1,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 
@@ -5027,7 +5059,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                                      arguments:@{
                                                        @"id" : @2,
                                                        @"viewType" : @"MockFlutterPlatformView",
-                                                       @"gestureBlockingPolicy": @"eager"
+                                                       @"gestureBlockingPolicy" : @"eager"
                                                      }]
             result:result];
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -148,6 +148,7 @@
 
 // Sets flutterAccessibilityContainer as this view's accessibilityContainer.
 @property(nonatomic, retain) id flutterAccessibilityContainer;
+@property(nonatomic, readonly) FlutterPlatformViewGestureRecognizersBlockingPolicy blockingPolicy;
 @end
 
 @interface UIView (FirstResponder)

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -102,6 +102,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -102,7 +102,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -102,7 +102,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -104,7 +104,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   }
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override {
+      const flutter::PointData touch_began_location) override {
     return false;
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1384,9 +1384,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self dispatchTouches:touches pointerDataChangeOverride:&cancel event:nullptr];
 }
 
-- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location {
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(CGPoint)location {
   flutter::PointData point{location.x, location.y};
-  return [self.engine platformViewShouldAcceptGestureAtTouchBeganLocation:point
+  return [self.engine platformViewShouldAcceptTouchAtTouchBeganLocation:point
                                                                    viewId:self.viewIdentifier];
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1384,6 +1384,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self dispatchTouches:touches pointerDataChangeOverride:&cancel event:nullptr];
 }
 
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location {
+  flutter::PointData point{location.x, location.y};
+  return [self.engine platformViewShouldAcceptGestureAtTouchBeganLocation:point
+                                                                   viewId:self.viewIdentifier];
+}
+
 #pragma mark - Touch events rate correction
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1387,7 +1387,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(CGPoint)location {
   flutter::PointData point{location.x, location.y};
   return [self.engine platformViewShouldAcceptTouchAtTouchBeganLocation:point
-                                                                   viewId:self.viewIdentifier];
+                                                                 viewId:self.viewIdentifier];
 }
 
 #pragma mark - Touch events rate correction

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)forceTouchesCancelled:(NSSet*)touches;
 
+/**
+ * Returns YES if a platform view should accept the gesture started at specified location.
+ * Returns NO otherwise. The touch location is with respect to flutter view's coordinate space.
+ */
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location;
+
 @end
 NS_ASSUME_NONNULL_END
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns YES if a platform view should accept the gesture started at specified location.
  * Returns NO otherwise. The touch location is with respect to flutter view's coordinate space.
  */
-- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location;
+- (BOOL)platformViewShouldAcceptTouchAtTouchBeganLocation:(CGPoint)location;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,6 +82,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,7 +82,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,7 +82,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -84,7 +84,7 @@ class MockDelegate : public PlatformView::Delegate {
   }
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override {
+      const flutter::PointData touch_began_location) override {
     return false;
   }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,7 +30,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,6 +30,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -32,7 +32,7 @@ class MockDelegate : public PlatformView::Delegate {
   }
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) override {
+      const flutter::PointData touch_began_location) override {
     return false;
   }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,7 +30,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -52,6 +52,10 @@ class MockDelegate : public PlatformView::Delegate {
               OnPlatformViewDispatchPointerDataPacket,
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (override));
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -53,7 +53,7 @@ class MockDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -53,7 +53,7 @@ class MockDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -54,7 +54,7 @@ class MockDelegate : public PlatformView::Delegate {
               (override));
   MOCK_METHOD(bool,
               OnPlatformViewEmbeddedNativeViewShouldAcceptTouch,
-              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (int64_t view_id, const flutter::PointData touch_began_location),
               (override));
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
@@ -16,6 +16,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/make_copyable.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,6 +117,12 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) {
+    return false;
+  }
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchKeyDataPacket(
       std::unique_ptr<flutter::KeyDataPacket> packet,
       std::function<void(bool)> callback) {}

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,7 +117,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) {
     return false;

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,7 +117,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
-  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
       const flutter::PointData& touch_began_location) {
     return false;

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -119,7 +119,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   // |flutter::PlatformView::Delegate|
   bool OnPlatformViewEmbeddedNativeViewShouldAcceptTouch(
       int64_t view_id,
-      const flutter::PointData& touch_began_location) {
+      const flutter::PointData touch_began_location) {
     return false;
   }
   // |flutter::PlatformView::Delegate|

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -14,6 +14,7 @@ import 'dart:collection';
 import 'dart:ui' as ui show PointerDataPacket;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'arena.dart';
@@ -278,7 +279,9 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void initInstances() {
     super.initInstances();
     _instance = this;
-    platformDispatcher.onPointerDataPacket = _handlePointerDataPacket;
+    platformDispatcher
+      ..onPointerDataPacket = _handlePointerDataPacket
+      ..onPlatformViewShouldAcceptGesture = _handlePlatformViewShouldAcceptGesture;
   }
 
   /// The singleton instance of this object.
@@ -317,6 +320,17 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
         ),
       );
     }
+  }
+
+  bool _handlePlatformViewShouldAcceptGesture(int viewId, double x, double y) {
+    final HitTestResult result = HitTestResult();
+    hitTestInView(result, Offset(x, y), viewId);
+
+    if (result.path.isEmpty) {
+      return false;
+    }
+    final HitTestTarget firstHit = result.path.first.target;
+    return firstHit is RenderUiKitView;
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -14,7 +14,6 @@ import 'dart:collection';
 import 'dart:ui' as ui show PointerDataPacket;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'arena.dart';
@@ -37,6 +36,9 @@ export 'pointer_router.dart' show PointerRouter;
 export 'pointer_signal_resolver.dart' show PointerSignalResolver;
 
 typedef _HandleSampleTimeChangedCallback = void Function();
+
+/// Abstract class that represents a hit test target backed by a embedded native view.
+abstract class NativeHitTestTarget {}
 
 /// Class that implements clock used for sampling.
 class SamplingClock {
@@ -330,7 +332,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
       return false;
     }
     final HitTestTarget firstHit = result.path.first.target;
-    return firstHit is RenderUiKitView;
+    return firstHit is NativeHitTestTarget;
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -283,7 +283,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     _instance = this;
     platformDispatcher
       ..onPointerDataPacket = _handlePointerDataPacket
-      ..onPlatformViewShouldAcceptGesture = _handlePlatformViewShouldAcceptGesture;
+      ..onPlatformViewShouldAcceptTouch = _handlePlatformViewShouldAcceptTouch;
   }
 
   /// The singleton instance of this object.
@@ -324,7 +324,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     }
   }
 
-  bool _handlePlatformViewShouldAcceptGesture(int viewId, double x, double y) {
+  bool _handlePlatformViewShouldAcceptTouch(int viewId, double x, double y) {
     final HitTestResult result = HitTestResult();
     hitTestInView(result, Offset(x, y), viewId);
 

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -325,11 +325,11 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   }
 
   ui.HitTestResponse _handleHitTest(ui.HitTestRequest request) {
-    final HitTestResult result = HitTestResult();
+    final result = HitTestResult();
     hitTestInView(result, request.offset, request.view.viewId);
 
     if (result.path.isEmpty) {
-      return ui.HitTestResponse();
+      return const ui.HitTestResponse();
     }
     final HitTestTarget firstHit = result.path.first.target;
     return ui.HitTestResponse(isPlatformView: firstHit is NativeHitTestTarget);

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -329,7 +329,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     hitTestInView(result, request.offset, request.view.viewId);
 
     if (result.path.isEmpty) {
-      return const ui.HitTestResponse();
+      return ui.HitTestResponse.empty;
     }
     final HitTestTarget firstHit = result.path.first.target;
     return ui.HitTestResponse(isPlatformView: firstHit is NativeHitTestTarget);

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -11,7 +11,7 @@ library;
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:ui' as ui show PointerDataPacket;
+import 'dart:ui' as ui show HitTestRequest, HitTestResponse, PointerDataPacket;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
@@ -283,7 +283,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     _instance = this;
     platformDispatcher
       ..onPointerDataPacket = _handlePointerDataPacket
-      ..onPlatformViewShouldAcceptTouch = _handlePlatformViewShouldAcceptTouch;
+      ..onHitTest = _handleHitTest;
   }
 
   /// The singleton instance of this object.
@@ -324,15 +324,15 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
     }
   }
 
-  bool _handlePlatformViewShouldAcceptTouch(int viewId, double x, double y) {
+  ui.HitTestResponse _handleHitTest(ui.HitTestRequest request) {
     final HitTestResult result = HitTestResult();
-    hitTestInView(result, Offset(x, y), viewId);
+    hitTestInView(result, request.offset, request.view.viewId);
 
     if (result.path.isEmpty) {
-      return false;
+      return ui.HitTestResponse();
     }
     final HitTestTarget firstHit = result.path.first.target;
-    return firstHit is NativeHitTestTarget;
+    return ui.HitTestResponse(isPlatformView: firstHit is NativeHitTestTarget);
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -408,7 +408,8 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 ///
 ///  * [UiKitView], which is a widget that is used to show a UIView.
 ///  * [PlatformViewsService], which is a service for controlling platform views.
-class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController> {
+class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController>
+    implements NativeHitTestTarget {
   /// Creates a render object for an iOS UIView.
   RenderUiKitView({
     required super.viewController,

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -257,7 +257,8 @@ class PlatformViewsService {
   static Future<UiKitViewController> initUiKitView({
     required int id,
     required String viewType,
-    required UiKitViewGestureBlockingPolicy gestureBlockingPolicy,
+    UiKitViewGestureBlockingPolicy gestureBlockingPolicy =
+        UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
     required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic>? creationParamsCodec,
@@ -1611,7 +1612,7 @@ enum UiKitViewGestureBlockingPolicy {
   /// https://github.com/flutter/flutter/issues/175099.
   touchBlockingOnly,
 
-  /// Fallback to use the policy set by `FlutterBaseRegistrar::registerViewFactory:withId:gestureRecognizersBlockingPolicy` API.
+  /// Fallback to use the policy set by the `registerViewFactory` engine API in FlutterPlugin.h.
   fallbackToPluginDefault,
 }
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -257,6 +257,7 @@ class PlatformViewsService {
   static Future<UiKitViewController> initUiKitView({
     required int id,
     required String viewType,
+    required UiKitViewGestureBlockingPolicy gestureBlockingPolicy,
     required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic>? creationParamsCodec,
@@ -264,9 +265,25 @@ class PlatformViewsService {
   }) async {
     assert(creationParams == null || creationParamsCodec != null);
 
+    final String gestureBlockingPolicyValue;
+    switch (gestureBlockingPolicy) {
+      case UiKitViewGestureBlockingPolicy.eager:
+        gestureBlockingPolicyValue = 'eager';
+      case UiKitViewGestureBlockingPolicy.waitUntilTouchesEnded:
+        gestureBlockingPolicyValue = 'waitUntilTouchesEnded';
+      case UiKitViewGestureBlockingPolicy.fallbackToPluginDefault:
+        gestureBlockingPolicyValue = 'fallbackToPluginDefault';
+      case UiKitViewGestureBlockingPolicy.touchBlockingOnly:
+        gestureBlockingPolicyValue = 'touchBlockingOnly';
+    }
+
     // TODO(amirh): pass layoutDirection once the system channel supports it.
     // https://github.com/flutter/flutter/issues/133682
-    final args = <String, dynamic>{'id': id, 'viewType': viewType};
+    final args = <String, dynamic>{
+      'id': id,
+      'viewType': viewType,
+      'gestureBlockingPolicy': gestureBlockingPolicyValue,
+    };
     if (creationParams != null) {
       final ByteData paramsByteData = creationParamsCodec!.encodeMessage(creationParams)!;
       args['params'] = Uint8List.view(paramsByteData.buffer, 0, paramsByteData.lengthInBytes);
@@ -1572,6 +1589,30 @@ abstract class DarwinPlatformViewController {
     await SystemChannels.platform_views.invokeMethod<void>('dispose', id);
     PlatformViewsService._instance._focusCallbacks.remove(id);
   }
+}
+
+/// How touch event callbacks and gesture recognizers of a platform view are blocked.
+/// This replaces engine's FlutterPlatformViewGestureRecognizersBlockingPolicy enum in FlutterPlugin.h.
+enum UiKitViewGestureBlockingPolicy {
+  /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+  /// decides they should be blocked.
+  eager,
+
+  /// Flutter blocks the platform view's UIGestureRecognizers from recognizing only after
+  /// touchesEnded was invoked.
+  waitUntilTouchesEnded,
+
+  /// Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+  /// decides they should be blocked.
+  ///
+  /// This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
+  /// internally it performs hit test rather than a blocking gesture recognizer. This addresses
+  /// a few bugs related to WKWebView being untappable. See
+  /// https://github.com/flutter/flutter/issues/175099.
+  touchBlockingOnly,
+
+  /// Fallback to use the policy set by `FlutterBaseRegistrar::registerViewFactory:withId:gestureRecognizersBlockingPolicy` API.
+  fallbackToPluginDefault,
 }
 
 /// Controller for an iOS platform view.

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -317,6 +317,7 @@ class UiKitView extends _DarwinView {
   const UiKitView({
     super.key,
     required super.viewType,
+    this.gestureBlockingPolicy = UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
     super.onPlatformViewCreated,
     super.hitTestBehavior = PlatformViewHitTestBehavior.opaque,
     super.layoutDirection,
@@ -324,6 +325,9 @@ class UiKitView extends _DarwinView {
     super.creationParamsCodec,
     super.gestureRecognizers,
   }) : assert(creationParams == null || creationParamsCodec != null);
+
+  /// The gesture blocking policy that controls touch and gesture blocking behaviors.
+  final UiKitViewGestureBlockingPolicy gestureBlockingPolicy;
 
   @override
   State<UiKitView> createState() => _UiKitViewState();
@@ -965,6 +969,7 @@ class _UiKitViewState
     return PlatformViewsService.initUiKitView(
       id: id,
       viewType: widget.viewType,
+      gestureBlockingPolicy: widget.gestureBlockingPolicy,
       layoutDirection: _layoutDirection!,
       creationParams: widget.creationParams,
       creationParamsCodec: widget.creationParamsCodec,

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -107,7 +107,7 @@ void main() {
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
     final ui.HitTestResponse repsonse =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        const ui.HitTestResponse();
+        ui.HitTestResponse.empty;
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -120,7 +120,7 @@ void main() {
     final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
     final ui.HitTestResponse repsonse =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        const ui.HitTestResponse();
+        ui.HitTestResponse.empty;
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -135,7 +135,7 @@ void main() {
 
     final ui.HitTestResponse repsonse =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        const ui.HitTestResponse();
+        ui.HitTestResponse.empty;
 
     expect(repsonse.isPlatformView, isFalse);
   });
@@ -151,7 +151,7 @@ void main() {
 
     final ui.HitTestResponse repsonse =
         GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
-        const ui.HitTestResponse();
+        ui.HitTestResponse.empty;
 
     expect(repsonse.isPlatformView, isTrue);
   });

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -101,7 +101,7 @@ void main() {
     final bool? acceptGesture = GestureBinding
         .instance
         .platformDispatcher
-        .onPlatformViewShouldAcceptGesture
+        .onPlatformViewShouldAcceptTouch
         ?.call(0, 1, 1);
     expect(acceptGesture, isFalse);
   });
@@ -114,7 +114,7 @@ void main() {
     final bool? acceptGesture = GestureBinding
         .instance
         .platformDispatcher
-        .onPlatformViewShouldAcceptGesture
+        .onPlatformViewShouldAcceptTouch
         ?.call(0, 1, 1);
     expect(acceptGesture, isFalse);
   });
@@ -129,7 +129,7 @@ void main() {
     final bool? acceptGesture = GestureBinding
         .instance
         .platformDispatcher
-        .onPlatformViewShouldAcceptGesture
+        .onPlatformViewShouldAcceptTouch
         ?.call(0, 1, 1);
     expect(acceptGesture, isFalse);
   });
@@ -144,7 +144,7 @@ void main() {
     final bool? acceptGesture = GestureBinding
         .instance
         .platformDispatcher
-        .onPlatformViewShouldAcceptGesture
+        .onPlatformViewShouldAcceptTouch
         ?.call(0, 1, 1);
     expect(acceptGesture, isTrue);
   });

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -108,9 +108,8 @@ void main() {
       view: _FakeFlutterView(),
       offset: const Offset(1, 1),
     );
-    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
-      request,
-    );
+    final ui.HitTestResponse repsonse =
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -124,9 +123,8 @@ void main() {
       view: _FakeFlutterView(),
       offset: const Offset(1, 1),
     );
-    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
-      request,
-    );
+    final ui.HitTestResponse repsonse =
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -142,9 +140,8 @@ void main() {
       offset: const Offset(1, 1),
     );
 
-    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
-      request,
-    );
+    final ui.HitTestResponse repsonse =
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
 
     expect(repsonse.isPlatformView, isFalse);
   });
@@ -161,9 +158,8 @@ void main() {
       offset: const Offset(1, 1),
     );
 
-    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
-      request,
-    );
+    final ui.HitTestResponse repsonse =
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
 
     expect(repsonse.isPlatformView, isTrue);
   });

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -81,6 +81,11 @@ class _DummyNativeHitTestTarget implements NativeHitTestTarget, HitTestTarget {
   }
 }
 
+class _FakeFlutterView extends Fake implements FlutterView {
+  @override
+  final int viewId = 0;
+}
+
 void main() {
   final TestGestureFlutterBinding binding = TestGestureFlutterBinding.ensureInitialized();
 
@@ -98,12 +103,15 @@ void main() {
     // not found
     TestGestureFlutterBinding.instance.onHitTestInView =
         (HitTestResult result, Offset position, int viewId) {};
-    final bool? acceptGesture = GestureBinding
-        .instance
-        .platformDispatcher
-        .onPlatformViewShouldAcceptTouch
-        ?.call(0, 1, 1);
-    expect(acceptGesture, isFalse);
+
+    final ui.HitTestRequest request = ui.HitTestRequest(
+      view: _FakeFlutterView(),
+      offset: const Offset(1, 1),
+    );
+    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
+      request,
+    );
+    expect(repsonse.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should not accept gesture if no platform view', () {
@@ -111,12 +119,15 @@ void main() {
         (HitTestResult result, Offset position, int viewId) {
           result.add(HitTestEntry(_DummyHitTestTarget()));
         };
-    final bool? acceptGesture = GestureBinding
-        .instance
-        .platformDispatcher
-        .onPlatformViewShouldAcceptTouch
-        ?.call(0, 1, 1);
-    expect(acceptGesture, isFalse);
+
+    final ui.HitTestRequest request = ui.HitTestRequest(
+      view: _FakeFlutterView(),
+      offset: const Offset(1, 1),
+    );
+    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
+      request,
+    );
+    expect(repsonse.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should not accept gesture if first hit is not a platform view', () {
@@ -126,12 +137,16 @@ void main() {
           result.add(HitTestEntry(_DummyNativeHitTestTarget()));
         };
 
-    final bool? acceptGesture = GestureBinding
-        .instance
-        .platformDispatcher
-        .onPlatformViewShouldAcceptTouch
-        ?.call(0, 1, 1);
-    expect(acceptGesture, isFalse);
+    final ui.HitTestRequest request = ui.HitTestRequest(
+      view: _FakeFlutterView(),
+      offset: const Offset(1, 1),
+    );
+
+    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
+      request,
+    );
+
+    expect(repsonse.isPlatformView, isFalse);
   });
 
   test('Platform view hit test should accept gesture if first hit is a platform view', () {
@@ -141,12 +156,16 @@ void main() {
           result.add(HitTestEntry(_DummyHitTestTarget()));
         };
 
-    final bool? acceptGesture = GestureBinding
-        .instance
-        .platformDispatcher
-        .onPlatformViewShouldAcceptTouch
-        ?.call(0, 1, 1);
-    expect(acceptGesture, isTrue);
+    final ui.HitTestRequest request = ui.HitTestRequest(
+      view: _FakeFlutterView(),
+      offset: const Offset(1, 1),
+    );
+
+    final ui.HitTestResponse? repsonse = GestureBinding.instance.platformDispatcher.onHitTest?.call(
+      request,
+    );
+
+    expect(repsonse.isPlatformView, isTrue);
   });
 
   test('Pointer tap events', () {

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -6,12 +6,17 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 typedef HandleEventCallback = void Function(PointerEvent event);
+typedef HandleHitTestInViewCallback =
+    void Function(HitTestResult result, Offset position, int viewId);
 
-class TestGestureFlutterBinding extends BindingBase with GestureBinding, SchedulerBinding {
+class TestGestureFlutterBinding extends BindingBase
+    with GestureBinding, SchedulerBinding, ServicesBinding, TestDefaultBinaryMessengerBinding {
   @override
   void initInstances() {
     super.initInstances();
@@ -50,10 +55,118 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding, Schedul
     super.handleEvent(event, entry);
     onHandleEvent?.call(event);
   }
+
+  HandleHitTestInViewCallback? onHitTestInView;
+
+  @override
+  void hitTestInView(HitTestResult result, Offset position, int viewId) {
+    if (onHitTestInView != null) {
+      onHitTestInView!(result, position, viewId);
+      return;
+    }
+    super.hitTestInView(result, position, viewId);
+  }
+}
+
+class _DummyHitTestTarget implements HitTestTarget {
+  @override
+  void handleEvent(PointerEvent event, HitTestEntry entry) {
+    // Nothing to do.
+  }
 }
 
 void main() {
   final TestGestureFlutterBinding binding = TestGestureFlutterBinding.ensureInitialized();
+
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform_views, (
+    MethodCall methodCall,
+  ) async {
+    return null;
+  });
+
+  tearDown(() {
+    binding.onHitTestInView = null;
+  });
+
+  test('Platform view hit test should not accept gesture if no hit', () {
+    // not found
+    TestGestureFlutterBinding.instance.onHitTestInView =
+        (HitTestResult result, Offset position, int viewId) {};
+    final bool? acceptGesture = GestureBinding
+        .instance
+        .platformDispatcher
+        .onPlatformViewShouldAcceptGesture
+        ?.call(0, 1, 1);
+    expect(acceptGesture, isFalse);
+  });
+
+  test('Platform view hit test should not accept gesture if no platform view', () {
+    TestGestureFlutterBinding.instance.onHitTestInView =
+        (HitTestResult result, Offset position, int viewId) {
+          result.add(HitTestEntry(_DummyHitTestTarget()));
+        };
+    final bool? acceptGesture = GestureBinding
+        .instance
+        .platformDispatcher
+        .onPlatformViewShouldAcceptGesture
+        ?.call(0, 1, 1);
+    expect(acceptGesture, isFalse);
+  });
+
+  test(
+    'Platform view hit test should not accept gesture if first hit is not a platform view',
+    () async {
+      final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
+        id: 0,
+        viewType: 'webview',
+        layoutDirection: TextDirection.ltr,
+      );
+      final RenderUiKitView platformViewTarget = RenderUiKitView(
+        viewController: viewController,
+        hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+      );
+
+      TestGestureFlutterBinding.instance.onHitTestInView =
+          (HitTestResult result, Offset position, int viewId) {
+            result.add(HitTestEntry(_DummyHitTestTarget()));
+            result.add(HitTestEntry(platformViewTarget));
+          };
+
+      final bool? acceptGesture = GestureBinding
+          .instance
+          .platformDispatcher
+          .onPlatformViewShouldAcceptGesture
+          ?.call(0, 1, 1);
+      expect(acceptGesture, isFalse);
+    },
+  );
+
+  test('Platform view hit test should accept gesture if first hit is a platform view', () async {
+    final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
+      id: 0,
+      viewType: 'webview',
+      layoutDirection: TextDirection.ltr,
+    );
+    final RenderUiKitView platformViewTarget = RenderUiKitView(
+      viewController: viewController,
+      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+    );
+
+    TestGestureFlutterBinding.instance.onHitTestInView =
+        (HitTestResult result, Offset position, int viewId) {
+          result.add(HitTestEntry(platformViewTarget));
+          result.add(HitTestEntry(_DummyHitTestTarget()));
+        };
+
+    final bool? acceptGesture = GestureBinding
+        .instance
+        .platformDispatcher
+        .onPlatformViewShouldAcceptGesture
+        ?.call(0, 1, 1);
+    expect(acceptGesture, isTrue);
+  });
 
   test('Pointer tap events', () {
     const packet = ui.PointerDataPacket(

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -104,12 +104,10 @@ void main() {
     TestGestureFlutterBinding.instance.onHitTestInView =
         (HitTestResult result, Offset position, int viewId) {};
 
-    final ui.HitTestRequest request = ui.HitTestRequest(
-      view: _FakeFlutterView(),
-      offset: const Offset(1, 1),
-    );
+    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
     final ui.HitTestResponse repsonse =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+        const ui.HitTestResponse();
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -119,12 +117,10 @@ void main() {
           result.add(HitTestEntry(_DummyHitTestTarget()));
         };
 
-    final ui.HitTestRequest request = ui.HitTestRequest(
-      view: _FakeFlutterView(),
-      offset: const Offset(1, 1),
-    );
+    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
     final ui.HitTestResponse repsonse =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+        const ui.HitTestResponse();
     expect(repsonse.isPlatformView, isFalse);
   });
 
@@ -135,13 +131,11 @@ void main() {
           result.add(HitTestEntry(_DummyNativeHitTestTarget()));
         };
 
-    final ui.HitTestRequest request = ui.HitTestRequest(
-      view: _FakeFlutterView(),
-      offset: const Offset(1, 1),
-    );
+    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
     final ui.HitTestResponse repsonse =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+        const ui.HitTestResponse();
 
     expect(repsonse.isPlatformView, isFalse);
   });
@@ -153,13 +147,11 @@ void main() {
           result.add(HitTestEntry(_DummyHitTestTarget()));
         };
 
-    final ui.HitTestRequest request = ui.HitTestRequest(
-      view: _FakeFlutterView(),
-      offset: const Offset(1, 1),
-    );
+    final request = ui.HitTestRequest(view: _FakeFlutterView(), offset: const Offset(1, 1));
 
     final ui.HitTestResponse repsonse =
-        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ?? ui.HitTestResponse();
+        GestureBinding.instance.platformDispatcher.onHitTest?.call(request) ??
+        const ui.HitTestResponse();
 
     expect(repsonse.isPlatformView, isTrue);
   });

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -362,6 +362,7 @@ void main() {
       PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       ).then((UiKitViewController viewController) {
         final renderBox = RenderUiKitView(
@@ -421,6 +422,7 @@ void main() {
         PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'webview',
+          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ).then((UiKitViewController viewController) {
           final renderBox = RenderUiKitView(
@@ -453,6 +455,7 @@ void main() {
         PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'webview',
+          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ).then((UiKitViewController viewController) {
           final renderBox = RenderUiKitView(

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -362,7 +362,6 @@ void main() {
       PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       ).then((UiKitViewController viewController) {
         final renderBox = RenderUiKitView(
@@ -422,7 +421,6 @@ void main() {
         PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'webview',
-          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ).then((UiKitViewController viewController) {
           final renderBox = RenderUiKitView(
@@ -455,7 +453,6 @@ void main() {
         PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'webview',
-          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ).then((UiKitViewController viewController) {
           final renderBox = RenderUiKitView(

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -509,7 +509,6 @@ void main() {
         return PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'web',
-          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         );
       }, throwsA(isA<PlatformException>()));
@@ -520,13 +519,11 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       await PlatformViewsService.initUiKitView(
         id: 1,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.rtl,
       );
       expect(
@@ -543,14 +540,12 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       expect(
         () => PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'web',
-          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ),
         throwsA(isA<PlatformException>()),
@@ -562,7 +557,6 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
@@ -583,13 +577,11 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
         id: 1,
         viewType: 'webview',
-        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       await viewController.dispose();

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -509,6 +509,7 @@ void main() {
         return PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'web',
+          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         );
       }, throwsA(isA<PlatformException>()));
@@ -519,11 +520,13 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       await PlatformViewsService.initUiKitView(
         id: 1,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.rtl,
       );
       expect(
@@ -540,12 +543,14 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       expect(
         () => PlatformViewsService.initUiKitView(
           id: 0,
           viewType: 'web',
+          gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
           layoutDirection: TextDirection.ltr,
         ),
         throwsA(isA<PlatformException>()),
@@ -557,6 +562,7 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
@@ -577,11 +583,13 @@ void main() {
       await PlatformViewsService.initUiKitView(
         id: 0,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       final UiKitViewController viewController = await PlatformViewsService.initUiKitView(
         id: 1,
         viewType: 'webview',
+        gestureBlockingPolicy: UiKitViewGestureBlockingPolicy.fallbackToPluginDefault,
         layoutDirection: TextDirection.ltr,
       );
       await viewController.dispose();

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -279,7 +279,9 @@ class AssembleCommand extends FlutterCommand {
       }
       final int indexEquals = chunk.indexOf('=');
       if (indexEquals == -1) {
-        throwToolExit('Improperly formatted define flag: $chunk');
+        // TODO: revert this change. seems like a tools bug.
+        // throwToolExit('Improperly formatted define flag: $chunk');
+        continue;
       }
       final String key = chunk.substring(0, indexEquals);
       final String value = chunk.substring(indexEquals + 1);

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -279,9 +279,7 @@ class AssembleCommand extends FlutterCommand {
       }
       final int indexEquals = chunk.indexOf('=');
       if (indexEquals == -1) {
-        // TODO: revert this change. seems like a tools bug.
-        // throwToolExit('Improperly formatted define flag: $chunk');
-        continue;
+        throwToolExit('Improperly formatted define flag: $chunk');
       }
       final String key = chunk.substring(0, indexEquals);
       final String value = chunk.substring(indexEquals + 1);


### PR DESCRIPTION
This is a follow up PR to [this original PR](https://github.com/flutter/flutter/pull/177859). 

The difference is the API - the original PR chooses Option 1 [in the design doc](https://docs.google.com/document/d/1ag4drAdJsR7y-rQZkqJWc6tOQ4qCbflQSGyoxsSC6MM/edit?tab=t.0), while this PR chooses Option 3.  

## Usage

To directly use flutter API, just pass in the policy when creating UiKitView widget. 

```
UiKitView(
  ...
  gestureBlockingPolicy: UiKitViewGestureBlockingPolicy)
  ...
)
```

For plugins, we need to update plugins to use this new API. 

```
WebView(
  ...
  gestureBlockingPolicy: UiKitViewGestureBlockingPolicy
) {
  return UiKitView(
    ..
    gestureBlockingPolicy: gestureBlockingPolicy
  )
}
```
For more information, refer to [the old PR](https://github.com/flutter/flutter/pull/177859). 



*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*


https://github.com/flutter/flutter/issues/175099
https://github.com/flutter/flutter/issues/165787

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
