### PR TITLE
[Reland] Unmodified android sdk bundle

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -51,7 +51,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
           {"dependency": "avd_cipd_version", "version": "build_id:8719362231152674241"},
           {"dependency": "open_jdk", "version": "version:21"},
@@ -74,7 +74,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
           {"dependency": "avd_cipd_version", "version": "build_id:8702262057250908257"},
           {"dependency": "open_jdk", "version": "version:21"},
@@ -98,7 +98,7 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
           {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
           {"dependency": "open_jdk", "version": "version:21"},
@@ -115,7 +115,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
@@ -127,7 +127,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
@@ -138,7 +138,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
@@ -149,7 +149,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
@@ -252,7 +252,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -264,7 +264,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Mac-15.1|Mac-15.5|Mac-15.6|Mac-15.7
@@ -342,7 +342,7 @@ platform_properties:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -375,7 +375,7 @@ targets:
       test_timeout_secs: "3600" # 1 hour
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
@@ -411,7 +411,7 @@ targets:
       # Requires Android SDK since we may re-generate Gradle lockfiles
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "gh_cli", "version": "version:2.8.0-2-g32256d38"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -432,7 +432,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -456,7 +456,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -475,7 +475,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -494,7 +494,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -513,7 +513,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -532,7 +532,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -692,7 +692,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -713,7 +713,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -801,7 +801,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -837,7 +837,7 @@ targets:
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
           {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "android_sdk", "version": "version:36v4"}
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"}
         ]
       shard: framework_tests
       subshard: misc
@@ -908,7 +908,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -931,7 +931,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -954,7 +954,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -977,7 +977,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1001,7 +1001,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1025,7 +1025,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1049,7 +1049,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1073,7 +1073,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1098,7 +1098,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1123,7 +1123,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1147,7 +1147,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1175,7 +1175,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1284,7 +1284,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -1348,7 +1348,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
         ]
       tags: >
@@ -1377,7 +1377,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1405,7 +1405,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1433,7 +1433,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1461,7 +1461,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1489,7 +1489,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1517,7 +1517,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1545,7 +1545,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1604,7 +1604,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1631,7 +1631,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:11"}
         ]
@@ -1655,7 +1655,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:17"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -1682,7 +1682,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
@@ -1707,7 +1707,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests
@@ -1729,7 +1729,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests
@@ -3715,7 +3715,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3734,7 +3734,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3753,7 +3753,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3772,7 +3772,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3792,7 +3792,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3810,7 +3810,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3828,7 +3828,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -3846,7 +3846,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4036,7 +4036,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "android_sdk", "version": "version:36v4"}
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"}
         ]
       shard: framework_tests
       subshard: misc
@@ -4067,7 +4067,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "android_sdk", "version": "version:36v4"}
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"}
         ]
       shard: framework_tests
       subshard: misc
@@ -4123,7 +4123,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4162,7 +4162,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4182,7 +4182,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4202,7 +4202,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4223,7 +4223,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4298,7 +4298,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
         ]
@@ -4360,7 +4360,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
@@ -4380,7 +4380,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -4484,7 +4484,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4511,7 +4511,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4538,7 +4538,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4565,7 +4565,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4592,7 +4592,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
@@ -4618,7 +4618,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests_commands
@@ -4633,7 +4633,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests_commands
@@ -4648,7 +4648,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests
@@ -5665,7 +5665,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5683,7 +5683,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5701,7 +5701,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5719,7 +5719,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5737,7 +5737,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5755,7 +5755,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5773,7 +5773,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5791,7 +5791,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5809,7 +5809,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -5901,7 +5901,7 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
           {"dependency": "vs_build", "version": "version:vs2019"},
           {"dependency": "open_jdk", "version": "version:21"},
-          {"dependency": "android_sdk", "version": "version:36v4"}
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"}
         ]
       shard: framework_tests
       subshard: misc
@@ -5989,7 +5989,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6035,7 +6035,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6056,7 +6056,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6077,7 +6077,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6100,7 +6100,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6148,7 +6148,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6169,7 +6169,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6190,7 +6190,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
@@ -6332,7 +6332,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6358,7 +6358,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6384,7 +6384,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6410,7 +6410,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6436,7 +6436,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6462,7 +6462,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6488,7 +6488,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6514,7 +6514,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6540,7 +6540,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"},
@@ -6567,7 +6567,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
@@ -6614,7 +6614,7 @@ targets:
       add_recipes_cq: "true"
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:36v4"},
+          {"dependency": "android_sdk", "version": "version:36v4unmodified"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       shard: tool_tests

--- a/DEPS
+++ b/DEPS
@@ -615,7 +615,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/all/${{platform}}',
-        'version': 'version:36v3'
+        'version': 'version:36v4unmodified'
        }
      ],
      'condition': 'download_android_deps',

