### PR TITLE
Suppress deprecated AChoreographer_postFrameCallback warning

### DIFF
--- a/engine/src/flutter/impeller/toolkit/android/proc_table.h
+++ b/engine/src/flutter/impeller/toolkit/android/proc_table.h
@@ -119,10 +119,17 @@ struct ProcTable {
   ///
   bool TraceIsEnabled() const;
 
+// The proc table references AChoreographer_postFrameCallback which is
+// deprecated in API level 29+. We suppress the warning because we dynamically
+// check for AChoreographer_postFrameCallback64 availability at runtime and
+// only use the older API on devices where the new one is not available.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #define DEFINE_PROC(name, api) \
   AndroidProc<decltype(name)> name = {.proc_name = #name};
   FOR_EACH_ANDROID_PROC(DEFINE_PROC);
 #undef DEFINE_PROC
+#pragma GCC diagnostic pop
 
  private:
   std::vector<fml::RefPtr<fml::NativeLibrary>> libraries_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173656

## Description

This PR suppresses the deprecation warning for `AChoreographer_postFrameCallback` in `proc_table.h`.

When building the engine against Android API level 35 (required for RISC-V), the build fails because Flutter treats deprecation warnings as errors:

```
warning: 'AChoreographer_postFrameCallback' is deprecated: first deprecated in Android 29 - Use AChoreographer_postFrameCallback64 instead [-Wdeprecated-declarations]
```

## Solution

As suggested by @chinmaygarde in the issue, we suppress the warning using `#pragma GCC diagnostic` because:
- The proc table already dynamically checks for `AChoreographer_postFrameCallback64` availability at runtime
- The older API is only used on devices where the new one is not available
- There is no risk of runtime errors

This follows the same pattern used elsewhere in the codebase (e.g., `FlutterAppDelegate.mm`).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md