### PR TITLE
Replace semantic announcements in expansion tile for Android

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -550,11 +550,10 @@ class _ExpansionTileState extends State<ExpansionTile> {
         _timer?.cancel();
         _timer = null;
       });
-
     }
-    // SemanticsService.sendAnnouncement is deprecated on android. we use liveregion to achieve the announcement effect.
-    else if (defaultTargetPlatform != TargetPlatform.android)
-    {
+    // SemanticsService.sendAnnouncement is deprecated on android.
+    // We use liveregion to achieve the announcement effect, so we do nothing here.
+    else if (defaultTargetPlatform != TargetPlatform.android) {
       SemanticsService.sendAnnouncement(View.of(context), stateHint, textDirection);
     }
     widget.onExpansionChanged?.call(_tileController.isExpanded);
@@ -609,37 +608,39 @@ class _ExpansionTileState extends State<ExpansionTile> {
     };
 
     final Widget child = ListTileTheme.merge(
-        iconColor: _iconColor.value ?? _expansionTileTheme.iconColor,
-        textColor: _headerColor.value,
-        child: ListTile(
-          enabled: widget.enabled,
-          onTap: _tileController.isExpanded ? _tileController.collapse : _tileController.expand,
-          dense: widget.dense,
-          splashColor: widget.splashColor,
-          visualDensity: widget.visualDensity,
-          enableFeedback: widget.enableFeedback,
-          contentPadding: widget.tilePadding ?? _expansionTileTheme.tilePadding,
-          leading: widget.leading ?? _buildLeadingIcon(context, animation),
-          title: widget.title,
-          subtitle: widget.subtitle,
-          trailing: widget.showTrailingIcon
-              ? widget.trailing ?? _buildTrailingIcon(context, animation)
-              : null,
-          minTileHeight: widget.minTileHeight,
-          internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
-        ),
-      );
-
-    if(){
-      
-    }
-
-
-    return Semantics(
-      hint: semanticsHint,
-      onTapHint: onTapHint,
-      child: child,
+      iconColor: _iconColor.value ?? _expansionTileTheme.iconColor,
+      textColor: _headerColor.value,
+      child: ListTile(
+        enabled: widget.enabled,
+        onTap: _tileController.isExpanded ? _tileController.collapse : _tileController.expand,
+        dense: widget.dense,
+        splashColor: widget.splashColor,
+        visualDensity: widget.visualDensity,
+        enableFeedback: widget.enableFeedback,
+        contentPadding: widget.tilePadding ?? _expansionTileTheme.tilePadding,
+        leading: widget.leading ?? _buildLeadingIcon(context, animation),
+        title: widget.title,
+        subtitle: widget.subtitle,
+        trailing: widget.showTrailingIcon
+            ? widget.trailing ?? _buildTrailingIcon(context, animation)
+            : null,
+        minTileHeight: widget.minTileHeight,
+        internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
+      ),
     );
+
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return Semantics(
+        // Live region used to announce state changes (e.g., "expanded" or "collapsed")
+        // without taking focus.
+        // blockNode prevents this node from being part of the focus traversal.
+        label: semanticsHint,
+        liveRegion: true,
+        accessiblityFocusBlockType: AccessiblityFocusBlockType.blockNode,
+        child: Semantics(hint: semanticsHint, onTapHint: onTapHint, child: child),
+      );
+    }
+    return Semantics(hint: semanticsHint, onTapHint: onTapHint, child: child);
   }
 
   Widget _buildBody(BuildContext context, Animation<double> animation) {

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -552,7 +552,7 @@ class _ExpansionTileState extends State<ExpansionTile> {
       });
     }
     // SemanticsService.sendAnnouncement is deprecated on android.
-    // We use liveregion to achieve the announcement effect, so we do nothing here.
+    // We use live region to achieve the announcement effect instead.
     else if (defaultTargetPlatform != TargetPlatform.android) {
       SemanticsService.sendAnnouncement(View.of(context), stateHint, textDirection);
     }

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -550,7 +550,11 @@ class _ExpansionTileState extends State<ExpansionTile> {
         _timer?.cancel();
         _timer = null;
       });
