### PR TITLE
fix: line endings for flutter/dart/flutter-dev

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,11 @@
 *.props.tmpl      text eol=crlf
 *.vcxproj.tmpl    text eol=crlf
 
+# Make sure that these Linux files always have LF line endings in checkout
+bin/flutter       text eol=lf
+bin/flutter-dev   text eol=lf
+bin/dart          text eol=lf
+
 # Never perform LF normalization on these files
 *.ico    binary
 *.jar    binary


### PR DESCRIPTION
the windows builders should respect these files when making new releases

fixes #179242
