### PR TITLE
Fix DecoratedSliver sample to avoid antialiasing gap

### DIFF
--- a/examples/api/lib/widgets/sliver/decorated_sliver.0.dart
+++ b/examples/api/lib/widgets/sliver/decorated_sliver.0.dart
@@ -33,31 +33,6 @@ class SliverDecorationExample extends StatelessWidget {
     return CustomScrollView(
       slivers: <Widget>[
         DecoratedSliver(
-          key: const ValueKey<String>('radial-gradient'),
-          decoration: const BoxDecoration(
-            gradient: RadialGradient(
-              center: Alignment(-0.5, -0.6),
-              radius: 0.15,
-              colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
-              stops: <double>[0.4, 0.8],
-            ),
-          ),
-          sliver: SliverList.list(
-            children: <Widget>[
-              SizedBox(
-                height: 200.0,
-                child: Center(
-                  child: Text(
-                    'A moon on a night sky',
-                    style: Theme.of(context).textTheme.titleLarge,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        DecoratedSliver(
-          key: const ValueKey<String>('linear-gradient'),
           decoration: const BoxDecoration(
             gradient: LinearGradient(
               begin: Alignment.topCenter,
@@ -74,18 +49,41 @@ class SliverDecorationExample extends StatelessWidget {
               ],
             ),
           ),
-          sliver: SliverList.list(
-            children: <Widget>[
-              SizedBox(
-                height: 500.0,
+          sliver: SliverMainAxisGroup(
+            slivers: <Widget>[
+              SliverToBoxAdapter(
                 child: Container(
-                  alignment: Alignment.topCenter,
-                  padding: const EdgeInsets.only(top: 56.0),
-                  child: Text(
-                    'A blue sky',
-                    style: Theme.of(context).textTheme.titleLarge,
+                  height: 200.0,
+                  decoration: const BoxDecoration(
+                    gradient: RadialGradient(
+                      center: Alignment(-0.5, -0.6),
+                      radius: 0.15,
+                      colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
+                      stops: <double>[0.4, 0.8],
+                    ),
+                  ),
+                  child: Center(
+                    child: Text(
+                      'A moon on a night sky',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
                   ),
                 ),
+              ),
+              SliverList.list(
+                children: <Widget>[
+                  SizedBox(
+                    height: 500.0,
+                    child: Container(
+                      alignment: Alignment.topCenter,
+                      padding: const EdgeInsets.only(top: 56.0),
+                      child: Text(
+                        'A blue sky',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/examples/api/test/widgets/sliver/decorated_sliver.0_test.dart
+++ b/examples/api/test/widgets/sliver/decorated_sliver.0_test.dart
@@ -18,67 +18,66 @@ void main() {
     expect(blueSkyText, findsOneWidget);
   });
 
-  testWidgets(
-    'Verify the DecoratedSliver has a LinearGradient',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const example.SliverDecorationExampleApp());
+  testWidgets('Verify the DecoratedSliver has a LinearGradient', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.SliverDecorationExampleApp());
 
-      final DecoratedSliver decoratedSliver = tester.widget<DecoratedSliver>(
-        find.byType(DecoratedSliver),
-      );
-      expect(
-        decoratedSliver.decoration,
-        const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: <Color>[
-              Color(0xFF111133),
-              Color(0xFF1A237E),
-              Color(0xFF283593),
-              Color(0xFF3949AB),
-              Color(0xFF3F51B5),
-              Color(0xFF1976D2),
-              Color(0xFF1E88E5),
-              Color(0xFF42A5F5),
-            ],
-          ),
+    final DecoratedSliver decoratedSliver = tester.widget<DecoratedSliver>(
+      find.byType(DecoratedSliver),
+    );
+    expect(
+      decoratedSliver.decoration,
+      const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: <Color>[
+            Color(0xFF111133),
+            Color(0xFF1A237E),
+            Color(0xFF283593),
+            Color(0xFF3949AB),
+            Color(0xFF3F51B5),
+            Color(0xFF1976D2),
+            Color(0xFF1E88E5),
+            Color(0xFF42A5F5),
+          ],
         ),
-      );
-    },
-  );
+      ),
+    );
+  });
 
-  testWidgets(
-    'Verify the moon section has a RadialGradient',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const example.SliverDecorationExampleApp());
+  testWidgets('Verify the moon section has a RadialGradient', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.SliverDecorationExampleApp());
 
-      final Container moonContainer = tester.widget<Container>(
-        find.ancestor(
-          of: find.text('A moon on a night sky'),
-          matching: find.byType(Container),
-        ).first,
-      );
-      expect(
-        moonContainer.decoration,
-        const BoxDecoration(
-          gradient: RadialGradient(
-            center: Alignment(-0.5, -0.6),
-            radius: 0.15,
-            colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
-            stops: <double>[0.4, 0.8],
-          ),
+    final Container moonContainer = tester.widget<Container>(
+      find
+          .ancestor(
+            of: find.text('A moon on a night sky'),
+            matching: find.byType(Container),
+          )
+          .first,
+    );
+    expect(
+      moonContainer.decoration,
+      const BoxDecoration(
+        gradient: RadialGradient(
+          center: Alignment(-0.5, -0.6),
+          radius: 0.15,
+          colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
+          stops: <double>[0.4, 0.8],
         ),
-      );
-    },
-  );
+      ),
+    );
+  });
 
-  testWidgets(
-    'Verify that SliverMainAxisGroup is used to group the slivers',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const example.SliverDecorationExampleApp());
+  testWidgets('Verify that SliverMainAxisGroup is used to group the slivers', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.SliverDecorationExampleApp());
 
-      expect(find.byType(SliverMainAxisGroup), findsOneWidget);
-    },
-  );
+    expect(find.byType(SliverMainAxisGroup), findsOneWidget);
+  });
 }

--- a/examples/api/test/widgets/sliver/decorated_sliver.0_test.dart
+++ b/examples/api/test/widgets/sliver/decorated_sliver.0_test.dart
@@ -19,39 +19,15 @@ void main() {
   });
 
   testWidgets(
-    'Verify the sliver with key `radial-gradient` has a RadialGradient',
+    'Verify the DecoratedSliver has a LinearGradient',
     (WidgetTester tester) async {
       await tester.pumpWidget(const example.SliverDecorationExampleApp());
 
-      final DecoratedSliver radialDecoratedSliver = tester
-          .widget<DecoratedSliver>(
-            find.byKey(const ValueKey<String>('radial-gradient')),
-          );
-      expect(
-        radialDecoratedSliver.decoration,
-        const BoxDecoration(
-          gradient: RadialGradient(
-            center: Alignment(-0.5, -0.6),
-            radius: 0.15,
-            colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
-            stops: <double>[0.4, 0.8],
-          ),
-        ),
+      final DecoratedSliver decoratedSliver = tester.widget<DecoratedSliver>(
+        find.byType(DecoratedSliver),
       );
-    },
-  );
-
-  testWidgets(
-    'Verify that the sliver with key `linear-gradient` has a LinearGradient',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const example.SliverDecorationExampleApp());
-
-      final DecoratedSliver linearDecoratedSliver = tester
-          .widget<DecoratedSliver>(
-            find.byKey(const ValueKey<String>('linear-gradient')),
-          );
       expect(
-        linearDecoratedSliver.decoration,
+        decoratedSliver.decoration,
         const BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topCenter,
@@ -69,6 +45,40 @@ void main() {
           ),
         ),
       );
+    },
+  );
+
+  testWidgets(
+    'Verify the moon section has a RadialGradient',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.SliverDecorationExampleApp());
+
+      final Container moonContainer = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('A moon on a night sky'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      expect(
+        moonContainer.decoration,
+        const BoxDecoration(
+          gradient: RadialGradient(
+            center: Alignment(-0.5, -0.6),
+            radius: 0.15,
+            colors: <Color>[Color(0xFFEEEEEE), Color(0xFF111133)],
+            stops: <double>[0.4, 0.8],
+          ),
+        ),
+      );
+    },
+  );
+
+  testWidgets(
+    'Verify that SliverMainAxisGroup is used to group the slivers',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.SliverDecorationExampleApp());
+
+      expect(find.byType(SliverMainAxisGroup), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Description

The DecoratedSliver sample was showing an antialiasing gap between two adjacent slivers when scrolling on desktop platforms (as reported in #166822).

The fix uses a single `DecoratedSliver` wrapping a `SliverMainAxisGroup` instead of two separate `DecoratedSliver` widgets. This eliminates the gap while still demonstrating the widget effectively.

Fixes https://github.com/flutter/flutter/issues/166822

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md


[![talabat.com contributions](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)