### PR TITLE
Add FloatingActionButtonTheme

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -266,8 +266,8 @@ class FloatingActionButton extends StatelessWidget {
 
   /// The default foreground color for icons and text within the button.
   ///
-  /// If this property is null, then the [FloatingActionButtonThemeData.foregroundColor]
-  /// of [ThemeData.floatingActionButtonTheme] is used. If that property is also
+  /// If this property is null, then the ambient
+  /// [FloatingActionButtonThemeData.foregroundColor] is used. If that property is also
   /// null, then the [ColorScheme.onPrimaryContainer] color of [ThemeData.colorScheme]
   /// is used. If [ThemeData.useMaterial3] is set to false, then the
   /// [ColorScheme.onSecondary] color of [ThemeData.colorScheme] is used.
@@ -275,8 +275,8 @@ class FloatingActionButton extends StatelessWidget {
 
   /// The button's background color.
   ///
-  /// If this property is null, then the [FloatingActionButtonThemeData.backgroundColor]
-  /// of [ThemeData.floatingActionButtonTheme] is used. If that property is also
+  /// If this property is null, then the ambient
+  /// [FloatingActionButtonThemeData.backgroundColor] is used. If that property is also
   /// null, then the [ColorScheme.primaryContainer] color of [ThemeData.colorScheme]
   /// is used. If [ThemeData.useMaterial3] is set to false, then the
   /// [ColorScheme.secondary] color of [ThemeData.colorScheme] is used.
@@ -488,7 +488,9 @@ class FloatingActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final FloatingActionButtonThemeData floatingActionButtonTheme = theme.floatingActionButtonTheme;
+    final FloatingActionButtonThemeData floatingActionButtonTheme = FloatingActionButtonTheme.of(
+      context,
+    );
     final FloatingActionButtonThemeData defaults = theme.useMaterial3
         ? _FABDefaultsM3(context, _floatingActionButtonType, child != null)
         : _FABDefaultsM2(context, _floatingActionButtonType, child != null);

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -15,11 +15,16 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'theme.dart';
+
+// Examples can assume:
+// late BuildContext context;
+
 /// Defines default property values for descendant [FloatingActionButton]
 /// widgets.
 ///
 /// Descendant widgets obtain the current [FloatingActionButtonThemeData] object
-/// using `Theme.of(context).floatingActionButtonTheme`. Instances of
+/// using [FloatingActionButtonTheme.of]. Instances of
 /// [FloatingActionButtonThemeData] can be customized with
 /// [FloatingActionButtonThemeData.copyWith].
 ///
@@ -27,8 +32,7 @@ import 'package:flutter/widgets.dart';
 /// overall [Theme] with [ThemeData.floatingActionButtonTheme].
 ///
 /// All [FloatingActionButtonThemeData] properties are `null` by default.
-/// When null, the [FloatingActionButton] will use the values from [ThemeData]
-/// if they exist, otherwise it will provide its own defaults.
+/// When null, the [FloatingActionButton] provides its own defaults.
 ///
 /// See also:
 ///
@@ -36,8 +40,8 @@ import 'package:flutter/widgets.dart';
 ///    application.
 @immutable
 class FloatingActionButtonThemeData with Diagnosticable {
-  /// Creates a theme that can be used for
-  /// [ThemeData.floatingActionButtonTheme].
+  /// Creates a theme that can be used for [ThemeData.floatingActionButtonTheme] and
+  /// [FloatingActionButtonTheme].
   const FloatingActionButtonThemeData({
     this.foregroundColor,
     this.backgroundColor,
@@ -365,4 +369,43 @@ class FloatingActionButtonThemeData with Diagnosticable {
       ),
     );
   }
+}
+
+/// An inherited widget that defines the configuration for
+/// [FloatingActionButton]s in this widget's subtree.
+///
+/// Values specified here are used for [FloatingActionButton] properties that are not
+/// given an explicit non-null value.
+class FloatingActionButtonTheme extends InheritedTheme {
+  /// Creates a floating action button theme that controls the configurations for
+  /// [FloatingActionButton]s in its widget subtree.
+  const FloatingActionButtonTheme({super.key, this.data, required super.child});
+
+  /// The properties for descendant [FloatingActionButton] widgets.
+  final FloatingActionButtonThemeData? data;
+
+  /// The closest instance of this class's [data] value that encloses the given
+  /// context.
+  ///
+  /// If there is no ancestor, it returns [ThemeData.floatingActionButtonTheme]. Applications
+  /// can assume that the returned value will not be null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// FloatingActionButtonThemeData theme = FloatingActionButtonTheme.of(context);
+  /// ```
+  static FloatingActionButtonThemeData of(BuildContext context) {
+    final FloatingActionButtonTheme? fabTheme = context
+        .dependOnInheritedWidgetOfExactType<FloatingActionButtonTheme>();
+    return fabTheme?.data ?? Theme.of(context).floatingActionButtonTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return FloatingActionButtonTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(FloatingActionButtonTheme oldWidget) => data != oldWidget.data;
 }

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -379,10 +379,10 @@ class FloatingActionButtonThemeData with Diagnosticable {
 class FloatingActionButtonTheme extends InheritedTheme {
   /// Creates a floating action button theme that controls the configurations for
   /// [FloatingActionButton]s in its widget subtree.
-  const FloatingActionButtonTheme({super.key, this.data, required super.child});
+  const FloatingActionButtonTheme({super.key, required this.data, required super.child});
 
   /// The properties for descendant [FloatingActionButton] widgets.
-  final FloatingActionButtonThemeData? data;
+  final FloatingActionButtonThemeData data;
 
   /// The closest instance of this class's [data] value that encloses the given
   /// context.

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -190,6 +190,100 @@ void main() {
     },
   );
 
+  testWidgets('Local FloatingActionButtonTheme are used', (WidgetTester tester) async {
+    const backgroundColor = Color(0x00000001);
+    const foregroundColor = Color(0x00000002);
+    const splashColor = Color(0x00000003);
+    const double elevation = 7;
+    const double disabledElevation = 1;
+    const double highlightElevation = 13;
+    const ShapeBorder shape = StadiumBorder();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FloatingActionButtonTheme(
+          data: const FloatingActionButtonThemeData(
+            backgroundColor: backgroundColor,
+            foregroundColor: foregroundColor,
+            splashColor: splashColor,
+            elevation: elevation,
+            disabledElevation: disabledElevation,
+            highlightElevation: highlightElevation,
+            shape: shape,
+          ),
+          child: Scaffold(
+            floatingActionButton: FloatingActionButton(
+              onPressed: () {},
+              child: const Icon(Icons.add),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(_getRawMaterialButton(tester).fillColor, backgroundColor);
+    expect(_getRichText(tester).text.style!.color, foregroundColor);
+    expect(_getRawMaterialButton(tester).elevation, elevation);
+    expect(_getRawMaterialButton(tester).disabledElevation, disabledElevation);
+    expect(_getRawMaterialButton(tester).highlightElevation, highlightElevation);
+    expect(_getRawMaterialButton(tester).shape, shape);
+    expect(_getRawMaterialButton(tester).splashColor, splashColor);
+  });
+
+  testWidgets(
+    'Local FloatingActionButtonTheme takes priority over ThemeData.floatingActionButtonTheme',
+    (WidgetTester tester) async {
+      const backgroundColor = Color(0x00000001);
+      const foregroundColor = Color(0x00000002);
+      const splashColor = Color(0x00000003);
+      const double elevation = 7;
+      const double disabledElevation = 1;
+      const double highlightElevation = 13;
+      const ShapeBorder shape = StadiumBorder();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData().copyWith(
+            floatingActionButtonTheme: const FloatingActionButtonThemeData(
+              backgroundColor: Color(0x00000004),
+              foregroundColor: Color(0x00000005),
+              splashColor: Color(0x00000006),
+              elevation: 23,
+              disabledElevation: 11,
+              highlightElevation: 43,
+              shape: BeveledRectangleBorder(),
+            ),
+          ),
+          home: FloatingActionButtonTheme(
+            data: const FloatingActionButtonThemeData(
+              backgroundColor: backgroundColor,
+              foregroundColor: foregroundColor,
+              splashColor: splashColor,
+              elevation: elevation,
+              disabledElevation: disabledElevation,
+              highlightElevation: highlightElevation,
+              shape: shape,
+            ),
+            child: Scaffold(
+              floatingActionButton: FloatingActionButton(
+                onPressed: () {},
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(_getRawMaterialButton(tester).fillColor, backgroundColor);
+      expect(_getRichText(tester).text.style!.color, foregroundColor);
+      expect(_getRawMaterialButton(tester).elevation, elevation);
+      expect(_getRawMaterialButton(tester).disabledElevation, disabledElevation);
+      expect(_getRawMaterialButton(tester).highlightElevation, highlightElevation);
+      expect(_getRawMaterialButton(tester).shape, shape);
+      expect(_getRawMaterialButton(tester).splashColor, splashColor);
+    },
+  );
+
   testWidgets('FloatingActionButton uses a custom shape when specified in the theme', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -108,7 +108,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData().copyWith(
+          theme: ThemeData(
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               backgroundColor: backgroundColor,
               foregroundColor: foregroundColor,
@@ -153,7 +153,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData().copyWith(
+          theme: ThemeData(
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               backgroundColor: Color(0x00000004),
               foregroundColor: Color(0x00000005),
@@ -190,7 +190,7 @@ void main() {
     },
   );
 
-  testWidgets('Local FloatingActionButtonTheme are used', (WidgetTester tester) async {
+  testWidgets('Local FloatingActionButtonTheme properties are used', (WidgetTester tester) async {
     const backgroundColor = Color(0x00000001);
     const foregroundColor = Color(0x00000002);
     const splashColor = Color(0x00000003);
@@ -243,7 +243,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData().copyWith(
+          theme: ThemeData(
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               backgroundColor: Color(0x00000004),
               foregroundColor: Color(0x00000005),
@@ -308,7 +308,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData().copyWith(
+        theme: ThemeData(
           floatingActionButtonTheme: const FloatingActionButtonThemeData(
             smallSizeConstraints: constraints,
           ),
@@ -335,7 +335,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData().copyWith(
+        theme: ThemeData(
           floatingActionButtonTheme: const FloatingActionButtonThemeData(
             largeSizeConstraints: constraints,
           ),
@@ -367,7 +367,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(colorScheme: colorScheme).copyWith(
+          theme: ThemeData(
+            colorScheme: colorScheme,
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               extendedSizeConstraints: constraints,
               extendedIconLabelSpacing: iconLabelSpacing,
@@ -419,7 +420,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: false).copyWith(
+          theme: ThemeData(
+            useMaterial3: false,
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               extendedSizeConstraints: constraints,
               extendedIconLabelSpacing: iconLabelSpacing,
@@ -472,7 +474,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(colorScheme: colorScheme).copyWith(
+          theme: ThemeData(
+            colorScheme: colorScheme,
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               extendedIconLabelSpacing: 25.0,
               extendedPadding: EdgeInsetsDirectional.only(start: 7.0, end: 8.0),
@@ -524,7 +527,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: false).copyWith(
+          theme: ThemeData(
+            useMaterial3: false,
             floatingActionButtonTheme: const FloatingActionButtonThemeData(
               extendedIconLabelSpacing: 25.0,
               extendedPadding: EdgeInsetsDirectional.only(start: 7.0, end: 8.0),
@@ -639,7 +643,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData().copyWith(
+          theme: ThemeData(
             floatingActionButtonTheme: FloatingActionButtonThemeData(
               mouseCursor: WidgetStateProperty.all(SystemMouseCursors.text),
             ),


### PR DESCRIPTION
## Description

This PR adds the `FloatingActionButtonTheme` subclass of InheritedTheme. Similarly to other theme classes.

This missing theme class was mentioned in [flutter.dev/go/material-theme-system-updates](http://flutter.dev/go/material-theme-system-updates):
"FloatingActionButtonThemeData is conformant but there’s no FloatingActionButtonTheme class. "


## Related Issue

Fixes [Missing FloatingActionButtonTheme](https://github.com/flutter/flutter/issues/179735) 

## Tests

Adds 2 tests.