### PR TITLE
[ios][pv] quick fix to enable and re-enable web view's gesture recognizer

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -589,14 +589,21 @@ static BOOL _preparedOnce = NO;
 }
 
 - (void)searchAndFixWebViewGestureRecognzier:(UIView*)view {
-  NSArray* recognizers = view.gestureRecognizers;
-  if (recognizers != nil && recognizers.count > 0) {
-    for (UIGestureRecognizer* recognizer in recognizers) {
-      if (recognizer.enabled &&
-          [NSStringFromClass([recognizer class]) hasSuffix:@"TouchEventsGestureRecognizer"]) {
-        recognizer.enabled = NO;
-        recognizer.enabled = YES;
-      }
+  for (UIGestureRecognizer* recognizer in view.gestureRecognizers) {
+    // This is to fix a bug on iOS 26 where web view link is not tappable.
+    // We reset the web view's WKTouchEventsGestureRecognizer in a bad state
+    // by disabling and re-enabling it.
+    // See: https://github.com/flutter/flutter/issues/175099.
+    // See also: https://github.com/flutter/engine/pull/56804 for an explanation of the
+    // bug on iOS 18.2, which is still valid on iOS 26.
+    // Warning: This is just a quick fix that patches the bug. For example,
+    // touches on a drawing website is still not completely blocked. A proper solution
+    // should rely on overriding the hitTest behavior.
+    // See: https://github.com/flutter/flutter/issues/179916.
+    if (recognizer.enabled &&
+        [NSStringFromClass([recognizer class]) hasSuffix:@"TouchEventsGestureRecognizer"]) {
+      recognizer.enabled = NO;
+      recognizer.enabled = YES;
     }
   }
   for (UIView* subview in view.subviews) {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -629,7 +629,12 @@ static BOOL _preparedOnce = NO;
         // This performs a nested DFS, with the outer one searching for any web view, and the inner
         // one searching for a TouchEventsGestureRecognizer inside the web view. Once found, disable
         // and immediately reenable it to reset its state.
-        [self searchAndFixWebView:self.embeddedView];
+        // TODO(hellohuanlin): remove this flag after it is battle tested.
+        NSNumber* isWorkaroundDisabled =
+            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTDisableWebViewGestureReset"];
+        if (!isWorkaroundDisabled.boolValue) {
+          [self searchAndFixWebView:self.embeddedView];
+        }
       } else if (@available(iOS 18.2, *)) {
         // This workaround is designed for WKWebView only. The 1P web view plugin provides a
         // WKWebView itself as the platform view. However, some 3P plugins provide wrappers of

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -48,6 +48,32 @@ const float kFloatCompareEpsilon = 0.001;
 
 @end
 
+// A mock recognizer without "TouchEventsGestureRecognizer" suffix in class name
+@interface MockGestureRecognizer : UIGestureRecognizer
+@property(nonatomic, strong) NSMutableArray<NSNumber*>* toggleHistory;
+@end
+
+@implementation MockGestureRecognizer
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _toggleHistory = [NSMutableArray array];
+  }
+  return self;
+}
+- (void)setEnabled:(BOOL)enabled {
+  [super setEnabled:enabled];
+  [self.toggleHistory addObject:@(enabled)];
+}
+@end
+
+// A mock recognizer with "TouchEventsGestureRecognizer" suffix in class name.
+@interface MockTouchEventsGestureRecognizer : MockGestureRecognizer
+@end
+
+@implementation MockTouchEventsGestureRecognizer
+@end
+
 @interface FlutterPlatformViewsTestMockFlutterPlatformView : NSObject <FlutterPlatformView>
 @property(nonatomic, strong) UIView* view;
 @property(nonatomic, assign) BOOL viewCreated;
@@ -3490,6 +3516,429 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
   XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+}
+
+- (void)
+    testFlutterPlatformViewBlockGestureUnderEagerPolicyShouldDisableAndReEnableTouchEventsGestureRecognizerForSimpleWebView {
+  if (@available(iOS 26.0, *)) {
+    flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+    flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                                 /*platform=*/GetDefaultTaskRunner(),
+                                 /*raster=*/GetDefaultTaskRunner(),
+                                 /*ui=*/GetDefaultTaskRunner(),
+                                 /*io=*/GetDefaultTaskRunner());
+    FlutterPlatformViewsController* flutterPlatformViewsController =
+        [[FlutterPlatformViewsController alloc] init];
+    flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+    auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+        /*delegate=*/mock_delegate,
+        /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+        /*platform_views_controller=*/flutterPlatformViewsController,
+        /*task_runners=*/runners,
+        /*worker_task_runner=*/nil,
+        /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+    FlutterPlatformViewsTestMockWebViewFactory* factory =
+        [[FlutterPlatformViewsTestMockWebViewFactory alloc] init];
+    [flutterPlatformViewsController
+                     registerViewFactory:factory
+                                  withId:@"MockWebView"
+        gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+    FlutterResult result = ^(id result) {
+    };
+    [flutterPlatformViewsController
+        onMethodCall:[FlutterMethodCall
+                         methodCallWithMethodName:@"create"
+                                        arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+              result:result];
+
+    XCTAssertNotNil(gMockPlatformView);
+
+    // Find touch inteceptor view
+    UIView* touchInteceptorView = gMockPlatformView;
+    while (touchInteceptorView != nil &&
+           ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+      touchInteceptorView = touchInteceptorView.superview;
+    }
+    XCTAssertNotNil(touchInteceptorView);
+
+    /*
+      Simple Web View at root, with [*] indicating views containing
+      MockTouchEventsGestureRecognizer.
+
+      Root (Web View) [*]
+        ├── Child 1
+        └── Child 2
+              ├── Child 2.1
+              └── Child 2.2 [*]
+    */
+
+    UIView* root = gMockPlatformView;
+    root.gestureRecognizers = nil;
+    for (UIView* subview in root.subviews) {
+      [subview removeFromSuperview];
+    }
+
+    MockGestureRecognizer* normalRecognizer0 = [[MockGestureRecognizer alloc] init];
+    [root addGestureRecognizer:normalRecognizer0];
+
+    UIView* child1 = [[UIView alloc] init];
+    [root addSubview:child1];
+    MockGestureRecognizer* normalRecognizer1 = [[MockGestureRecognizer alloc] init];
+    [child1 addGestureRecognizer:normalRecognizer1];
+
+    UIView* child2 = [[UIView alloc] init];
+    [root addSubview:child2];
+    MockGestureRecognizer* normalRecognizer2 = [[MockGestureRecognizer alloc] init];
+    [child2 addGestureRecognizer:normalRecognizer2];
+
+    UIView* child2_1 = [[UIView alloc] init];
+    [child2 addSubview:child2_1];
+    MockGestureRecognizer* normalRecognizer2_1 = [[MockGestureRecognizer alloc] init];
+    [child2_1 addGestureRecognizer:normalRecognizer2_1];
+
+    UIView* child2_2 = [[UIView alloc] init];
+    [child2 addSubview:child2_2];
+    MockGestureRecognizer* normalRecognizer2_2 = [[MockGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:normalRecognizer2_2];
+
+    // Add the target recognizer at root & child2_2.
+    MockTouchEventsGestureRecognizer* targetRecognizer0 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [root addGestureRecognizer:targetRecognizer0];
+
+    MockTouchEventsGestureRecognizer* targetRecognizer2_2 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:targetRecognizer2_2];
+
+    [(FlutterTouchInterceptingView*)touchInteceptorView blockGesture];
+
+    NSArray* normalRecognizers = @[
+      normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
+      normalRecognizer2_2
+    ];
+
+    NSArray* targetRecognizers = @[ targetRecognizer0, targetRecognizer2_2 ];
+
+    NSArray* expectedEmptyHistory = @[];
+    NSArray* expectedToggledHistory = @[ @NO, @YES ];
+
+    for (MockGestureRecognizer* recognizer in normalRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedEmptyHistory);
+    }
+    for (MockGestureRecognizer* recognizer in targetRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedToggledHistory);
+    }
+  }
+}
+
+- (void)
+    testFlutterPlatformViewBlockGestureUnderEagerPolicyShouldDisableAndReEnableTouchEventsGestureRecognizerForMultipleWebViewInDifferentBranches {
+  if (@available(iOS 26.0, *)) {
+    flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+    flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                                 /*platform=*/GetDefaultTaskRunner(),
+                                 /*raster=*/GetDefaultTaskRunner(),
+                                 /*ui=*/GetDefaultTaskRunner(),
+                                 /*io=*/GetDefaultTaskRunner());
+    FlutterPlatformViewsController* flutterPlatformViewsController =
+        [[FlutterPlatformViewsController alloc] init];
+    flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+    auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+        /*delegate=*/mock_delegate,
+        /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+        /*platform_views_controller=*/flutterPlatformViewsController,
+        /*task_runners=*/runners,
+        /*worker_task_runner=*/nil,
+        /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+    FlutterPlatformViewsTestMockWrapperWebViewFactory* factory =
+        [[FlutterPlatformViewsTestMockWrapperWebViewFactory alloc] init];
+    [flutterPlatformViewsController
+                     registerViewFactory:factory
+                                  withId:@"MockWrapperWebView"
+        gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+    FlutterResult result = ^(id result) {
+    };
+    [flutterPlatformViewsController
+        onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                       arguments:@{
+                                                         @"id" : @2,
+                                                         @"viewType" : @"MockWrapperWebView"
+                                                       }]
+              result:result];
+
+    XCTAssertNotNil(gMockPlatformView);
+
+    // Find touch inteceptor view
+    UIView* touchInteceptorView = gMockPlatformView;
+    while (touchInteceptorView != nil &&
+           ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+      touchInteceptorView = touchInteceptorView.superview;
+    }
+    XCTAssertNotNil(touchInteceptorView);
+
+    /*
+      Platform View with Multiple Web Views in different branches, with [*] indicating views
+      containing MockTouchEventsGestureRecognizer.
+
+      Root (Platform View)
+        ├── Child 1
+        ├── Child 2 (Web View)
+        |       ├── Child 2.1
+        |       └── Child 2.2 [*]
+        └── Child 3
+                └── Child 3.1 (Web View)
+                        ├── Child 3.1.1
+                        └── Child 3.1.2 [*]
+      */
+
+    UIView* root = gMockPlatformView;
+    for (UIView* subview in root.subviews) {
+      [subview removeFromSuperview];
+    }
+
+    MockGestureRecognizer* normalRecognizer0 = [[MockGestureRecognizer alloc] init];
+    [root addGestureRecognizer:normalRecognizer0];
+
+    UIView* child1 = [[UIView alloc] init];
+    [root addSubview:child1];
+    MockGestureRecognizer* normalRecognizer1 = [[MockGestureRecognizer alloc] init];
+    [child1 addGestureRecognizer:normalRecognizer1];
+
+    UIView* child2 = [[WKWebView alloc] init];
+    child2.gestureRecognizers = nil;
+    for (UIView* subview in child2.subviews) {
+      [subview removeFromSuperview];
+    }
+    [root addSubview:child2];
+    MockGestureRecognizer* normalRecognizer2 = [[MockGestureRecognizer alloc] init];
+    [child2 addGestureRecognizer:normalRecognizer2];
+
+    UIView* child2_1 = [[UIView alloc] init];
+    [child2 addSubview:child2_1];
+    MockGestureRecognizer* normalRecognizer2_1 = [[MockGestureRecognizer alloc] init];
+    [child2_1 addGestureRecognizer:normalRecognizer2_1];
+
+    UIView* child2_2 = [[UIView alloc] init];
+    [child2 addSubview:child2_2];
+    MockGestureRecognizer* normalRecognizer2_2 = [[MockGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:normalRecognizer2_2];
+
+    UIView* child3 = [[UIView alloc] init];
+    [root addSubview:child3];
+    MockGestureRecognizer* normalRecognizer3 = [[MockGestureRecognizer alloc] init];
+    [child3 addGestureRecognizer:normalRecognizer3];
+
+    UIView* child3_1 = [[WKWebView alloc] init];
+    child3_1.gestureRecognizers = nil;
+    for (UIView* subview in child3_1.subviews) {
+      [subview removeFromSuperview];
+    }
+    [child3 addSubview:child3_1];
+    MockGestureRecognizer* normalRecognizer3_1 = [[MockGestureRecognizer alloc] init];
+    [child3_1 addGestureRecognizer:normalRecognizer3_1];
+
+    UIView* child3_1_1 = [[UIView alloc] init];
+    [child3_1 addSubview:child3_1_1];
+    MockGestureRecognizer* normalRecognizer3_1_1 = [[MockGestureRecognizer alloc] init];
+    [child3_1_1 addGestureRecognizer:normalRecognizer3_1_1];
+
+    UIView* child3_1_2 = [[UIView alloc] init];
+    [child3_1 addSubview:child3_1_2];
+    MockGestureRecognizer* normalRecognizer3_1_2 = [[MockGestureRecognizer alloc] init];
+    [child3_1_2 addGestureRecognizer:normalRecognizer3_1_2];
+
+    // Add the target recognizer at child2_2 & child3_1_2
+
+    MockTouchEventsGestureRecognizer* targetRecognizer2_2 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:targetRecognizer2_2];
+
+    MockTouchEventsGestureRecognizer* targetRecognizer3_1_2 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [child3_1_2 addGestureRecognizer:targetRecognizer3_1_2];
+
+    [(FlutterTouchInterceptingView*)touchInteceptorView blockGesture];
+
+    NSArray* normalRecognizers = @[
+      normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
+      normalRecognizer2_2, normalRecognizer3, normalRecognizer3_1, normalRecognizer3_1_1,
+      normalRecognizer3_1_2
+    ];
+    NSArray* targetRecognizers = @[ targetRecognizer2_2, targetRecognizer3_1_2 ];
+
+    NSArray* expectedEmptyHistory = @[];
+    NSArray* expectedToggledHistory = @[ @NO, @YES ];
+
+    for (MockGestureRecognizer* recognizer in normalRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedEmptyHistory);
+    }
+
+    for (MockGestureRecognizer* recognizer in targetRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedToggledHistory);
+    }
+  }
+}
+
+- (void)
+    testFlutterPlatformViewBlockGestureUnderEagerPolicyShouldDisableAndReEnableTouchEventsGestureRecognizerForNestedMultipleWebView {
+  if (@available(iOS 26.0, *)) {
+    flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+    flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                                 /*platform=*/GetDefaultTaskRunner(),
+                                 /*raster=*/GetDefaultTaskRunner(),
+                                 /*ui=*/GetDefaultTaskRunner(),
+                                 /*io=*/GetDefaultTaskRunner());
+    FlutterPlatformViewsController* flutterPlatformViewsController =
+        [[FlutterPlatformViewsController alloc] init];
+    flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+    auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+        /*delegate=*/mock_delegate,
+        /*rendering_api=*/flutter::IOSRenderingAPI::kMetal,
+        /*platform_views_controller=*/flutterPlatformViewsController,
+        /*task_runners=*/runners,
+        /*worker_task_runner=*/nil,
+        /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+    FlutterPlatformViewsTestMockWebViewFactory* factory =
+        [[FlutterPlatformViewsTestMockWebViewFactory alloc] init];
+    [flutterPlatformViewsController
+                     registerViewFactory:factory
+                                  withId:@"MockWebView"
+        gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+    FlutterResult result = ^(id result) {
+    };
+    [flutterPlatformViewsController
+        onMethodCall:[FlutterMethodCall
+                         methodCallWithMethodName:@"create"
+                                        arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}]
+              result:result];
+
+    XCTAssertNotNil(gMockPlatformView);
+
+    // Find touch inteceptor view
+    UIView* touchInteceptorView = gMockPlatformView;
+    while (touchInteceptorView != nil &&
+           ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+      touchInteceptorView = touchInteceptorView.superview;
+    }
+    XCTAssertNotNil(touchInteceptorView);
+
+    /*
+      Platform View with nested web views, with [*] indicating views containing
+    MockTouchEventsGestureRecognizer.
+
+    Root (Web View)
+      ├── Child 1
+      ├── Child 2
+      |     ├── Child 2.1
+      |     └── Child 2.2 [*]
+      └── Child 3
+            └── Child 3.1 (Another Web View)
+                  └── Child 3.1.1
+                  └── Child 3.1.2
+                        ├── Child 3.1.2.1
+                        └── Child 3.1.2.2 [*]
+      */
+
+    UIView* root = gMockPlatformView;
+    root.gestureRecognizers = nil;
+    for (UIView* subview in root.subviews) {
+      [subview removeFromSuperview];
+    }
+
+    MockGestureRecognizer* normalRecognizer0 = [[MockGestureRecognizer alloc] init];
+    [root addGestureRecognizer:normalRecognizer0];
+
+    UIView* child1 = [[UIView alloc] init];
+    [root addSubview:child1];
+    MockGestureRecognizer* normalRecognizer1 = [[MockGestureRecognizer alloc] init];
+    [child1 addGestureRecognizer:normalRecognizer1];
+
+    UIView* child2 = [[UIView alloc] init];
+    [root addSubview:child2];
+    MockGestureRecognizer* normalRecognizer2 = [[MockGestureRecognizer alloc] init];
+    [child2 addGestureRecognizer:normalRecognizer2];
+
+    UIView* child2_1 = [[UIView alloc] init];
+    [child2 addSubview:child2_1];
+    MockGestureRecognizer* normalRecognizer2_1 = [[MockGestureRecognizer alloc] init];
+    [child2_1 addGestureRecognizer:normalRecognizer2_1];
+
+    UIView* child2_2 = [[UIView alloc] init];
+    [child2 addSubview:child2_2];
+    MockGestureRecognizer* normalRecognizer2_2 = [[MockGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:normalRecognizer2_2];
+
+    UIView* child3 = [[UIView alloc] init];
+    [root addSubview:child3];
+    MockGestureRecognizer* normalRecognizer3 = [[MockGestureRecognizer alloc] init];
+    [child3 addGestureRecognizer:normalRecognizer3];
+
+    UIView* child3_1 = [[WKWebView alloc] init];
+    child3_1.gestureRecognizers = nil;
+    for (UIView* subview in child3_1.subviews) {
+      [subview removeFromSuperview];
+    }
+    [child3 addSubview:child3_1];
+    MockGestureRecognizer* normalRecognizer3_1 = [[MockGestureRecognizer alloc] init];
+    [child3_1 addGestureRecognizer:normalRecognizer3_1];
+
+    UIView* child3_1_1 = [[UIView alloc] init];
+    [child3_1 addSubview:child3_1_1];
+    MockGestureRecognizer* normalRecognizer3_1_1 = [[MockGestureRecognizer alloc] init];
+    [child3_1_1 addGestureRecognizer:normalRecognizer3_1_1];
+
+    UIView* child3_1_2 = [[UIView alloc] init];
+    [child3_1 addSubview:child3_1_2];
+    MockGestureRecognizer* normalRecognizer3_1_2 = [[MockGestureRecognizer alloc] init];
+    [child3_1_2 addGestureRecognizer:normalRecognizer3_1_2];
+
+    UIView* child3_1_2_1 = [[UIView alloc] init];
+    [child3_1_2 addSubview:child3_1_2_1];
+    MockGestureRecognizer* normalRecognizer3_1_2_1 = [[MockGestureRecognizer alloc] init];
+    [child3_1_2_1 addGestureRecognizer:normalRecognizer3_1_2_1];
+
+    UIView* child3_1_2_2 = [[UIView alloc] init];
+    [child3_1_2 addSubview:child3_1_2_2];
+    MockGestureRecognizer* normalRecognizer3_1_2_2 = [[MockGestureRecognizer alloc] init];
+    [child3_1_2_2 addGestureRecognizer:normalRecognizer3_1_2_2];
+
+    // Add the target recognizer at child2_2 & child3_1_2_2
+
+    MockTouchEventsGestureRecognizer* targetRecognizer2_2 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [child2_2 addGestureRecognizer:targetRecognizer2_2];
+
+    MockTouchEventsGestureRecognizer* targetRecognizer3_1_2_2 =
+        [[MockTouchEventsGestureRecognizer alloc] init];
+    [child3_1_2_2 addGestureRecognizer:targetRecognizer3_1_2_2];
+
+    [(FlutterTouchInterceptingView*)touchInteceptorView blockGesture];
+
+    NSArray* normalRecognizers = @[
+      normalRecognizer0, normalRecognizer1, normalRecognizer2, normalRecognizer2_1,
+      normalRecognizer2_2, normalRecognizer3, normalRecognizer3_1, normalRecognizer3_1_1,
+      normalRecognizer3_1_2, normalRecognizer3_1_2_1, normalRecognizer3_1_2_2
+    ];
+
+    NSArray* targetRecognizers = @[ targetRecognizer2_2, targetRecognizer3_1_2_2 ];
+
+    NSArray* expectedEmptyHistory = @[];
+    NSArray* expectedToggledHistory = @[ @NO, @YES ];
+
+    for (MockGestureRecognizer* recognizer in normalRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedEmptyHistory);
+    }
+
+    for (MockGestureRecognizer* recognizer in targetRecognizers) {
+      XCTAssertEqualObjects(recognizer.toggleHistory, expectedToggledHistory);
+    }
+  }
 }
 
 - (void)testFlutterPlatformViewControllerSubmitFrameWithoutFlutterViewNotCrashing {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -48,7 +48,11 @@ const float kFloatCompareEpsilon = 0.001;
 
 @end
 
-// A mock recognizer without "TouchEventsGestureRecognizer" suffix in class name
+// A mock recognizer without "TouchEventsGestureRecognizer" suffix in class name.
+// This is to verify a fix to a bug on iOS 26 where web view link is not tappable.
+// We reset the web view's WKTouchEventsGestureRecognizer in a bad state
+// by disabling and re-enabling it.
+// See: https://github.com/flutter/flutter/issues/175099.
 @interface MockGestureRecognizer : UIGestureRecognizer
 @property(nonatomic, strong) NSMutableArray<NSNumber*>* toggleHistory;
 @end


### PR DESCRIPTION
This is a quick fix to the web view/admob not tappable issue. It performs DFS on a platform view hierarchy to find a web view. If found, it performs another DFS into the web view to "fix" a gesture recognizer. 

Warning: This is just a "quick fix" that patches the bug. However, a real solution should rely on overriding the "hitTest" behavior. 

For example, there's still a existing bug that a drawing website's touch is not completely blocked (see https://github.com/flutter/flutter/issues/179916). This can only be fixed by "hitTest". However, "hitTest" approach requires plugin updates and would take much longer time, so we decided to [revert it](https://github.com/flutter/flutter/pull/179895). But we should revisit after putting out the fire. 

https://github.com/flutter/flutter/issues/175099
https://github.com/flutter/flutter/issues/165787


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
