### PR TITLE
Add drag handle to CupertinoSheet

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -127,9 +127,9 @@ final Animatable<double> _kScaleTween = Tween<double>(begin: 1.0, end: 1.0 - _kS
 /// means the sheet takes up only the bottom 10% of the screen. If not provided, defaults
 /// to 0.08 (8% of screen height).
 ///
-/// When 'dragHandle' is set to `true`, then a an iOS-style drag handle will be placed
-/// at the top of the sheet. If a value is not provided, then it will default to
-/// false.
+/// When `showDragHandle` is set to `true`, then an iOS-style drag handle will
+/// be placed at the top of the sheet. If a value is not provided, then it will
+/// default to false.
 ///
 /// iOS sheet widgets are generally designed to be tightly coupled to the context
 /// of the widget that opened the sheet. As such, it is not recommended to push
@@ -618,6 +618,11 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
     if (!showDragHandle) {
       return builder(context);
     }
+
+    const dragHandleTopPadding = 5.0;
+    const dragHandleHeight = 5.0;
+    const dragHandleWidth = 36.0;
+
     return Stack(
       children: <Widget>[
         MediaQuery(
@@ -629,15 +634,15 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
           child: Semantics.fromProperties(
             properties: SemanticsProperties(role: SemanticsRole.dragHandle),
             child: Padding(
-              padding: EdgeInsetsGeometry.only(top: 5),
+              padding: EdgeInsetsGeometry.only(top: dragHandleTopPadding),
               child: DecoratedBox(
                 decoration: ShapeDecoration(
                   shape: RoundedSuperellipseBorder(
-                    borderRadius: BorderRadiusGeometry.all(Radius.circular(18)),
+                    borderRadius: BorderRadiusGeometry.all(Radius.circular(dragHandleWidth / 2)),
                   ),
                   color: CupertinoColors.tertiaryLabel,
                 ),
-                child: SizedBox(height: 5, width: 36),
+                child: SizedBox(height: dragHandleHeight, width: dragHandleWidth),
               ),
             ),
           ),

--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -2,10 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:flutter/gestures.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -631,19 +628,16 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
         ),
         const Align(
           alignment: Alignment.topCenter,
-          child: Semantics.fromProperties(
-            properties: SemanticsProperties(role: SemanticsRole.dragHandle),
-            child: Padding(
-              padding: EdgeInsetsGeometry.only(top: dragHandleTopPadding),
-              child: DecoratedBox(
-                decoration: ShapeDecoration(
-                  shape: RoundedSuperellipseBorder(
-                    borderRadius: BorderRadiusGeometry.all(Radius.circular(dragHandleWidth / 2)),
-                  ),
-                  color: CupertinoColors.tertiaryLabel,
+          child: Padding(
+            padding: EdgeInsetsGeometry.only(top: dragHandleTopPadding),
+            child: DecoratedBox(
+              decoration: ShapeDecoration(
+                shape: RoundedSuperellipseBorder(
+                  borderRadius: BorderRadiusGeometry.all(Radius.circular(dragHandleWidth / 2)),
                 ),
-                child: SizedBox(height: dragHandleHeight, width: dragHandleWidth),
+                color: CupertinoColors.tertiaryLabel,
               ),
+              child: SizedBox(height: dragHandleHeight, width: dragHandleWidth),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -124,9 +124,8 @@ final Animatable<double> _kScaleTween = Tween<double>(begin: 1.0, end: 1.0 - _kS
 /// means the sheet takes up only the bottom 10% of the screen. If not provided, defaults
 /// to 0.08 (8% of screen height).
 ///
-/// When `showDragHandle` is set to `true`, then an iOS-style drag handle will
-/// be placed at the top of the sheet. If a value is not provided, then it will
-/// default to false.
+/// When `showDragHandle` is set to `true`, then a drag handle will be placed at
+/// the top of the sheet. This flag will default to false.
 ///
 /// iOS sheet widgets are generally designed to be tightly coupled to the context
 /// of the widget that opened the sheet. As such, it is not recommended to push
@@ -611,19 +610,23 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
   /// Defaults to false.
   final bool showDragHandle;
 
-  Widget _dragHandleBuilder(BuildContext context) {
+  Widget _sheetWithDragHandle(BuildContext context) {
     if (!showDragHandle) {
       return builder(context);
     }
 
+    // Values derived from Apple's Figma files and a simulator running iOS 18.2.
     const dragHandleTopPadding = 5.0;
     const dragHandleHeight = 5.0;
     const dragHandleWidth = 36.0;
+    const dragHandleViewInset = 15.0;
 
     return Stack(
       children: <Widget>[
         MediaQuery(
-          data: MediaQuery.of(context).copyWith(viewInsets: const EdgeInsets.only(top: 30)),
+          data: MediaQuery.of(
+            context,
+          ).copyWith(viewInsets: const EdgeInsets.only(top: dragHandleViewInset)),
           child: builder(context),
         ),
         const Align(
@@ -654,7 +657,7 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
         borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
         child: CupertinoUserInterfaceLevel(
           data: CupertinoUserInterfaceLevelData.elevated,
-          child: _CupertinoSheetScope(child: _dragHandleBuilder(context)),
+          child: _CupertinoSheetScope(child: _sheetWithDragHandle(context)),
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -619,14 +619,15 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
     const dragHandleTopPadding = 5.0;
     const dragHandleHeight = 5.0;
     const dragHandleWidth = 36.0;
-    const dragHandleViewInset = 15.0;
+    const dragHandlePadding = 15.0;
 
     return Stack(
+      fit: StackFit.expand,
       children: <Widget>[
         MediaQuery(
           data: MediaQuery.of(
             context,
-          ).copyWith(viewInsets: const EdgeInsets.only(top: dragHandleViewInset)),
+          ).copyWith(padding: const EdgeInsets.only(top: dragHandlePadding)),
           child: builder(context),
         ),
         const Align(

--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -641,13 +641,6 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
               ),
             ),
           ),
-          // child: const DecoratedBox(
-          //   decoration: ShapeDecoration(
-          //     shape: RoundedSuperellipseBorder(),
-          //     color: CupertinoColors.inactiveGray,
-          //   ),
-          //   child: SizedBox(height: 10, width: 40),
-          // ),
         ),
       ],
     );

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -187,7 +187,7 @@ sealed class _DebugSemanticsRoleChecks {
       SemanticsRole.progressBar => _semanticsProgressBar,
       // TODO(chunhtai): add checks when the roles are used in framework.
       // https://github.com/flutter/flutter/issues/159741.
-      SemanticsRole.dragHandle => _unimplemented,
+      SemanticsRole.dragHandle => _noCheckRequired,
       SemanticsRole.spinButton => _unimplemented,
       SemanticsRole.comboBox => _unimplemented,
       SemanticsRole.tooltip => _unimplemented,

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -187,7 +187,7 @@ sealed class _DebugSemanticsRoleChecks {
       SemanticsRole.progressBar => _semanticsProgressBar,
       // TODO(chunhtai): add checks when the roles are used in framework.
       // https://github.com/flutter/flutter/issues/159741.
-      SemanticsRole.dragHandle => _noCheckRequired,
+      SemanticsRole.dragHandle => _unimplemented,
       SemanticsRole.spinButton => _unimplemented,
       SemanticsRole.comboBox => _unimplemented,
       SemanticsRole.tooltip => _unimplemented,

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -62,6 +62,55 @@ void main() {
     );
   });
 
+  testWidgets('showDragHandle adds a drag handle to the top of the sheet', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Page 1'),
+                CupertinoButton(
+                  onPressed: () {
+                    Navigator.push<void>(
+                      scaffoldKey.currentContext!,
+                      CupertinoSheetRoute<void>(
+                        showDragHandle: true,
+                        builder: (BuildContext context) {
+                          return const CupertinoPageScaffold(child: Text('Page 2'));
+                        },
+                      ),
+                    );
+                  },
+                  child: const Text('Push Page 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Page 1'), findsOneWidget);
+    expect(find.text('Page 2'), findsNothing);
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 2'), findsOneWidget);
+    final Finder dragHandleFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is DecoratedBox &&
+          widget.decoration is ShapeDecoration &&
+          (widget.decoration as ShapeDecoration).color == CupertinoColors.tertiaryLabel;
+    });
+    expect(dragHandleFinder, findsOneWidget);
+  });
+
   testWidgets('Previous route moves slight downward when sheet route is pushed', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -111,6 +111,60 @@ void main() {
     expect(dragHandleFinder, findsOneWidget);
   });
 
+  testWidgets('showDragHandle adds a MediaQuery padding so content can render below the handle', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                const Text('Page 1'),
+                CupertinoButton(
+                  onPressed: () {
+                    Navigator.push<void>(
+                      scaffoldKey.currentContext!,
+                      CupertinoSheetRoute<void>(
+                        showDragHandle: true,
+                        builder: (BuildContext context) {
+                          return const CupertinoPageScaffold(
+                            child: SafeArea(child: Text('Page 2')),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                  child: const Text('Push Page 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Page 1'), findsOneWidget);
+    expect(find.text('Page 2'), findsNothing);
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 2'), findsOneWidget);
+    final Finder dragHandleFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is DecoratedBox &&
+          widget.decoration is ShapeDecoration &&
+          (widget.decoration as ShapeDecoration).color == CupertinoColors.tertiaryLabel;
+    });
+
+    final Offset dragHandleOffset = tester.getTopLeft(dragHandleFinder);
+    final Offset sheetContentOffset = tester.getTopLeft(find.text('Page 2'));
+    expect(sheetContentOffset.dy, greaterThan(dragHandleOffset.dy));
+  });
+
   testWidgets('Previous route moves slight downward when sheet route is pushed', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes #179358.

Adds the option to add a native styled drag handle to the top of a Cupertino sheet through the `showDragHandle` property. By default this is false, the same way it is for the native SwiftUI sheet.

Styling for the handle is based off of native versions of the handle, and Apple's Figma files.

From this PR:
<img width="412" height="293" alt="Screenshot 2025-12-16 at 12 53 06 PM" src="https://github.com/user-attachments/assets/b8f48179-775c-4f90-8930-0ca526e62d33" />

From the iOS Maps app (this sheet has a slight transparency)
<img width="401" height="132" alt="Screenshot 2025-12-16 at 12 53 15 PM" src="https://github.com/user-attachments/assets/640b0736-0fe2-4713-81c9-b89c1c1ac41d" />

From the Figma files:
<img width="636" height="371" alt="Screenshot 2025-12-16 at 12 53 36 PM" src="https://github.com/user-attachments/assets/a6fb7853-84f9-4728-85eb-ffdd6e1167cd" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
