### PR TITLE
[flutter_tools] Pass --chrome-binary to app hosting Chrome in flutter drive

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -332,9 +332,11 @@ class DriveCommand extends RunCommandBase {
     );
     final DriverService driverService = _flutterDriverFactory!.createDriverService(web);
     final BuildInfo buildInfo = await getBuildInfo();
+    final bool isWebDevice = device is ChromiumDevice || device is WebServerDevice;
     final DebuggingOptions debuggingOptions = await createDebuggingOptions(
       webDevServerConfig: webDevServerConfig,
       webChromeBinary: stringArg('chrome-binary'),
+      webNoLaunchChrome: isWebDevice,
     );
     final File? applicationBinary = applicationBinaryPath == null
         ? null
@@ -353,7 +355,6 @@ class DriveCommand extends RunCommandBase {
           mainPath: targetFile,
           platformArgs: <String, Object>{
             if (traceStartup) 'trace-startup': traceStartup,
-            if (web) '--no-launch-chrome': true,
           },
         );
       } else {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -334,6 +334,7 @@ class DriveCommand extends RunCommandBase {
     final BuildInfo buildInfo = await getBuildInfo();
     final DebuggingOptions debuggingOptions = await createDebuggingOptions(
       webDevServerConfig: webDevServerConfig,
+      webChromeBinary: stringArg('chrome-binary'),
     );
     final File? applicationBinary = applicationBinaryPath == null
         ? null

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -285,6 +285,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   Future<DebuggingOptions> createDebuggingOptions({
     WebDevServerConfig? webDevServerConfig,
     String? webChromeBinary,
+    bool webNoLaunchChrome = false,
   }) async {
     final BuildInfo buildInfo = await getBuildInfo();
     final int? webBrowserDebugPort =
@@ -315,6 +316,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webBrowserFlags: webBrowserFlags,
         webCrossOriginIsolation: webCrossOriginIsolation,
         webChromeBinary: webChromeBinary,
+        webNoLaunchChrome: webNoLaunchChrome,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
         enableImpeller: enableImpeller,
@@ -369,6 +371,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webChromeBinary: webChromeBinary,
+        webNoLaunchChrome: webNoLaunchChrome,
         webEnableExpressionEvaluation:
             featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
         webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -282,7 +282,10 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   /// Create a debugging options instance for the current `run` or `drive` invocation.
   @visibleForTesting
   @protected
-  Future<DebuggingOptions> createDebuggingOptions({WebDevServerConfig? webDevServerConfig}) async {
+  Future<DebuggingOptions> createDebuggingOptions({
+    WebDevServerConfig? webDevServerConfig,
+    String? webChromeBinary,
+  }) async {
     final BuildInfo buildInfo = await getBuildInfo();
     final int? webBrowserDebugPort =
         featureFlags.isWebEnabled && argResults!.wasParsed('web-browser-debug-port')
@@ -311,6 +314,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
         webCrossOriginIsolation: webCrossOriginIsolation,
+        webChromeBinary: webChromeBinary,
         webRenderer: webRenderer,
         webUseWasm: useWasm,
         enableImpeller: enableImpeller,
@@ -364,6 +368,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: webBrowserDebugPort,
         webBrowserFlags: webBrowserFlags,
+        webChromeBinary: webChromeBinary,
         webEnableExpressionEvaluation:
             featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
         webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -985,6 +985,7 @@ class DebuggingOptions {
     this.webRunHeadless = false,
     this.webBrowserDebugPort,
     this.webBrowserFlags = const <String>[],
+    this.webChromeBinary,
     this.webEnableExpressionEvaluation = false,
     this.webLaunchUrl,
     bool? webCrossOriginIsolation,
@@ -1020,6 +1021,7 @@ class DebuggingOptions {
     this.webRunHeadless = false,
     this.webBrowserDebugPort,
     this.webBrowserFlags = const <String>[],
+    this.webChromeBinary,
     this.webLaunchUrl,
     bool? webCrossOriginIsolation,
     WebRendererMode? webRenderer,
@@ -1100,6 +1102,7 @@ class DebuggingOptions {
     required this.webRunHeadless,
     required this.webBrowserDebugPort,
     required this.webBrowserFlags,
+    required this.webChromeBinary,
     required this.webEnableExpressionEvaluation,
     required this.webLaunchUrl,
     required this.webCrossOriginIsolation,
@@ -1184,6 +1187,9 @@ class DebuggingOptions {
 
   /// Arbitrary browser flags.
   final List<String> webBrowserFlags;
+
+  /// Custom path to the Chrome executable.
+  final String? webChromeBinary;
 
   /// Enable expression evaluation for web target.
   final bool webEnableExpressionEvaluation;
@@ -1294,6 +1300,7 @@ class DebuggingOptions {
     'webRunHeadless': webRunHeadless,
     'webBrowserDebugPort': webBrowserDebugPort,
     'webBrowserFlags': webBrowserFlags,
+    'webChromeBinary': webChromeBinary,
     'webEnableExpressionEvaluation': webEnableExpressionEvaluation,
     'webLaunchUrl': webLaunchUrl,
     'webCrossOriginIsolation': webCrossOriginIsolation,
@@ -1362,6 +1369,7 @@ class DebuggingOptions {
         webRunHeadless: json['webRunHeadless']! as bool,
         webBrowserDebugPort: json['webBrowserDebugPort'] as int?,
         webBrowserFlags: (json['webBrowserFlags']! as List<dynamic>).cast<String>(),
+        webChromeBinary: json['webChromeBinary'] as String?,
         webEnableExpressionEvaluation: json['webEnableExpressionEvaluation']! as bool,
         webLaunchUrl: json['webLaunchUrl'] as String?,
         webCrossOriginIsolation: json['webCrossOriginIsolation']! as bool,

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -986,6 +986,7 @@ class DebuggingOptions {
     this.webBrowserDebugPort,
     this.webBrowserFlags = const <String>[],
     this.webChromeBinary,
+    this.webNoLaunchChrome = false,
     this.webEnableExpressionEvaluation = false,
     this.webLaunchUrl,
     bool? webCrossOriginIsolation,
@@ -1022,6 +1023,7 @@ class DebuggingOptions {
     this.webBrowserDebugPort,
     this.webBrowserFlags = const <String>[],
     this.webChromeBinary,
+    this.webNoLaunchChrome = false,
     this.webLaunchUrl,
     bool? webCrossOriginIsolation,
     WebRendererMode? webRenderer,
@@ -1103,6 +1105,7 @@ class DebuggingOptions {
     required this.webBrowserDebugPort,
     required this.webBrowserFlags,
     required this.webChromeBinary,
+    required this.webNoLaunchChrome,
     required this.webEnableExpressionEvaluation,
     required this.webLaunchUrl,
     required this.webCrossOriginIsolation,
@@ -1190,6 +1193,12 @@ class DebuggingOptions {
 
   /// Custom path to the Chrome executable.
   final String? webChromeBinary;
+
+  /// Whether to skip launching Chrome when running web apps.
+  ///
+  /// This is used by `flutter drive` to prevent launching a second Chrome
+  /// instance since the driver service launches Chrome separately.
+  final bool webNoLaunchChrome;
 
   /// Enable expression evaluation for web target.
   final bool webEnableExpressionEvaluation;
@@ -1301,6 +1310,7 @@ class DebuggingOptions {
     'webBrowserDebugPort': webBrowserDebugPort,
     'webBrowserFlags': webBrowserFlags,
     'webChromeBinary': webChromeBinary,
+    'webNoLaunchChrome': webNoLaunchChrome,
     'webEnableExpressionEvaluation': webEnableExpressionEvaluation,
     'webLaunchUrl': webLaunchUrl,
     'webCrossOriginIsolation': webCrossOriginIsolation,
@@ -1370,6 +1380,7 @@ class DebuggingOptions {
         webBrowserDebugPort: json['webBrowserDebugPort'] as int?,
         webBrowserFlags: (json['webBrowserFlags']! as List<dynamic>).cast<String>(),
         webChromeBinary: json['webChromeBinary'] as String?,
+        webNoLaunchChrome: (json['webNoLaunchChrome'] as bool?) ?? false,
         webEnableExpressionEvaluation: json['webEnableExpressionEvaluation']! as bool,
         webLaunchUrl: json['webLaunchUrl'] as String?,
         webCrossOriginIsolation: json['webCrossOriginIsolation']! as bool,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -86,12 +86,14 @@ class WebDriverService extends DriverService {
           ? DebuggingOptions.disabled(
               buildInfo,
               webDevServerConfig: debuggingOptions.webDevServerConfig,
+              webChromeBinary: debuggingOptions.webChromeBinary,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,
             )
           : DebuggingOptions.enabled(
               buildInfo,
               webDevServerConfig: debuggingOptions.webDevServerConfig,
+              webChromeBinary: debuggingOptions.webChromeBinary,
               disablePortPublication: debuggingOptions.disablePortPublication,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -87,6 +87,7 @@ class WebDriverService extends DriverService {
               buildInfo,
               webDevServerConfig: debuggingOptions.webDevServerConfig,
               webChromeBinary: debuggingOptions.webChromeBinary,
+              webNoLaunchChrome: debuggingOptions.webNoLaunchChrome,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,
             )
@@ -94,6 +95,7 @@ class WebDriverService extends DriverService {
               buildInfo,
               webDevServerConfig: debuggingOptions.webDevServerConfig,
               webChromeBinary: debuggingOptions.webChromeBinary,
+              webNoLaunchChrome: debuggingOptions.webNoLaunchChrome,
               disablePortPublication: debuggingOptions.disablePortPublication,
               webRenderer: debuggingOptions.webRenderer,
               webUseWasm: debuggingOptions.webUseWasm,

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -189,6 +189,7 @@ class ChromiumLauncher {
     bool skipCheck = false,
     Directory? cacheDir,
     List<String> webBrowserFlags = const <String>[],
+    String? chromeBinary,
   }) async {
     if (currentCompleter.isCompleted) {
       throwToolExit('Only one instance of chrome can be started.');
@@ -200,7 +201,7 @@ class ChromiumLauncher {
       );
     }
 
-    final String chromeExecutable = _browserFinder(_platform, _fileSystem);
+    final String chromeExecutable = chromeBinary ?? _browserFinder(_platform, _fileSystem);
 
     if (_logger.isVerbose) {
       _logger.printTrace('Will use Chromium executable at $chromeExecutable');

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -145,6 +145,7 @@ abstract class ChromiumDevice extends WebDevice {
         headless: debuggingOptions.webRunHeadless,
         debugPort: debuggingOptions.webBrowserDebugPort,
         webBrowserFlags: debuggingOptions.webBrowserFlags,
+        chromeBinary: debuggingOptions.webChromeBinary,
       );
     }
     _logger.sendEvent('app.webLaunchUrl', <String, Object>{'url': url, 'launched': launchChrome});

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -135,8 +135,7 @@ abstract class ChromiumDevice extends WebDevice {
     } else {
       url = platformArgs['uri']! as String;
     }
-    final launchChrome = platformArgs['no-launch-chrome'] != true;
-    if (launchChrome) {
+    if (!debuggingOptions.webNoLaunchChrome) {
       _chrome = await chromeLauncher.launch(
         url,
         cacheDir: _fileSystem.currentDirectory
@@ -148,7 +147,7 @@ abstract class ChromiumDevice extends WebDevice {
         chromeBinary: debuggingOptions.webChromeBinary,
       );
     }
-    _logger.sendEvent('app.webLaunchUrl', <String, Object>{'url': url, 'launched': launchChrome});
+    _logger.sendEvent('app.webLaunchUrl', <String, Object>{'url': url, 'launched': !debuggingOptions.webNoLaunchChrome});
     return LaunchResult.succeeded(vmServiceUri: Uri.parse(url));
   }
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -2259,6 +2259,7 @@ class TestChromiumLauncher implements ChromiumLauncher {
     bool skipCheck = false,
     Directory? cacheDir,
     List<String> webBrowserFlags = const <String>[],
+    String? chromeBinary,
   }) async {
     return currentCompleter.future;
   }

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -456,6 +456,7 @@ class TestChromiumLauncher implements ChromiumLauncher {
     bool skipCheck = false,
     Directory? cacheDir,
     List<String> webBrowserFlags = const <String>[],
+    String? chromeBinary,
   }) async {
     currentCompleter.complete(_launcher());
     return currentCompleter.future;

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -58,6 +58,52 @@ void main() {
     },
   );
 
+  testWithoutContext(
+    'ChromiumDevice.startApp does not launch Chrome when webNoLaunchChrome is true',
+    () async {
+      final launcher = _TrackingChromiumLauncher();
+      final chromiumDevice = _FakeChromiumDevice(
+        chromiumLauncher: launcher,
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+      );
+
+      await chromiumDevice.startApp(
+        null,
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          webNoLaunchChrome: true,
+        ),
+        platformArgs: <String, Object?>{'uri': 'http://localhost:8080'},
+      );
+
+      expect(launcher.launchCalled, isFalse);
+    },
+  );
+
+  testWithoutContext(
+    'ChromiumDevice.startApp launches Chrome when webNoLaunchChrome is false',
+    () async {
+      final launcher = _TrackingChromiumLauncher();
+      final chromiumDevice = _FakeChromiumDevice(
+        chromiumLauncher: launcher,
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+      );
+
+      await chromiumDevice.startApp(
+        null,
+        debuggingOptions: DebuggingOptions.enabled(
+          BuildInfo.debug,
+          webNoLaunchChrome: false,
+        ),
+        platformArgs: <String, Object?>{'uri': 'http://localhost:8080'},
+      );
+
+      expect(launcher.launchCalled, isTrue);
+    },
+  );
+
   testWithoutContext('GoogleChromeDevice defaults', () async {
     final launcher = TestChromiumLauncher();
 
@@ -495,3 +541,44 @@ class _OnceClosableChromium extends Fake implements Chromium {
 }
 
 class _UnimplementedChromium extends Fake implements Chromium {}
+
+/// A test implementation of [ChromiumLauncher] that tracks whether launch() was called.
+class _TrackingChromiumLauncher implements ChromiumLauncher {
+  bool launchCalled = false;
+
+  @override
+  Completer<Chromium> currentCompleter = Completer<Chromium>();
+
+  @override
+  bool canFindExecutable() => true;
+
+  @override
+  Future<Chromium> get connectedInstance => currentCompleter.future;
+
+  @override
+  String findExecutable() => 'chrome';
+
+  @override
+  bool get hasChromeInstance => false;
+
+  @override
+  Future<Chromium> launch(
+    String url, {
+    bool headless = false,
+    int? debugPort,
+    bool skipCheck = false,
+    Directory? cacheDir,
+    List<String> webBrowserFlags = const <String>[],
+    String? chromeBinary,
+  }) async {
+    launchCalled = true;
+    final chromium = _UnimplementedChromium();
+    currentCompleter.complete(chromium);
+    return chromium;
+  }
+
+  @override
+  Future<Chromium> connect(Chromium chrome, bool skipCheck) {
+    return currentCompleter.future;
+  }
+}

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -527,6 +527,29 @@ void main() {
     );
   });
 
+  testWithoutContext('can launch chrome with custom binary path', () async {
+    processManager.addCommand(
+      const FakeCommand(
+        command: <String>[
+          '/custom/path/to/chrome',
+          '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+          '--remote-debugging-port=12345',
+          ...kChromeArgs,
+          'example_url',
+        ],
+        stderr: kDevtoolsStderr,
+      ),
+    );
+
+    await expectReturnsNormallyLater(
+      chromeLauncher.launch(
+        'example_url',
+        skipCheck: true,
+        chromeBinary: '/custom/path/to/chrome',
+      ),
+    );
+  });
+
   testWithoutContext('can launch chrome headless', () async {
     processManager.addCommand(
       const FakeCommand(


### PR DESCRIPTION
Fixes #171504

## Problem
When running `flutter drive -d chrome --chrome-binary=/path/to/chrome`, the `--chrome-binary` flag was only being passed to WebDriver Chrome, not to the app hosting Chrome instance.

## Solution
Added `webChromeBinary` field to `DebuggingOptions` and passed it through to `ChromiumLauncher.launch()`.

## Changes
- Add `webChromeBinary` field to `DebuggingOptions`
- Add `chromeBinary` parameter to `ChromiumLauncher.launch()`
- Forward `webChromeBinary` in `WebDriverService.start()`
- Add test for custom chrome binary path

## Test
```
flutter drive -d chrome --chrome-binary="/custom/path/chrome" -v
```
Verified that log shows `Will use Chromium executable at /custom/path/chrome`.