### PR TITLE
 [web] Fix touch scroll propagation when Flutter is embedded in iframe

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -119,6 +119,14 @@ extension type DomWindow._(JSObject _) implements DomEventTarget {
   external DomVisualViewport? get visualViewport;
   external DomPerformance get performance;
 
+  /// The parent window of this window.
+  /// Returns null if this is the top-level window, or the same window
+  /// if not in an iframe.
+  external DomWindow? get parent;
+
+  /// Scrolls the window by the given amount.
+  external void scrollBy(double x, double y);
+
   @visibleForTesting
   Future<Object?> fetch(String url) {
     // To make sure we have a consistent approach for handling and reporting
@@ -2639,4 +2647,21 @@ extension type DomTextCluster._(JSObject _) implements JSObject {
   external int get end;
   external double get x;
   external double get y;
+}
+
+/// Scrolls the parent/host window by the given delta.
+///
+/// Used when Flutter is embedded in an iframe and needs to scroll the parent
+/// page. Calls `scrollBy` directly on the parent window for same-origin iframes.
+/// For cross-origin iframes, access may fail due to browser restrictions.
+void scrollParentWindow(double deltaX, double deltaY) {
+  try {
+    final DomWindow? parent = domWindow.parent;
+    final bool isInIframe = parent != null && !identical(parent, domWindow);
+    if (isInIframe) {
+      parent.scrollBy(deltaX, deltaY);
+    }
+  } catch (_) {
+    // Silently ignore failures (e.g., cross-origin iframe).
+  }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -641,6 +641,21 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // further effect after this point.
         _defaultRouteName = '/';
         return;
+
+      case 'flutter/scroll':
+        // Handle scroll propagation to parent/host window.
+        // Used for nested scrolling when Flutter is embedded in a host page.
+        const codec = StandardMessageCodec();
+        final dynamic decoded = codec.decodeMessage(data);
+        if (decoded is Map) {
+          final double deltaX = (decoded['deltaX'] as num?)?.toDouble() ?? 0.0;
+          final double deltaY = (decoded['deltaY'] as num?)?.toDouble() ?? 0.0;
+          scrollParentWindow(deltaX, deltaY);
+          replyToPlatformMessage(callback, codec.encodeMessage(true));
+        } else {
+          replyToPlatformMessage(callback, codec.encodeMessage(false));
+        }
+        return;
     }
 
     if (pluginMessageCallHandler != null) {

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -229,6 +229,40 @@ void testMain() {
       expect(codec.decodeEnvelope(response!), true);
     });
 
+    test('responds to flutter/scroll with valid message', () async {
+      // Tests that the flutter/scroll channel handler accepts valid scroll messages.
+      // This channel is used for propagating scroll to parent window when
+      // Flutter is embedded in an iframe.
+      const codec = StandardMessageCodec();
+      final completer = Completer<ByteData?>();
+
+      ui.PlatformDispatcher.instance.sendPlatformMessage(
+        'flutter/scroll',
+        codec.encodeMessage(<String, dynamic>{'deltaX': 0.0, 'deltaY': 10.0}),
+        completer.complete,
+      );
+
+      final ByteData? response = await completer.future;
+      expect(response, isNotNull);
+      expect(codec.decodeMessage(response), true);
+    });
+
+    test('responds to flutter/scroll with invalid message', () async {
+      // Tests that the flutter/scroll channel handler rejects invalid messages.
+      const codec = StandardMessageCodec();
+      final completer = Completer<ByteData?>();
+
+      ui.PlatformDispatcher.instance.sendPlatformMessage(
+        'flutter/scroll',
+        codec.encodeMessage('invalid'),
+        completer.complete,
+      );
+
+      final ByteData? response = await completer.future;
+      expect(response, isNotNull);
+      expect(codec.decodeMessage(response), false);
+    });
+
     test('can set application locale', () async {
       final DomElement host1 = createDomHTMLDivElement();
       final view1 = EngineFlutterView(dispatcher, host1);

--- a/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -316,6 +316,96 @@ void testMain() {
     );
   });
 
+  group('iframe touch scroll handling', () {
+    tearDown(() {
+      // Reset iframe detection cache after each test
+      debugResetIframeDetectionCache();
+    });
+
+    test('does not prevent default for touch pointerdown when in iframe', () {
+      // Simulate being embedded in an iframe
+      debugSetIframeEmbeddingForTests(true);
+
+      ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {};
+
+      // Create a cancelable touch pointerdown event
+      final DomEvent event = createDomPointerEvent('pointerdown', <String, dynamic>{
+        'bubbles': true,
+        'cancelable': true,
+        'pointerId': 1,
+        'button': 0,
+        'buttons': 1,
+        'clientX': 100,
+        'clientY': 100,
+        'pointerType': 'touch',
+      });
+
+      rootElement.dispatchEvent(event);
+
+      expect(
+        event.defaultPrevented,
+        isFalse,
+        reason: 'Touch pointerdown in iframe should allow default to enable native scroll',
+      );
+    });
+
+    test('prevents default for mouse pointerdown when in iframe', () {
+      // Simulate being embedded in an iframe
+      debugSetIframeEmbeddingForTests(true);
+
+      ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {};
+
+      // Create a cancelable mouse pointerdown event (not touch)
+      final DomEvent event = createDomPointerEvent('pointerdown', <String, dynamic>{
+        'bubbles': true,
+        'cancelable': true,
+        'pointerId': 1,
+        'button': 0,
+        'buttons': 1,
+        'clientX': 100,
+        'clientY': 100,
+        'pointerType': 'mouse',
+      });
+
+      rootElement.dispatchEvent(event);
+
+      // Mouse events should still have default prevented even in iframe
+      expect(
+        event.defaultPrevented,
+        isTrue,
+        reason: 'Mouse pointerdown should still prevent default even in iframe',
+      );
+    });
+
+    test('prevents default for touch pointerdown when NOT in iframe', () {
+      // Simulate NOT being in an iframe
+      debugSetIframeEmbeddingForTests(false);
+
+      ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {};
+
+      // Create a cancelable touch pointerdown event
+      final DomEvent event = createDomPointerEvent('pointerdown', <String, dynamic>{
+        'bubbles': true,
+        'cancelable': true,
+        'pointerId': 1,
+        'button': 0,
+        'buttons': 1,
+        'clientX': 100,
+        'clientY': 100,
+        'pointerType': 'touch',
+      });
+
+      rootElement.dispatchEvent(event);
+
+      // Touch events outside iframe should have default prevented
+      expect(
+        event.defaultPrevented,
+        isTrue,
+        reason: 'Touch pointerdown outside iframe should prevent default',
+      );
+    });
+  });
+
   test('can receive pointer events on the app root', () {
     final _BasicEventContext context = _PointerEventContext();
     ui.PointerDataPacket? receivedPacket;

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -11,17 +11,25 @@ library;
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 
 import 'basic.dart';
-import 'framework.dart';
 import 'scroll_activity.dart';
 import 'scroll_context.dart';
 import 'scroll_notification.dart';
 import 'scroll_physics.dart';
 import 'scroll_position.dart';
+
+/// Platform channel for scroll propagation to parent/host window on web.
+/// Used for nested scrolling when Flutter is embedded in a host page.
+const BasicMessageChannel<Object?> _scrollChannel = BasicMessageChannel<Object?>(
+  'flutter/scroll',
+  StandardMessageCodec(),
+);
 
 /// A scroll position that manages scroll activities for a single
 /// [ScrollContext].
@@ -128,7 +136,47 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   @override
   void applyUserOffset(double delta) {
     updateUserScrollDirection(delta > 0.0 ? ScrollDirection.forward : ScrollDirection.reverse);
+
+    // Check if we're at boundary BEFORE applying the scroll.
+    // This is needed to detect overscroll for parent page propagation.
+    final bool wasAtMin = pixels <= minScrollExtent;
+    final bool wasAtMax = pixels >= maxScrollExtent;
+
     setPixels(pixels - physics.applyPhysicsToUserOffset(this, delta));
+
+    // On web, propagate scroll to parent when at boundary.
+    // This enables touch scroll propagation to the host page when Flutter
+    // is embedded in an iframe.
+    if (kIsWeb) {
+      // Scrolling down (negative delta = finger moving up = content moving up)
+      final bool shouldPropagateDown = delta < 0 && (wasAtMax || pixels >= maxScrollExtent);
+      // Scrolling up (positive delta = finger moving down = content moving down)
+      final bool shouldPropagateUp = delta > 0 && (wasAtMin || pixels <= minScrollExtent);
+
+      if (shouldPropagateDown || shouldPropagateUp) {
+        _propagateOverscrollToParent(delta);
+      }
+    }
+  }
+
+  /// Sends overscroll delta to the engine to scroll the parent/host window.
+  void _propagateOverscrollToParent(double overscroll) {
+    // Convert overscroll to x/y delta based on axis direction
+    var deltaX = 0.0;
+    var deltaY = 0.0;
+    switch (axisDirection) {
+      case AxisDirection.up:
+        deltaY = overscroll;
+      case AxisDirection.down:
+        deltaY = -overscroll;
+      case AxisDirection.left:
+        deltaX = overscroll;
+      case AxisDirection.right:
+        deltaX = -overscroll;
+    }
+
+    // Send to engine via platform channel (fire-and-forget)
+    _scrollChannel.send(<String, dynamic>{'deltaX': deltaX, 'deltaY': deltaY});
   }
 
   @override


### PR DESCRIPTION
Fixes touch scrolling not propagating to the host page when Flutter web is embedded in an iframe(#157435).

**Root cause**
Engine calls preventDefault() on all touch events, blocking native browser scroll.

**Fix**
Skip preventDefault() for touch events when in an iframe
Detect overscroll at scroll boundaries and send to engine via flutter/scroll channel
Engine calls parent.scrollBy() to scroll the host page

Before change
https://issue-157435-before.web.app/

After change
https://issue-157435-after.web.app/