### PR TITLE
add the existing compute unit tests to the build

### DIFF
--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -107,6 +107,9 @@ template("renderer_unittests_component") {
     "pool_unittests.cc",
     "renderer_unittests.cc",
   ]
+  if (impeller_enable_compute) {
+    predefined_sources += [ "compute_unittests.cc" ]
+  }
   impeller_component(target_name) {
     testonly = true
     if (defined(invoker.defines)) {

--- a/engine/src/flutter/impeller/renderer/compute_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/compute_unittests.cc
@@ -16,6 +16,15 @@
 #include "impeller/renderer/prefix_sum_test.comp.h"
 #include "impeller/renderer/threadgroup_sizing_test.comp.h"
 
+namespace {
+std::shared_ptr<impeller::HostBuffer> CreateHostBufferFromContext(
+    const std::shared_ptr<impeller::Context>& context) {
+  return impeller::HostBuffer::Create(
+      context->GetResourceAllocator(), context->GetIdleWaiter(),
+      context->GetCapabilities()->GetMinimumUniformAlignment());
+}
+}  // namespace
+
 namespace impeller {
 namespace testing {
 using ComputeTest = ComputePlaygroundTest;
@@ -30,8 +39,7 @@ TEST_P(ComputeTest, CapabilitiesReportSupport) {
 TEST_P(ComputeTest, CanCreateComputePass) {
   using CS = SampleComputeShader;
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
 
@@ -110,8 +118,7 @@ TEST_P(ComputeTest, CanCreateComputePass) {
 TEST_P(ComputeTest, CanComputePrefixSum) {
   using CS = PrefixSumTestComputeShader;
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
 
@@ -231,8 +238,7 @@ TEST_P(ComputeTest, CanComputePrefixSumLargeInteractive) {
   using CS = PrefixSumTestComputeShader;
 
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
 
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
@@ -278,8 +284,7 @@ TEST_P(ComputeTest, MultiStageInputAndOutput) {
   using Stage2PipelineBuilder = ComputePipelineBuilder<CS2>;
 
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
 
@@ -377,8 +382,7 @@ TEST_P(ComputeTest, MultiStageInputAndOutput) {
 TEST_P(ComputeTest, CanCompute1DimensionalData) {
   using CS = SampleComputeShader;
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
 
@@ -457,8 +461,7 @@ TEST_P(ComputeTest, CanCompute1DimensionalData) {
 TEST_P(ComputeTest, ReturnsEarlyWhenAnyGridDimensionIsZero) {
   using CS = SampleComputeShader;
   auto context = GetContext();
-  auto host_buffer = HostBuffer::Create(context->GetResourceAllocator(),
-                                        context->GetIdleWaiter());
+  auto host_buffer = CreateHostBufferFromContext(context);
   ASSERT_TRUE(context);
   ASSERT_TRUE(context->GetCapabilities()->SupportsCompute());
 


### PR DESCRIPTION
There are existing compute unit tests in `compute_unittests.cc` but they were not added to the build. Add them if `impeller_enable_compute` is enabled.

Closes #179709

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
