### PR TITLE
Fix web proxy incorrectly merging Set-Cookie headers

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
+++ b/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
@@ -10,6 +10,66 @@ import '../web/devfs_proxy.dart';
 
 const _kLogEntryPrefix = '[proxyMiddleware]';
 
+const Set<String> _kCookieAttributes = <String>{
+  'path',
+  'domain',
+  'expires',
+  'max-age',
+  'secure',
+  'httponly',
+  'samesite',
+  'partitioned',
+};
+
+List<String> splitSetCookieHeader(String headerValue) {
+  if (headerValue.isEmpty) {
+    return <String>[];
+  }
+
+  final cookies = <String>[];
+  final currentCookie = StringBuffer();
+  final List<String> parts = headerValue.split(', ');
+
+  for (var i = 0; i < parts.length; i++) {
+    final String part = parts[i];
+
+    if (currentCookie.isEmpty) {
+      currentCookie.write(part);
+    } else if (_isNewCookie(part)) {
+      cookies.add(currentCookie.toString());
+      currentCookie.clear();
+      currentCookie.write(part);
+    } else {
+      currentCookie.write(', $part');
+    }
+  }
+
+  if (currentCookie.isNotEmpty) {
+    cookies.add(currentCookie.toString());
+  }
+
+  return cookies;
+}
+
+bool _isNewCookie(String part) {
+  final int equalsIndex = part.indexOf('=');
+  if (equalsIndex <= 0) {
+    return false;
+  }
+
+  final String beforeEquals = part.substring(0, equalsIndex);
+  final int lastSemicolon = beforeEquals.lastIndexOf(';');
+  final int lastSpace = beforeEquals.lastIndexOf(' ');
+  final int tokenStart = (lastSemicolon > lastSpace ? lastSemicolon : lastSpace) + 1;
+  final String token = beforeEquals.substring(tokenStart).trim().toLowerCase();
+
+  if (token.isEmpty || _kCookieAttributes.contains(token)) {
+    return false;
+  }
+
+  return RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(token);
+}
+
 /// Creates a new [shelf.Request] by proxying an [originalRequest] to a [finalTargetUrl].
 ///
 /// The new request will have the same method, headers, body, and context as the
@@ -44,9 +104,14 @@ Future<shelf.Response> _applyProxyRules(
     final Uri finalTargetUrl = rule.finalTargetUri(request.requestedUri);
     try {
       final shelf.Request proxyBackendRequest = proxyRequest(request, finalTargetUrl);
-      final shelf.Response proxyResponse = await handler(proxyBackendRequest);
+      shelf.Response proxyResponse = await handler(proxyBackendRequest);
       logger.printStatus('$_kLogEntryPrefix Matched "$requestPath". Requesting "$finalTargetUrl"');
       logger.printTrace('$_kLogEntryPrefix Matched with proxy rule: $rule');
+      if (proxyResponse.statusCode == 404) {
+        logger.printTrace('$_kLogEntryPrefix "$finalTargetUrl" responded with status 404');
+        return innerHandler(request);
+      }
+      proxyResponse = _fixSetCookieHeaders(proxyResponse);
       return proxyResponse;
     } on Exception catch (e) {
       logger.printError('$_kLogEntryPrefix Error for $finalTargetUrl: $e. Allowing fall-through.');
@@ -54,6 +119,22 @@ Future<shelf.Response> _applyProxyRules(
     }
   }
   return innerHandler(request);
+}
+
+shelf.Response _fixSetCookieHeaders(shelf.Response response) {
+  final String? setCookieHeader = response.headers['set-cookie'];
+  if (setCookieHeader == null) {
+    return response;
+  }
+
+  final List<String> cookies = splitSetCookieHeader(setCookieHeader);
+  if (cookies.length <= 1) {
+    return response;
+  }
+
+  final newHeaders = Map<String, Object>.from(response.headers);
+  newHeaders['set-cookie'] = cookies;
+  return response.change(headers: newHeaders);
 }
 
 /// Creates a [shelf.Middleware] that proxies requests based on a list of [ProxyRule]s.

--- a/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
+++ b/packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
@@ -67,7 +67,7 @@ bool _isNewCookie(String part) {
     return false;
   }
 
-  return RegExp(r'^[a-zA-Z0-9_\-]+$').hasMatch(token);
+  return RegExp(r'^[a-zA-Z0-9_.\-]+$').hasMatch(token);
 }
 
 /// Creates a new [shelf.Request] by proxying an [originalRequest] to a [finalTargetUrl].

--- a/packages/flutter_tools/test/general.shard/web/proxy_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/proxy_test.dart
@@ -537,5 +537,15 @@ void main() {
         'other=xyz; Secure',
       ]);
     });
+
+    test('should handle cookie name with a dot', () {
+      final List<String> result = splitSetCookieHeader(
+        'app.session=123; Path=/, other.id=456',
+      );
+      expect(result, <String>[
+        'app.session=123; Path=/',
+        'other.id=456',
+      ]);
+    });
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/proxy_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/proxy_test.dart
@@ -445,4 +445,97 @@ void main() {
       },
     );
   });
