### PR TITLE
Make sure that a CupertinoTextFormFieldRow doesn't crash in 0x0 envir…

### DIFF
--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -652,4 +652,19 @@ void main() {
     variant: TargetPlatformVariant.all(),
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
   );
+
+  testWidgets('CupertinoTextFormFieldRow does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    final controller = TextEditingController(text: 'X');
+    addTearDown(tester.view.reset);
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoTextFormFieldRow(controller: controller)),
+      ),
+    );
+    expect(tester.getSize(find.byType(CupertinoTextFormFieldRow)), Size.zero);
+    controller.selection = const TextSelection.collapsed(offset: 0);
+    await tester.pump();
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CupertinoTextFormFieldRow widget.