### PR TITLE
[web] Handle scroll in HTML platform views

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -478,6 +478,8 @@ extension type DomElement._(JSObject _) implements DomNode {
 
   external double scrollTop;
   external double scrollLeft;
+  external double get scrollHeight;
+  external double get scrollWidth;
   external DomTokenList get classList;
   external String className;
 
@@ -1920,6 +1922,10 @@ extension type DomTouchEvent._(JSObject _) implements DomUIEvent {
   @JS('changedTouches')
   external _DomList get _changedTouches;
   Iterable<DomTouch> get changedTouches => _createDomListWrapper<DomTouch>(_changedTouches);
+
+  @JS('touches')
+  external _DomList get _touches;
+  Iterable<DomTouch> get touches => _createDomListWrapper<DomTouch>(_touches);
 }
 
 @JS('Touch')

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -309,5 +309,32 @@ void testMain() {
         expect(() => contentManager.updatePlatformViewAccessibility(999, false), returnsNormally);
       });
     });
+
+    group('touch scrolling support', () {
+      setUp(() {
+        contentManager.registerFactory(viewType, (int id) => createDomHTMLDivElement());
+      });
+
+      test('sets touch-action style to enable native touch scrolling', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+
+        // Browser may return 'pan-x pan-y' or 'pan-y pan-x' depending on implementation
+        final String touchAction = wrapper.style.touchAction;
+        expect(
+          touchAction.contains('pan-x') && touchAction.contains('pan-y'),
+          isTrue,
+          reason: 'Platform views should have touch-action set to enable native touch scrolling',
+        );
+      });
+
+      test('sets up touch event listeners on content element', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+        final DomElement content = wrapper.querySelector('div')!;
+
+        // Verify content element exists and is properly nested
+        expect(content, isNotNull);
+        expect(content.parentElement, equals(wrapper));
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes #179360.

Allow HTML platform views to use native touch scrolling by setting touch-action and adding touch boundary detection to avoid rubber-banding and hand off to Flutter at edges.
Handle wheel events over HTML platform views by scrolling the element directly when possible, falling back to Flutter at boundaries.

Before change
https://flutter-demo-01-before.web.app/

After change
https://flutter-demo-01-after.web.app/

