### PR TITLE
refactor: migrate CupertinoPageTransitionsBuilder to cupertino folder

### DIFF
--- a/examples/api/lib/material/page_transitions_theme/page_transitions_theme.0.dart
+++ b/examples/api/lib/material/page_transitions_theme/page_transitions_theme.0.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [PageTransitionsTheme].

--- a/examples/api/test/material/page_transitions_theme/page_transitions_theme.0_test.dart
+++ b/examples/api/test/material/page_transitions_theme/page_transitions_theme.0_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/page_transitions_theme/page_transitions_theme.0.dart'
     as example;

--- a/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
@@ -26,6 +26,18 @@
 #     * WidgetState: fix_widget_state.yaml
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/179776
+  - title: 'Replaced by cupertino CupertinoPageTransitionsBuilder'
+    date: 2026-01-15
+    element:
+      uris: ['material.dart']
+      class: 'CupertinoPageTransitionsBuilder'
+    changes:
+    - kind: 'replacedBy'
+      newElement:
+        uris: ['cupertino.dart']
+        class: 'CupertinoPageTransitionsBuilder'
+
   # Changes made in https://github.com/flutter/flutter/pull/15303
   - title: "Replace 'child' with 'builder'"
     date: 2020-12-17

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -1549,19 +1549,39 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
   static final Tween<double> _dialogScaleTween = Tween<double>(begin: 1.3, end: 1.0);
 }
 
-/// Used by [PageTransitionsTheme] to define a horizontal [MaterialPageRoute]
-/// page transition animation that matches native iOS page transitions.
+/// A [PageTransitionsBuilder] that provides an iOS-style page transition
+/// animation.
+///
+/// The page slides in from the right and exits in reverse. It also shifts
+/// to the left in a parallax motion when another page enters to cover it.
+/// This transition is commonly seen in native iOS applications.
+///
+/// This builder can be used with [PageTransitionsTheme] to apply iOS-style
+/// transitions to [MaterialPageRoute] or any [PageRoute] that uses a
+/// [PageTransitionsTheme].
+///
+/// In a [CupertinoApp], this transition is used automatically when navigating
+/// with [CupertinoPageRoute]:
+///
+/// ```dart
+/// Navigator.push(
+///   context,
+///   CupertinoPageRoute<void>(
+///     builder: (BuildContext context) => const MyPage(),
+///   ),
+/// );
+/// ```
 ///
 /// See also:
 ///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
-///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
-///  * [PredictiveBackPageTransitionsBuilder], which defines a page
-///    transition that allows peeking behind the current route on Android.
+///  * [CupertinoPageRoute], which uses this transition style by default for
+///    Cupertino apps.
+///  * [CupertinoPageTransition], the widget that implements the iOS page
+///    transition animation.
+///  * [MaterialPageRoute], an adaptive [PageRoute] that can use this builder
+///    through [PageTransitionsTheme].
+///  * [PageTransitionsTheme], which defines the page transitions used by
+///    [MaterialPageRoute] for different target platforms.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Constructs a page transition animation that matches the iOS transition.
   const CupertinoPageTransitionsBuilder();

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -1556,21 +1556,8 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
 /// to the left in a parallax motion when another page enters to cover it.
 /// This transition is commonly seen in native iOS applications.
 ///
-/// This builder can be used with [PageTransitionsTheme] to apply iOS-style
-/// transitions to [MaterialPageRoute] or any [PageRoute] that uses a
-/// [PageTransitionsTheme].
-///
 /// In a [CupertinoApp], this transition is used automatically when navigating
-/// with [CupertinoPageRoute]:
-///
-/// ```dart
-/// Navigator.push(
-///   context,
-///   CupertinoPageRoute<void>(
-///     builder: (BuildContext context) => const MyPage(),
-///   ),
-/// );
-/// ```
+/// with [CupertinoPageRoute].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -1548,3 +1548,45 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
   // transitions.
   static final Tween<double> _dialogScaleTween = Tween<double>(begin: 1.3, end: 1.0);
 }
+
+/// Used by [PageTransitionsTheme] to define a horizontal [MaterialPageRoute]
+/// page transition animation that matches native iOS page transitions.
+///
+/// See also:
+///
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android O.
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [ZoomPageTransitionsBuilder], which defines the default page transition
+///    that's similar to the one provided in Android Q.
+///  * [PredictiveBackPageTransitionsBuilder], which defines a page
+///    transition that allows peeking behind the current route on Android.
+class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
+  /// Constructs a page transition animation that matches the iOS transition.
+  const CupertinoPageTransitionsBuilder();
+
+  @override
+  Duration get transitionDuration => CupertinoRouteTransitionMixin.kTransitionDuration;
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition =>
+      CupertinoPageTransition.delegatedTransition;
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return CupertinoRouteTransitionMixin.buildPageTransitions<T>(
+      route,
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -720,48 +720,6 @@ class ZoomPageTransitionsBuilder extends PageTransitionsBuilder {
   }
 }
 
-/// Used by [PageTransitionsTheme] to define a horizontal [MaterialPageRoute]
-/// page transition animation that matches native iOS page transitions.
-///
-/// See also:
-///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
-///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
-///  * [PredictiveBackPageTransitionsBuilder], which defines a page
-///    transition that allows peeking behind the current route on Android.
-class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
-  /// Constructs a page transition animation that matches the iOS transition.
-  const CupertinoPageTransitionsBuilder();
-
-  @override
-  Duration get transitionDuration => CupertinoRouteTransitionMixin.kTransitionDuration;
-
-  @override
-  DelegatedTransitionBuilder? get delegatedTransition =>
-      CupertinoPageTransition.delegatedTransition;
-
-  @override
-  Widget buildTransitions<T>(
-    PageRoute<T> route,
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  ) {
-    return CupertinoRouteTransitionMixin.buildPageTransitions<T>(
-      route,
-      context,
-      animation,
-      secondaryAnimation,
-      child,
-    );
-  }
-}
-
 /// Defines the page transition animations used by [MaterialPageRoute]
 /// for different [TargetPlatform]s.
 ///

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -3231,41 +3231,6 @@ void main() {
       expect(builder.delegatedTransition, isNotNull);
       expect(builder.delegatedTransition, CupertinoPageTransition.delegatedTransition);
     });
