### PR TITLE
Make sure that a CupertinoTabView doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/cupertino/tab_test.dart
+++ b/packages/flutter/test/cupertino/tab_test.dart
@@ -323,4 +323,15 @@ void main() {
     // Navigator didn't pop, so first route is still visible
     expect(find.text('first route'), findsOneWidget);
   });
+
+  testWidgets('CupertinoTabView does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox.shrink(child: CupertinoTabView(builder: (context) => const Text('X'))),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CupertinoTabView)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CupertinoTabView widget.