### PR TITLE
Filter out FrameEvents/updateAcquireFence log spam from adb logcat

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -1154,6 +1154,11 @@ class AdbLogReader extends DeviceLogReader {
     // Some versions of Android spew this out. It is inactionable to the end user
     // and causes no problems for the application.
     RegExp(r'^E/SurfaceSyncer\(\s*\d+\): Failed to find sync for id=\d+'),
+    // E/FrameEvents(26685): updateAcquireFence: Did not find frame.
+    // This is a HWUI bug that spams the console when using platform views like Google Maps.
+    // It is not an actual error and causes no problems for the application.
+    // See https://github.com/flutter/flutter/issues/104268
+    RegExp(r'^E/FrameEvents\(\s*\d+\): updateAcquireFence: Did not find frame'),
     // See https://github.com/flutter/flutter/issues/160598
     RegExp(r'ViewPostIme pointer'),
     RegExp(r'mali.instrumentation.graph.work'),

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -1158,7 +1158,7 @@ class AdbLogReader extends DeviceLogReader {
     // This is a HWUI bug that spams the console when using platform views like Google Maps.
     // It is not an actual error and causes no problems for the application.
     // See https://github.com/flutter/flutter/issues/104268
-    RegExp(r'^E/FrameEvents\(\s*\d+\): updateAcquireFence: Did not find frame'),
+    RegExp(r'^E/FrameEvents\(\s*\d+\): updateAcquireFence: Did not find frame\.$'),
     // See https://github.com/flutter/flutter/issues/160598
     RegExp(r'ViewPostIme pointer'),
     RegExp(r'mali.instrumentation.graph.work'),


### PR DESCRIPTION
## Problem

When using platform views like Google Maps on Android, the console gets flooded with messages like:

```
E/FrameEvents(26685): updateAcquireFence: Did not find frame.
E/FrameEvents(26685): updateAcquireFence: Did not find frame.
E/FrameEvents(26685): updateAcquireFence: Did not find frame.
... (repeats many times)
```

This makes it hard to see actual errors and warnings in the console.

## Cause

This is a HWUI bug in Android, not an actual error. The message doesn't indicate any problem with the application.

## Fix

Add a regex filter to `_filteredMessagees` in `AdbLogReader` to suppress these messages, following the same pattern used for similar spam messages like `SurfaceSyncer` and `ViewPostIme pointer`.

## Fixes

https://github.com/flutter/flutter/issues/104268

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md