-
-    testWidgets('works with MaterialApp and PageTransitionsTheme', (WidgetTester tester) async {
-      final routes = <String, WidgetBuilder>{
-        '/': (BuildContext context) => Material(
-          child: TextButton(
-            child: const Text('push'),
-            onPressed: () {
-              Navigator.of(context).pushNamed('/b');
-            },
-          ),
-        ),
-        '/b': (BuildContext context) => const Text('page b'),
-      };
-
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            pageTransitionsTheme: const PageTransitionsTheme(
-              builders: <TargetPlatform, PageTransitionsBuilder>{
-                TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-                TargetPlatform.android: CupertinoPageTransitionsBuilder(),
-              },
-            ),
-          ),
-          routes: routes,
-        ),
-      );
-
-      expect(find.byType(CupertinoPageTransition), findsOneWidget);
-
-      await tester.tap(find.text('push'));
-      await tester.pumpAndSettle();
-      expect(find.text('page b'), findsOneWidget);
-      expect(find.byType(CupertinoPageTransition), findsOneWidget);
-    });
   });
 }
 

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -3188,6 +3188,85 @@ void main() {
     expect(FocusScope.of(tester.element(find.text('dialog'))).hasFocus, false);
     expect(focusNode.hasFocus, true);
   });
+
+  group('CupertinoPageTransitionsBuilder', () {
+    testWidgets('builds a CupertinoPageTransition', (WidgetTester tester) async {
+      final routes = <String, WidgetBuilder>{
+        '/': (BuildContext context) => CupertinoPageScaffold(
+          child: CupertinoButton(
+            child: const Text('push'),
+            onPressed: () {
+              Navigator.of(context).pushNamed('/b');
+            },
+          ),
+        ),
+        '/b': (BuildContext context) => const CupertinoPageScaffold(child: Text('page b')),
+      };
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          theme: const CupertinoThemeData(brightness: Brightness.light),
+          routes: routes,
+        ),
+      );
+
+      expect(find.byType(CupertinoPageTransition), findsOneWidget);
+
+      await tester.tap(find.text('push'));
+      await tester.pumpAndSettle();
+      expect(find.text('page b'), findsOneWidget);
+      expect(find.byType(CupertinoPageTransition), findsOneWidget);
+    });
+
+    testWidgets('has correct transitionDuration of 500ms', (WidgetTester tester) async {
+      const builder = CupertinoPageTransitionsBuilder();
+
+      // CupertinoRouteTransitionMixin.kTransitionDuration is 500ms
+      expect(builder.transitionDuration, const Duration(milliseconds: 500));
+    });
+
+    testWidgets('has delegatedTransition', (WidgetTester tester) async {
+      const builder = CupertinoPageTransitionsBuilder();
+
+      expect(builder.delegatedTransition, isNotNull);
+      expect(builder.delegatedTransition, CupertinoPageTransition.delegatedTransition);
+    });
+
+    testWidgets('works with MaterialApp and PageTransitionsTheme', (WidgetTester tester) async {
+      final routes = <String, WidgetBuilder>{
+        '/': (BuildContext context) => Material(
+          child: TextButton(
+            child: const Text('push'),
+            onPressed: () {
+              Navigator.of(context).pushNamed('/b');
+            },
+          ),
+        ),
+        '/b': (BuildContext context) => const Text('page b'),
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            pageTransitionsTheme: const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+                TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+              },
+            ),
+          ),
+          routes: routes,
+        ),
+      );
+
+      expect(find.byType(CupertinoPageTransition), findsOneWidget);
+
+      await tester.tap(find.text('push'));
+      await tester.pumpAndSettle();
+      expect(find.text('page b'), findsOneWidget);
+      expect(find.byType(CupertinoPageTransition), findsOneWidget);
+    });
+  });
 }
 
 class MockNavigatorObserver extends NavigatorObserver {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -10,6 +10,7 @@ library;
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test_fixes/material/material.dart
+++ b/packages/flutter/test_fixes/material/material.dart
@@ -349,4 +349,11 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/166382
   Switch(activeColor: Colors.red, value: false, onChanged: null);
   SwitchListTile(activeColor: Colors.red, value: false, onChanged: null);
+
+  // Changes made in https://github.com/flutter/flutter/pull/179776
+  PageTransitionsTheme(
+    builders: <TargetPlatform, PageTransitionsBuilder>{
+      TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+    },
+  );
 }

--- a/packages/flutter/test_fixes/material/material.dart.expect
+++ b/packages/flutter/test_fixes/material/material.dart.expect
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -342,4 +343,11 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/166382
   Switch(activeThumbColor: Colors.red, value: false, onChanged: null);
   SwitchListTile(activeThumbColor: Colors.red, value: false, onChanged: null);
+
+  // Changes made in https://github.com/flutter/flutter/pull/179776
+  PageTransitionsTheme(
+    builders: <TargetPlatform, PageTransitionsBuilder>{
+      TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+    },
+  );
 }


### PR DESCRIPTION
Changes:

* Move CupertinoPageTransitionsBuilder from material/page_transitions_theme.dart to cupertino/route.dart

part of: https://github.com/flutter/flutter/issues/172929

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.