### PR TITLE
[Impeller] Convert paths in ImpellerC command line flags to std::filesystem::path objects

### DIFF
--- a/engine/src/flutter/impeller/compiler/compiler.cc
+++ b/engine/src/flutter/impeller/compiler/compiler.cc
@@ -525,7 +525,7 @@ static std::string JoinStrings(std::vector<std::string> items,
 
 std::string Compiler::GetDependencyNames(const std::string& separator) const {
   std::vector<std::string> dependencies = included_file_names_;
-  dependencies.push_back(options_.file_name);
+  dependencies.push_back(Utf8FromPath(options_.file_name));
   return JoinStrings(dependencies, separator);
 }
 

--- a/engine/src/flutter/impeller/compiler/impellerc_main.cc
+++ b/engine/src/flutter/impeller/compiler/impellerc_main.cc
@@ -27,8 +27,8 @@ static Reflector::Options CreateReflectorOptions(const SourceOptions& options,
   reflector_options.entry_point_name = options.entry_point_name;
   reflector_options.shader_name =
       InferShaderNameFromPath(switches.source_file_name);
-  reflector_options.header_file_name = Utf8FromPath(
-      std::filesystem::path{switches.reflection_header_name}.filename());
+  reflector_options.header_file_name =
+      Utf8FromPath(switches.reflection_header_name.filename());
   return reflector_options;
 }
 
@@ -164,9 +164,8 @@ static bool OutputReflectionData(const Compiler& compiler,
     }
 
     if (!switches.reflection_header_name.empty()) {
-      auto reflection_header_name =
-          std::filesystem::absolute(std::filesystem::current_path() /
-                                    switches.reflection_header_name.c_str());
+      auto reflection_header_name = std::filesystem::absolute(
+          std::filesystem::current_path() / switches.reflection_header_name);
       if (!fml::WriteAtomically(
               *switches.working_directory,
               Utf8FromPath(reflection_header_name).c_str(),
@@ -178,9 +177,8 @@ static bool OutputReflectionData(const Compiler& compiler,
     }
 
     if (!switches.reflection_cc_name.empty()) {
-      auto reflection_cc_name =
-          std::filesystem::absolute(std::filesystem::current_path() /
-                                    switches.reflection_cc_name.c_str());
+      auto reflection_cc_name = std::filesystem::absolute(
+          std::filesystem::current_path() / switches.reflection_cc_name);
       if (!fml::WriteAtomically(*switches.working_directory,
                                 Utf8FromPath(reflection_cc_name).c_str(),
                                 *compiler.GetReflector()->GetReflectionCC())) {
@@ -211,14 +209,14 @@ static bool OutputDepfile(const Compiler& compiler, const Switches& switches) {
       case TargetPlatform::kRuntimeStageVulkan:
       case TargetPlatform::kSkSL:
       case TargetPlatform::kVulkan:
-        result_file = switches.sl_file_name;
+        result_file = Utf8FromPath(switches.sl_file_name);
         break;
       case TargetPlatform::kUnknown:
-        result_file = switches.spirv_file_name;
+        result_file = Utf8FromPath(switches.spirv_file_name);
         break;
     }
     auto depfile_path = std::filesystem::absolute(
-        std::filesystem::current_path() / switches.depfile_path.c_str());
+        std::filesystem::current_path() / switches.depfile_path);
     if (!fml::WriteAtomically(*switches.working_directory,
                               Utf8FromPath(depfile_path).c_str(),
                               *compiler.CreateDepfileContents({result_file}))) {
@@ -252,7 +250,7 @@ bool Main(const fml::CommandLine& command_line) {
   }
 
   std::shared_ptr<fml::FileMapping> source_file_mapping =
-      fml::FileMapping::CreateReadOnly(switches.source_file_name);
+      fml::FileMapping::CreateReadOnly(Utf8FromPath(switches.source_file_name));
   if (!source_file_mapping) {
     std::cerr << "Could not open input file." << std::endl;
     return false;

--- a/engine/src/flutter/impeller/compiler/source_options.h
+++ b/engine/src/flutter/impeller/compiler/source_options.h
@@ -23,7 +23,7 @@ struct SourceOptions {
   SourceLanguage source_language = SourceLanguage::kUnknown;
   std::shared_ptr<fml::UniqueFD> working_directory;
   std::vector<IncludeDir> include_dirs;
-  std::string file_name = "main.glsl";
+  std::filesystem::path file_name = "main.glsl";
   std::string entry_point_name = "main";
   uint32_t gles_language_version = 100;
   std::vector<std::string> defines;

--- a/engine/src/flutter/impeller/compiler/spirv_compiler.cc
+++ b/engine/src/flutter/impeller/compiler/spirv_compiler.cc
@@ -8,6 +8,7 @@
 
 #include "impeller/compiler/logger.h"
 #include "impeller/compiler/types.h"
+#include "impeller/compiler/utilities.h"
 
 namespace impeller {
 namespace compiler {
@@ -44,11 +45,11 @@ std::shared_ptr<fml::Mapping> SPIRVCompiler::CompileToSPV(
   auto result = std::make_shared<shaderc::SpvCompilationResult>(
       spv_compiler.CompileGlslToSpv(
           reinterpret_cast<const char*>(sources_->GetMapping()),  // source_text
-          sources_->GetSize(),                // source_text_size
-          shader_kind,                        // shader_kind
-          options_.file_name.c_str(),         // input_file_name
-          options_.entry_point_name.c_str(),  // entry_point_name
-          spirv_options                       // options
+          sources_->GetSize(),                       // source_text_size
+          shader_kind,                               // shader_kind
+          Utf8FromPath(options_.file_name).c_str(),  // input_file_name
+          options_.entry_point_name.c_str(),         // entry_point_name
+          spirv_options                              // options
           ));
   if (result->GetCompilationStatus() !=
       shaderc_compilation_status::shaderc_compilation_status_success) {

--- a/engine/src/flutter/impeller/compiler/switches.cc
+++ b/engine/src/flutter/impeller/compiler/switches.cc
@@ -160,25 +160,32 @@ static SourceType SourceTypeFromCommandLine(
   return source_type_search->second;
 }
 
+// Get the value of a command line option as a filesystem path.  The option
+// value string must be encoded in UTF-8.
+static std::filesystem::path GetOptionAsPath(
+    const fml::CommandLine& command_line,
+    const char* arg) {
+  std::string value = command_line.GetOptionValueWithDefault(arg, "");
+  return std::filesystem::path(std::u8string(value.begin(), value.end()));
+}
+
 Switches::Switches(const fml::CommandLine& command_line)
     : working_directory(std::make_shared<fml::UniqueFD>(fml::OpenDirectory(
           Utf8FromPath(std::filesystem::current_path()).c_str(),
           false,  // create if necessary,
           fml::FilePermission::kRead))),
-      source_file_name(command_line.GetOptionValueWithDefault("input", "")),
+      source_file_name(GetOptionAsPath(command_line, "input")),
       input_type(SourceTypeFromCommandLine(command_line)),
-      sl_file_name(command_line.GetOptionValueWithDefault("sl", "")),
+      sl_file_name(GetOptionAsPath(command_line, "sl")),
       iplr(command_line.HasOption("iplr")),
       shader_bundle(
           command_line.GetOptionValueWithDefault("shader-bundle", "")),
-      spirv_file_name(command_line.GetOptionValueWithDefault("spirv", "")),
-      reflection_json_name(
-          command_line.GetOptionValueWithDefault("reflection-json", "")),
+      spirv_file_name(GetOptionAsPath(command_line, "spirv")),
+      reflection_json_name(GetOptionAsPath(command_line, "reflection-json")),
       reflection_header_name(
-          command_line.GetOptionValueWithDefault("reflection-header", "")),
-      reflection_cc_name(
-          command_line.GetOptionValueWithDefault("reflection-cc", "")),
-      depfile_path(command_line.GetOptionValueWithDefault("depfile", "")),
+          GetOptionAsPath(command_line, "reflection-header")),
+      reflection_cc_name(GetOptionAsPath(command_line, "reflection-cc")),
+      depfile_path(GetOptionAsPath(command_line, "depfile")),
       json_format(command_line.HasOption("json")),
       gles_language_version(
           stoi(command_line.GetOptionValueWithDefault("gles-language-version",

--- a/engine/src/flutter/impeller/compiler/switches.h
+++ b/engine/src/flutter/impeller/compiler/switches.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_COMPILER_SWITCHES_H_
 
 #include <cstdint>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 
@@ -22,19 +23,19 @@ class Switches {
  public:
   std::shared_ptr<fml::UniqueFD> working_directory = nullptr;
   std::vector<IncludeDir> include_directories = {};
-  std::string source_file_name = "";
+  std::filesystem::path source_file_name;
   SourceType input_type = SourceType::kUnknown;
   /// The raw shader file output by the compiler. For --iplr and
   /// --shader-bundle modes, this is used as the filename for the output
   /// flatbuffer output.
-  std::string sl_file_name = "";
+  std::filesystem::path sl_file_name;
   bool iplr = false;
   std::string shader_bundle = "";
-  std::string spirv_file_name = "";
-  std::string reflection_json_name = "";
-  std::string reflection_header_name = "";
-  std::string reflection_cc_name = "";
-  std::string depfile_path = "";
+  std::filesystem::path spirv_file_name;
+  std::filesystem::path reflection_json_name;
+  std::filesystem::path reflection_header_name;
+  std::filesystem::path reflection_cc_name;
+  std::filesystem::path depfile_path;
   std::vector<std::string> defines = {};
   bool json_format = false;
   SourceLanguage source_language = SourceLanguage::kUnknown;

--- a/engine/src/flutter/impeller/compiler/switches_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/switches_unittests.cc
@@ -7,6 +7,7 @@
 
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/file.h"
+#include "flutter/fml/string_conversion.h"
 #include "flutter/testing/testing.h"
 #include "impeller/compiler/switches.h"
 #include "impeller/compiler/utilities.h"
@@ -102,6 +103,14 @@ TEST(SwitchesTest, EntryPointPrefixIsApplied) {
   switches.source_file_name = "test.frag";
   auto options = switches.CreateSourceOptions();
   EXPECT_EQ(options.entry_point_name, "my_prefix_test_fragment_main");
+}
+
+TEST(SwitchesTest, CommandLinePathUtf8) {
+  std::u16string filename = u"test\u1234";
+  std::string input_flag = "--input=" + fml::Utf16ToUtf8(filename);
+  Switches switches = MakeSwitchesDesktopGL({input_flag.c_str()});
+  ASSERT_TRUE(switches.AreValid(std::cout));
+  ASSERT_EQ(switches.source_file_name, filename);
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/compiler/types.cc
+++ b/engine/src/flutter/impeller/compiler/types.cc
@@ -14,29 +14,17 @@
 namespace impeller {
 namespace compiler {
 
-static bool StringEndWith(const std::string& string,
-                          const std::string& suffix) {
-  if (suffix.size() > string.size()) {
-    return false;
-  }
-
-  if (suffix.empty() || suffix.empty()) {
-    return false;
-  }
-
-  return string.rfind(suffix) == (string.size() - suffix.size());
-}
-
-SourceType SourceTypeFromFileName(const std::string& file_name) {
-  if (StringEndWith(file_name, ".vert")) {
+SourceType SourceTypeFromFileName(const std::filesystem::path& file_name) {
+  std::string extension = file_name.extension().string();
+  if (extension == ".vert") {
     return SourceType::kVertexShader;
   }
 
-  if (StringEndWith(file_name, ".frag")) {
+  if (extension == ".frag") {
     return SourceType::kFragmentShader;
   }
 
-  if (StringEndWith(file_name, ".comp")) {
+  if (extension == ".comp") {
     return SourceType::kComputeShader;
   }
 
@@ -111,7 +99,7 @@ std::string SourceLanguageToString(SourceLanguage source_language) {
 }
 
 std::string EntryPointFunctionNameFromSourceName(
-    const std::string& file_name,
+    const std::filesystem::path& file_name,
     SourceType type,
     SourceLanguage source_language,
     const std::string& entry_point_name) {
@@ -120,8 +108,7 @@ std::string EntryPointFunctionNameFromSourceName(
   }
 
   std::stringstream stream;
-  std::filesystem::path file_path(file_name);
-  stream << ConvertToEntrypointName(Utf8FromPath(file_path.stem())) << "_";
+  stream << ConvertToEntrypointName(Utf8FromPath(file_name.stem())) << "_";
   switch (type) {
     case SourceType::kUnknown:
       stream << "unknown";

--- a/engine/src/flutter/impeller/compiler/types.h
+++ b/engine/src/flutter/impeller/compiler/types.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_COMPILER_TYPES_H_
 
 #include <codecvt>
+#include <filesystem>
 #include <locale>
 #include <map>
 #include <optional>
@@ -87,7 +88,7 @@ bool TargetPlatformIsOpenGL(TargetPlatform platform);
 
 bool TargetPlatformIsVulkan(TargetPlatform platform);
 
-SourceType SourceTypeFromFileName(const std::string& file_name);
+SourceType SourceTypeFromFileName(const std::filesystem::path& file_name);
 
 SourceType SourceTypeFromString(std::string name);
 
@@ -102,7 +103,7 @@ std::string SourceLanguageToString(SourceLanguage source_language);
 std::string TargetPlatformSLExtension(TargetPlatform platform);
 
 std::string EntryPointFunctionNameFromSourceName(
-    const std::string& file_name,
+    const std::filesystem::path& file_name,
     SourceType type,
     SourceLanguage source_language,
     const std::string& entry_point_name);

--- a/engine/src/flutter/impeller/compiler/utilities.cc
+++ b/engine/src/flutter/impeller/compiler/utilities.cc
@@ -31,9 +31,8 @@ std::string Utf8FromPath(const std::filesystem::path& path) {
   return reinterpret_cast<const char*>(path.u8string().c_str());
 }
 
-std::string InferShaderNameFromPath(std::string_view path) {
-  auto p = std::filesystem::path{path}.stem();
-  return Utf8FromPath(p);
+std::string InferShaderNameFromPath(const std::filesystem::path& path) {
+  return Utf8FromPath(path.stem());
 }
 
 std::string ToCamelCase(std::string_view string) {

--- a/engine/src/flutter/impeller/compiler/utilities.h
+++ b/engine/src/flutter/impeller/compiler/utilities.h
@@ -23,7 +23,7 @@ bool SetPermissiveAccess(const std::filesystem::path& p);
 ///         has utf16 paths), the path will get mangled.
 std::string Utf8FromPath(const std::filesystem::path& path);
 
-std::string InferShaderNameFromPath(std::string_view path);
+std::string InferShaderNameFromPath(const std::filesystem::path& path);
 
 std::string ToCamelCase(std::string_view string);
 


### PR DESCRIPTION
This ensures proper handling of non-ASCII characters in paths when running ImpellerC on Windows.