### PR TITLE
Fix RenderParagraph.textAlign setter to call markNeedsLayout

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -555,7 +555,7 @@ class RenderParagraph extends RenderBox
       return;
     }
     _textPainter.textAlign = value;
-    markNeedsPaint();
+    markNeedsLayout();
   }
 
   /// The directionality of the text.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -374,7 +374,7 @@ void main() {
     expect(paragraph.size.height, 30.0);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61018
 
-  test('textAlign triggers TextPainter relayout in the paint method', () {
+  test('changing textAlign triggers layout', () {
     final paragraph = RenderParagraph(
       const TextSpan(text: 'A', style: TextStyle(fontSize: 10.0)),
       textDirection: TextDirection.ltr,
@@ -391,10 +391,9 @@ void main() {
     expect(getRectForA(), const Rect.fromLTWH(0, 0, 10, 10));
 
     paragraph.textAlign = TextAlign.right;
-    expect(paragraph.debugNeedsLayout, isFalse);
-    expect(paragraph.debugNeedsPaint, isTrue);
+    expect(paragraph.debugNeedsLayout, isTrue);
 
-    paragraph.paint(MockPaintingContext(), Offset.zero);
+    pumpFrame();
     expect(getRectForA(), const Rect.fromLTWH(90, 0, 10, 10));
   });
 


### PR DESCRIPTION
## Problem

When you change `textAlign` on a `RenderParagraph`, the parent widget doesn't know the layout changed.

**Example:** If you use `LayoutBuilder` to position elements based on text alignment, changing from `TextAlign.left` to `TextAlign.right` won't trigger a rebuild - even though the text moved.

## Cause

The `textAlign` setter was calling `markNeedsPaint()` (just repaint) instead of `markNeedsLayout()` (recalculate layout).

## Fix

One line change: `markNeedsPaint()` → `markNeedsLayout()`

This matches how other setters like `textDirection` and `softWrap` already work.

## Fixes

https://github.com/flutter/flutter/issues/140756

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md