### PR TITLE
Switch to js_interop for web import configuration

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
@@ -10,7 +10,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
-    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+    if (dart.library.js_interop) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 

--- a/engine/src/flutter/lib/web_ui/test/ui/utils.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/utils.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
-    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+    if (dart.library.js_interop) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart';
 
 import '../common/rendering.dart';


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/61875

All conditional web imports should now use `dart.library.js_interop`, as per https://dart.dev/tools/pub/create-packages#conditionally-importing-and-exporting-library-files and https://github.com/dart-lang/sdk/issues/61875.