+
+  group('splitSetCookieHeader', () {
+    test('should return single cookie unchanged', () {
+      final List<String> result = splitSetCookieHeader('sessionid=abc123; Path=/; HttpOnly');
+      expect(result, <String>['sessionid=abc123; Path=/; HttpOnly']);
+    });
+
+    test('should split two simple cookies', () {
+      final List<String> result = splitSetCookieHeader(
+        'csrftoken=abc; Path=/; SameSite=Lax, sessionid=xyz; Path=/; HttpOnly; SameSite=Lax',
+      );
+      expect(result, <String>[
+        'csrftoken=abc; Path=/; SameSite=Lax',
+        'sessionid=xyz; Path=/; HttpOnly; SameSite=Lax',
+      ]);
+    });
+
+    test('should handle cookies with Expires containing comma in date', () {
+      final List<String> result = splitSetCookieHeader(
+        'token=abc; Expires=Thu, 01 Jan 2025 00:00:00 GMT; Path=/, session=xyz; Path=/',
+      );
+      expect(result, <String>[
+        'token=abc; Expires=Thu, 01 Jan 2025 00:00:00 GMT; Path=/',
+        'session=xyz; Path=/',
+      ]);
+    });
+
+    test('should handle multiple cookies with Expires dates', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Expires=Mon, 01 Jan 2024 00:00:00 GMT, b=2; Expires=Tue, 02 Jan 2024 00:00:00 GMT',
+      );
+      expect(result, <String>[
+        'a=1; Expires=Mon, 01 Jan 2024 00:00:00 GMT',
+        'b=2; Expires=Tue, 02 Jan 2024 00:00:00 GMT',
+      ]);
+    });
+
+    test('should handle cookies with Max-Age attribute', () {
+      final List<String> result = splitSetCookieHeader(
+        'cookie1=value1; Max-Age=3600; Path=/, cookie2=value2; Max-Age=7200',
+      );
+      expect(result, <String>[
+        'cookie1=value1; Max-Age=3600; Path=/',
+        'cookie2=value2; Max-Age=7200',
+      ]);
+    });
+
+    test('should handle cookies with Domain attribute', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Domain=.example.com; Path=/, b=2; Domain=.test.com',
+      );
+      expect(result, <String>[
+        'a=1; Domain=.example.com; Path=/',
+        'b=2; Domain=.test.com',
+      ]);
+    });
+
+    test('should handle cookies with SameSite attribute', () {
+      final List<String> result = splitSetCookieHeader(
+        'csrf=token; SameSite=Strict, session=id; SameSite=Lax',
+      );
+      expect(result, <String>[
+        'csrf=token; SameSite=Strict',
+        'session=id; SameSite=Lax',
+      ]);
+    });
+
+    test('should handle three or more cookies', () {
+      final List<String> result = splitSetCookieHeader(
+        'a=1; Path=/, b=2; Path=/, c=3; Path=/',
+      );
+      expect(result, <String>[
+        'a=1; Path=/',
+        'b=2; Path=/',
+        'c=3; Path=/',
+      ]);
+    });
+
+    test('should handle empty string', () {
+      final List<String> result = splitSetCookieHeader('');
+      expect(result, <String>[]);
+    });
+
+    test('should handle cookie with Secure and HttpOnly flags', () {
+      final List<String> result = splitSetCookieHeader(
+        'token=abc; Secure; HttpOnly; Path=/, other=xyz; Secure',
+      );
+      expect(result, <String>[
+        'token=abc; Secure; HttpOnly; Path=/',
+        'other=xyz; Secure',
+      ]);
+    });
+  });
 }

--- a/packages/flutter_tools/test/general.shard/web/proxy_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/proxy_test.dart
@@ -496,31 +496,19 @@ void main() {
       final List<String> result = splitSetCookieHeader(
         'a=1; Domain=.example.com; Path=/, b=2; Domain=.test.com',
       );
-      expect(result, <String>[
-        'a=1; Domain=.example.com; Path=/',
-        'b=2; Domain=.test.com',
-      ]);
+      expect(result, <String>['a=1; Domain=.example.com; Path=/', 'b=2; Domain=.test.com']);
     });
 
     test('should handle cookies with SameSite attribute', () {
       final List<String> result = splitSetCookieHeader(
         'csrf=token; SameSite=Strict, session=id; SameSite=Lax',
       );
-      expect(result, <String>[
-        'csrf=token; SameSite=Strict',
-        'session=id; SameSite=Lax',
-      ]);
+      expect(result, <String>['csrf=token; SameSite=Strict', 'session=id; SameSite=Lax']);
     });
 
     test('should handle three or more cookies', () {
-      final List<String> result = splitSetCookieHeader(
-        'a=1; Path=/, b=2; Path=/, c=3; Path=/',
-      );
-      expect(result, <String>[
-        'a=1; Path=/',
-        'b=2; Path=/',
-        'c=3; Path=/',
-      ]);
+      final List<String> result = splitSetCookieHeader('a=1; Path=/, b=2; Path=/, c=3; Path=/');
+      expect(result, <String>['a=1; Path=/', 'b=2; Path=/', 'c=3; Path=/']);
     });
 
     test('should handle empty string', () {
@@ -532,20 +520,12 @@ void main() {
       final List<String> result = splitSetCookieHeader(
         'token=abc; Secure; HttpOnly; Path=/, other=xyz; Secure',
       );
-      expect(result, <String>[
-        'token=abc; Secure; HttpOnly; Path=/',
-        'other=xyz; Secure',
-      ]);
+      expect(result, <String>['token=abc; Secure; HttpOnly; Path=/', 'other=xyz; Secure']);
     });
 
     test('should handle cookie name with a dot', () {
-      final List<String> result = splitSetCookieHeader(
-        'app.session=123; Path=/, other.id=456',
-      );
-      expect(result, <String>[
-        'app.session=123; Path=/',
-        'other.id=456',
-      ]);
+      final List<String> result = splitSetCookieHeader('app.session=123; Path=/, other.id=456');
+      expect(result, <String>['app.session=123; Path=/', 'other.id=456']);
     });
   });
 }


### PR DESCRIPTION
## Description

Fixes the web dev server proxy incorrectly merging multiple Set-Cookie headers into one comma-separated value.

Fixes https://github.com/flutter/flutter/issues/178582

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md


[![talabat.com contributions](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)