--- a/dev/a11y_assessments/android/app/build.gradle
+++ b/dev/a11y_assessments/android/app/build.gradle
@@ -36,14 +36,6 @@ android {
     namespace = "com.example.a11y_assessments"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "com.yourcompany.complexLayout"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "com.example.macrobenchmarks"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "com.yourcompany.microbenchmarks"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -16,14 +16,6 @@ android {
     namespace = "dev.flutter.multipleflutters"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "28.2.13676358" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "dev.benchmarks.platform_views_layout"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "dev.benchmarks.platform_views_layout_hybrid_composition"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "io.flutter.examples.stocks"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
+++ b/dev/devicelab/bin/tasks/build_android_host_app_with_module_aar.dart
@@ -47,6 +47,7 @@ class ModuleTest {
 
   Future<TaskResult> call() async {
     section('Running: $buildTarget-$gradleVersion');
+
     section('Find Java');
 
     final String? javaHome = await findJavaHome();

--- a/dev/devicelab/test/tasks/build_test_task_test.dart
+++ b/dev/devicelab/test/tasks/build_test_task_test.dart
@@ -62,8 +62,10 @@ void main() {
     final capturedPrint = capturedPrintLines.toString();
     expect(
       capturedPrint,
-      contains(
-        'with environment {FLUTTER_DEVICELAB_DEVICEID: FAKE_SUCCESS, BOT: true, LANG: en_US.UTF-8}',
+      allOf(
+        contains('with environment {'),
+        contains('FLUTTER_DEVICELAB_DEVICEID: FAKE_SUCCESS'),
+        contains('BOT: true'),
       ),
     );
     expect(capturedPrint, contains('Process terminated with exit code 0.'));

--- a/dev/integration_tests/android_engine_test/android/app/build.gradle
+++ b/dev/integration_tests/android_engine_test/android/app/build.gradle
@@ -13,14 +13,6 @@ android {
     namespace = "com.example.android_engine_test"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -20,14 +20,6 @@ android {
     namespace = "com.yourcompany.platforminteraction"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/android_verified_input/android/app/build.gradle
+++ b/dev/integration_tests/android_verified_input/android/app/build.gradle
@@ -30,15 +30,6 @@ android {
     namespace "io.flutter.integration.android_verified_input"
     compileSdk flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = 'io.flutter.integration.platformviews'
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -30,15 +30,6 @@ android {
     namespace = "com.example.channels"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/deferred_components_test/android/app/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/app/build.gradle
@@ -36,19 +36,9 @@ android {
     namespace = "io.flutter.integration.deferred_components_test"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/dev/integration_tests/deferred_components_test/android/component1/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/component1/build.gradle
@@ -26,14 +26,6 @@ android {
     namespace = "io.flutter.integration.deferred_components_test.component1"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "26.3.11579264" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
 
     sourceSets {
         applicationVariants.all { variant ->

--- a/dev/integration_tests/external_textures/android/app/build.gradle
+++ b/dev/integration_tests/external_textures/android/app/build.gradle
@@ -19,14 +19,6 @@ android {
     namespace = "io.flutter.externalui"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -19,14 +19,6 @@ android {
     namespace = "com.yourcompany.flavors"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -48,14 +48,6 @@ android {
     namespace = "io.flutter.demo.gallery"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -8,14 +8,6 @@ android {
     namespace = "io.flutter.addtoapp"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "26.3.11579264" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -19,14 +19,6 @@ android {
     namespace = "com.yourcompany.platforminteraction"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/pure_android_host_apps/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/pure_android_host_apps/android_custom_host_app/SampleApp/build.gradle
@@ -8,14 +8,6 @@ android {
     namespace = "io.flutter.add2app"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "26.3.11579264" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/pure_android_host_apps/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/pure_android_host_apps/android_host_app_v2_embedding/app/build.gradle
@@ -8,15 +8,6 @@ android {
     namespace = "io.flutter.add2app"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "26.3.11579264" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
+++ b/dev/integration_tests/pure_android_host_apps/host_app_kotlin_gradle_dsl/app/build.gradle.kts
@@ -7,14 +7,6 @@ android {
     namespace = "com.example.myapplication"
     compileSdk = 36
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    val systemNdkPath: String? = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = "26.3.11579264" // This version must exactly match the version of the NDK that the recipe pulls from CIPD.
-        ndkPath = systemNdkPath
-    }
 
     defaultConfig {
         applicationId = "com.example.myapplication"

--- a/dev/integration_tests/release_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/app/build.gradle
@@ -30,14 +30,6 @@ android {
     namespace = "com.example.release_smoke_test"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/integration_tests/spell_check/android/app/build.gradle
+++ b/dev/integration_tests/spell_check/android/app/build.gradle
@@ -30,14 +30,6 @@ android {
     namespace = "com.example.spell_check"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -11,6 +11,7 @@ plugins {
 android {
     namespace = "com.yourcompany.integration_ui"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
 
     compileOptions {

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -12,14 +12,6 @@ android {
     namespace = "com.yourcompany.integration_ui"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -30,14 +30,6 @@ android {
     namespace = "dev.flutter.manual_tests"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/dev/tracing_tests/android/app/build.gradle
+++ b/dev/tracing_tests/android/app/build.gradle
@@ -30,14 +30,6 @@ android {
     namespace = "com.example.tracing_tests"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/engine/src/build/config/android/config.gni
+++ b/engine/src/build/config/android/config.gni
@@ -53,7 +53,8 @@ if (is_android) {
   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
 
   # Path to the Android NDK and SDK.
-  android_ndk_root = "//flutter/third_party/android_tools/ndk"
+  android_ndk_version = "28.2.13676358"
+  android_ndk_root = "//flutter/third_party/android_tools/sdk/ndk/$android_ndk_version"
   android_ndk_include_dir = "$android_ndk_root/usr/include"
 
   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"

--- a/engine/src/flutter/ci/binary_size_treemap.sh
+++ b/engine/src/flutter/ci/binary_size_treemap.sh
@@ -22,8 +22,9 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   NDK_PLATFORM="linux-x86_64"
 fi
-ADDR2LINE="flutter/third_party/android_tools/ndk/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-addr2line"
-NM="flutter/third_party/android_tools/ndk/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-nm"
+NDK_VERSION="28.2.13676358"
+ADDR2LINE="flutter/third_party/android_tools/sdk/ndk/$NDK_VERSION/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-addr2line"
+NM="flutter/third_party/android_tools/sdk/ndk/$NDK_VERSION/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-nm"
 
 # Run the binary size script from the buildroot directory so the treemap path
 # navigation will start from there.

--- a/engine/src/flutter/sky/tools/flutter_gdb
+++ b/engine/src/flutter/sky/tools/flutter_gdb
@@ -26,6 +26,7 @@ previous run for a given device, then you can skip this step by passing
 """
 
 ADB_LOCAL_PATH = 'flutter/third_party/android_tools/sdk/platform-tools/adb'
+ANDROID_NDK_VERSION = '28.2.13676358'
 
 
 def _get_flutter_root():
@@ -84,7 +85,7 @@ class GdbClient(object):
     SYSTEM_LIBS_PATH = '/tmp/flutter_gdb_device_libs'
 
     def _gdb_local_path(self):
-        GDB_LOCAL_PATH = ('flutter/third_party/android_tools/ndk/prebuilt/%s-x86_64/bin/gdb')
+        GDB_LOCAL_PATH = ('flutter/third_party/android_tools/sdk/ndk/%s/prebuilt/%%s-x86_64/bin/gdb' % ANDROID_NDK_VERSION)
         if sys.platform.startswith('darwin'):
             return GDB_LOCAL_PATH % 'darwin'
         else:
@@ -192,7 +193,7 @@ class GdbServer(object):
             return 1
 
         abi = _get_device_abi(adb_command)
-        gdb_server_local_path = 'flutter/third_party/android_tools/ndk/prebuilt/android-%s/gdbserver/gdbserver' % abi
+        gdb_server_local_path = 'flutter/third_party/android_tools/sdk/ndk/%s/prebuilt/android-%s/gdbserver/gdbserver' % (ANDROID_NDK_VERSION, abi)
 
         # Copy gdbserver to the package's data directory.
         subprocess.check_call(adb_command + ['push',

--- a/engine/src/flutter/testing/analyze_core_dump.sh
+++ b/engine/src/flutter/testing/analyze_core_dump.sh
@@ -18,7 +18,8 @@ if [ "$UNAME" == "Linux" ]; then
   if [ -x "$(command -v gdb)" ]; then
     GDB=gdb
   else
-    GDB=$BUILDROOT/flutter/third_party/android_tools/ndk/prebuilt/linux-x86_64/bin/gdb
+    NDK_VERSION="28.2.13676358"
+    GDB=$BUILDROOT/flutter/third_party/android_tools/sdk/ndk/$NDK_VERSION/prebuilt/linux-x86_64/bin/gdb
   fi
   echo "GDB=$GDB"
   $GDB $EXE $CORE --batch -ex "thread apply all bt" > $OUTPUT

--- a/engine/src/flutter/tools/android_sdk/create_cipd_packages.sh
+++ b/engine/src/flutter/tools/android_sdk/create_cipd_packages.sh
@@ -122,23 +122,6 @@ for platform in "${platforms[@]}"; do
     done
   done
 
-  # Special treatment for NDK to move to expected directory.
-  # Instead of the ndk being in `sdk/ndk/<major>.<minor>.<patch>/`, it will be
-  # in `ndk/`.
-  # This simplifies the build scripts, and enables version difference between
-  # the Dart and Flutter build while reusing the same build rules.
-  # See https://github.com/flutter/flutter/issues/136666#issuecomment-1805467578
-  mv $upload_dir/sdk/ndk $upload_dir/ndk-bundle
-  ndk_sub_paths=`find $upload_dir/ndk-bundle -maxdepth 1 -type d`
-  ndk_sub_paths_arr=($ndk_sub_paths)
-  mv ${ndk_sub_paths_arr[1]} $upload_dir/ndk
-  rm -rf $upload_dir/ndk-bundle
-
-  if [[ ! -d "$upload_dir/ndk" ]]; then
-    echo "Failure to bundle ndk for platform"
-    exit 1
-  fi
-
   # Accept all licenses to ensure they are generated and uploaded.
   yes "y" | $sdkmanager_path --licenses --sdk_root=$sdk_root
   cp -a "$sdk_root/licenses" "$upload_dir/sdk"

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -11,14 +11,6 @@ android {
     namespace = "com.example.view"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/examples/hello_world/android/app/build.gradle.kts
+++ b/examples/hello_world/android/app/build.gradle.kts
@@ -11,15 +11,6 @@ android {
     namespace = "io.flutter.examples.hello_world"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    val systemNdkPath: String? = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "com.example.image_list"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -11,14 +11,6 @@ android {
     namespace = "io.flutter.examples.Layers"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "com.example.platformchannel"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -29,14 +29,6 @@ android {
     namespace = "io.flutter.examples.platform_view"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/integration_test/example/android/app/build.gradle.kts
+++ b/packages/integration_test/example/android/app/build.gradle.kts
@@ -13,15 +13,6 @@ android {
     namespace = "com.example.integration_test_example"
     compileSdk = flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    val systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/179647

There were only two failing tests (there were also two bringup failures, the `mac_arm64_mokey` versions of these)
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_mokey%20run_release_test/3866/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_mokey%20run_debug_test_android/5454/overview

They failed with the same logs
```
Task result:
{
  "success": false,
  "reason": "Task failed: flutter run  had unexpected output on standard error."
}
```

The stderr in question:
```
[2025-12-15 14:06:56.311794] [STDOUT] run:stderr: - integration_test requires Android NDK 28.2.13676358
[2025-12-15 14:06:56.311989] [STDOUT] run:stderr: Fix this issue by using the highest Android NDK version (they are backward compatible).
[2025-12-15 14:06:56.312019] [STDOUT] run:stderr: Add the following to /opt/s/w/ir/x/w/rc/tmpr6kj09d_/flutter sdk/dev/integration_tests/ui/android/app/build.gradle:
[2025-12-15 14:06:56.312074] [STDOUT] run:stderr: 
[2025-12-15 14:06:56.312092] [STDOUT] run:stderr:     android {
[2025-12-15 14:06:56.312144] [STDOUT] run:stderr:         ndkVersion = "28.2.13676358"
[2025-12-15 14:06:56.312162] [STDOUT] run:stderr:         ...
[2025-12-15 14:06:56.312205] [STDOUT] run:stderr:     }
```

We can just set the ndk version to `flutter.ndkVersion`, which is this value. It's also what is set in the templates, so it isn't a hack that doesn't represent a real flutter app. Verified the tests pass now with 
```
../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t run_release_test
../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t run_debug_test_android
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
