### PR TITLE
Make sure that a CupertinoSwitch doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -2097,6 +2097,17 @@ void main() {
       expect(find.byType(CupertinoSwitch), paints..rrect(color: activeTrackColor));
     });
   });
+
+  testWidgets('CupertinoSwitch does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox.shrink(child: CupertinoSwitch(value: false, onChanged: (_) {})),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CupertinoSwitch)), Size.zero);
+  });
 }
 
 class _TestImageProvider extends ImageProvider<Object> {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CupertinoSwitch widget.