-    } else {
+
+    }
+    // SemanticsService.sendAnnouncement is deprecated on android. we use liveregion to achieve the announcement effect.
+    else if (defaultTargetPlatform != TargetPlatform.android)
+    {
       SemanticsService.sendAnnouncement(View.of(context), stateHint, textDirection);
     }
     widget.onExpansionChanged?.call(_tileController.isExpanded);
@@ -604,10 +608,7 @@ class _ExpansionTileState extends State<ExpansionTile> {
       _ => _tileController.isExpanded ? localizations.collapsedHint : localizations.expandedHint,
     };
 
-    return Semantics(
-      hint: semanticsHint,
-      onTapHint: onTapHint,
-      child: ListTileTheme.merge(
+    final Widget child = ListTileTheme.merge(
         iconColor: _iconColor.value ?? _expansionTileTheme.iconColor,
         textColor: _headerColor.value,
         child: ListTile(
@@ -627,7 +628,17 @@ class _ExpansionTileState extends State<ExpansionTile> {
           minTileHeight: widget.minTileHeight,
           internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
         ),
-      ),
+      );
+
+    if(){
+      
+    }
+
+
+    return Semantics(
+      hint: semanticsHint,
+      onTapHint: onTapHint,
+      child: child,
     );
   }
 

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -827,8 +827,11 @@ void main() {
       );
       handle.dispose();
     },
-    // [intended] https://github.com/flutter/flutter/issues/122101.
-    skip: defaultTargetPlatform == TargetPlatform.iOS,
+    // [intended] iOS: https://github.com/flutter/flutter/issues/122101.
+    // android: https://github.com/flutter/flutter/issues/165510
+    skip:
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.android,
   );
 
   // This is a regression test for https://github.com/flutter/flutter/issues/132264.
@@ -1917,7 +1920,7 @@ void main() {
   );
 
   // Regression test for https://github.com/flutter/flutter/issues/173060
-  group('Semantics tests for non-iOS/macOS platforms', () {
+  group('Semantics tests for non-iOS/macOS/android platforms', () {
     testWidgets(
       'Semantics hint should show current state',
       (WidgetTester tester) async {
@@ -2007,6 +2010,67 @@ void main() {
         TargetPlatform.linux,
         TargetPlatform.windows,
       }),
+    );
+  });
+  group('Semantics tests for android platform', () {
+    testWidgets(
+      'Semantics liveregion updates when expansion state changes',
+      (WidgetTester tester) async {
+        final SemanticsHandle handle = tester.ensureSemantics();
+        const localizations = DefaultMaterialLocalizations();
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Material(
+              child: ExpansionTile(title: Text('Test Tile'), children: <Widget>[Text('Child')]),
+            ),
+          ),
+        );
+
+        // Initially collapsed - live region label is "Collapsed".
+
+        SemanticsNode liveRegionSemantics = tester.getSemantics(
+          find.ancestor(
+            of: find.byType(ListTile),
+            matching: find.byWidgetPredicate(
+              (Widget widget) => widget is Semantics && (widget.properties.liveRegion ?? false),
+            ),
+          ),
+        );
+        expect(liveRegionSemantics.label, localizations.expandedHint);
+
+        // Tap to expand.
+        await tester.tap(find.text('Test Tile'));
+        await tester.pumpAndSettle();
+
+        // Now expanded - should show "Expanded".
+        liveRegionSemantics = tester.getSemantics(
+          find.ancestor(
+            of: find.byType(ListTile),
+            matching: find.byWidgetPredicate(
+              (Widget widget) => widget is Semantics && (widget.properties.liveRegion ?? false),
+            ),
+          ),
+        );
+        expect(liveRegionSemantics.label, localizations.collapsedHint);
+
+        // Tap to collapse.
+        await tester.tap(find.text('Test Tile'));
+        await tester.pumpAndSettle();
+
+        // Back to collapsed - should show "Collapsed" again.
+        liveRegionSemantics = tester.getSemantics(
+          find.ancestor(
+            of: find.byType(ListTile),
+            matching: find.byWidgetPredicate(
+              (Widget widget) => widget is Semantics && (widget.properties.liveRegion ?? false),
+            ),
+          ),
+        );
+        expect(liveRegionSemantics.label, localizations.expandedHint);
+
+        handle.dispose();
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
     );
   });
 }


### PR DESCRIPTION
fixes: https://github.com/flutter/flutter/issues/177785  
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
