### PR TITLE
[Impeller] Delete GLES framebuffer objects only on the thread where they were created

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/handle_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/handle_gles.cc
@@ -28,4 +28,8 @@ std::string HandleTypeToString(HandleType type) {
   FML_UNREACHABLE();
 }
 
+bool HandleTypeIsShareable(HandleType type) {
+  return type != HandleType::kFrameBuffer;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/reactor_gles.cc
@@ -308,6 +308,9 @@ bool ReactorGLES::ConsolidateHandles() {
     for (auto& handle : handles_) {
       // Collect dead handles.
       if (handle.second.pending_collection) {
+        // Some objects can only be deleted on a specific thread.  Collection
+        // of these objects will be deferred until the owner thead executes
+        // a reaction and triggers collection of handles.
         const auto& owner_thread = handle.first.owner_thread_;
         if (owner_thread.has_value() && *owner_thread != current_thread) {
           continue;


### PR DESCRIPTION
OpenGL does not allow cross-context sharing of container objects (such as framebuffers) that hold references to other objects.  ReactorGLES must ensure that framebuffers are deleted using the thread and context where the object was created.

Fixes https://github.com/flutter/flutter/issues/178276