### PR TITLE
feat: Introduce FlutterStringUtils for sanitizing UTF-8 data and JSON escape sequences.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -150,6 +150,7 @@ source_set("framework_common") {
     "framework/Source/FlutterStandardCodec.mm",
     "framework/Source/FlutterStandardCodecHelper.cc",
     "framework/Source/FlutterStandardCodec_Internal.h",
+    "framework/Source/FlutterStringUtils.mm",
   ]
 
   public = framework_common_headers
@@ -222,6 +223,7 @@ executable("framework_common_unittests") {
 
   sources = [
     "framework/Source/FlutterBinaryMessengerRelayTest.mm",
+    "framework/Source/FlutterStringUtilsTest.mm",
     "framework/Source/FlutterTestUtils.mm",
     "framework/Source/flutter_codecs_unittest.mm",
     "framework/Source/flutter_standard_codec_unittest.mm",

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_HEADERS_FLUTTERSTRINGUTILS_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_HEADERS_FLUTTERSTRINGUTILS_H_
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Sanitizes a UTF-8 string to ensure it is valid and contains no unpaired surrogate escape
+ * sequences (e.g. \uXXXX) typical in JSON.
+ *
+ * This function performs two passes:
+ * 1. Lossy UTF-8 decoding to replace invalid bytes with \uFFFD.
+ * 2. Scans for JSON-style escape sequences \uXXXX and replaces unpaired surrogates with \uFFFD.
+ */
+NSString* FlutterSanitizeUTF8ForJSON(NSData* data);
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_HEADERS_FLUTTERSTRINGUTILS_H_

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h
@@ -15,6 +15,6 @@
  * 1. Lossy UTF-8 decoding to replace invalid bytes with \uFFFD.
  * 2. Scans for JSON-style escape sequences \uXXXX and replaces unpaired surrogates with \uFFFD.
  */
-NSString* FlutterSanitizeUTF8ForJSON(NSData* data);
+NSString* FLTSanitizeUTF8ForJSON(NSData* data);
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_HEADERS_FLUTTERSTRINGUTILS_H_

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -91,7 +91,7 @@ FLUTTER_ASSERT_ARC
   // Sanitize the input to ensure it is valid UTF-8.
   // This prevents NSJSONSerialization from throwing an exception on invalid Unicode,
   // which causes a crash.
-  NSString* stringMessage = FlutterSanitizeUTF8ForJSON(message);
+  NSString* stringMessage = FLTSanitizeUTF8ForJSON(message);
   NSData* utf8Message = [stringMessage dataUsingEncoding:NSUTF8StringEncoding];
 
   BOOL isSimpleValue = NO;

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtils.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtils.mm
@@ -4,7 +4,7 @@
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h"
 
-NSString* FlutterSanitizeUTF8ForJSON(NSData* data) {
+NSString* FLTSanitizeUTF8ForJSON(NSData* data) {
   if (!data) {
     return nil;
   }

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtils.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtils.mm
@@ -1,0 +1,129 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h"
+
+NSString* FlutterSanitizeUTF8ForJSON(NSData* data) {
+  if (!data) {
+    return nil;
+  }
+
+  // Pass 1: Decode as UTF-8, potentially lossy.
+  // This handles invalid UTF-8 bytes (e.g. truncated sequences).
+  NSString* string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  if (!string) {
+    NSMutableString* result = [NSMutableString stringWithCapacity:data.length];
+    const uint8_t* bytes = (const uint8_t*)data.bytes;
+    NSUInteger length = data.length;
+    NSUInteger i = 0;
+
+    while (i < length) {
+      uint8_t c = bytes[i];
+      if (c < 0x80) {
+        [result appendFormat:@"%c", c];
+        i++;
+      } else {
+        NSUInteger seqLen = 0;
+        if ((c & 0xE0) == 0xC0) {
+          seqLen = 2;
+        } else if ((c & 0xF0) == 0xE0) {
+          seqLen = 3;
+        } else if ((c & 0xF8) == 0xF0) {
+          seqLen = 4;
+        }
+
+        BOOL valid = seqLen > 0 && i + seqLen <= length;
+        for (NSUInteger j = 1; valid && j < seqLen; j++) {
+          if ((bytes[i + j] & 0xC0) != 0x80) {
+            valid = NO;
+          }
+        }
+
+        if (valid) {
+          NSString* part = [[NSString alloc] initWithBytes:bytes + i
+                                                    length:seqLen
+                                                  encoding:NSUTF8StringEncoding];
+          if (part) {
+            [result appendString:part];
+            i += seqLen;
+            continue;
+          }
+        }
+
+        [result appendString:@"\uFFFD"];
+        i++;
+      }
+    }
+    string = result;
+  }
+
+  // Pass 2: Sanitize unpaired surrogate escape sequences (\uXXXX).
+  // NSJSONSerialization fails if it encounters unpaired surrogates in escape sequences.
+  // We scan for \uXXXX and replace unpaired ones with \uFFFD.
+  NSUInteger length = string.length;
+  NSMutableString* result = [NSMutableString stringWithCapacity:length];
+  BOOL modified = NO;
+
+  for (NSUInteger i = 0; i < length;) {
+    unichar c = [string characterAtIndex:i];
+    if (c == '\\' && i + 1 < length) {
+      unichar next = [string characterAtIndex:i + 1];
+      if (next == 'u' && i + 5 < length) {
+        NSString* hexStr = [string substringWithRange:NSMakeRange(i + 2, 4)];
+        unsigned int codePoint;
+        NSScanner* scanner = [NSScanner scannerWithString:hexStr];
+        if ([scanner scanHexInt:&codePoint]) {
+          BOOL isHigh = (codePoint >= 0xD800 && codePoint <= 0xDBFF);
+          BOOL isLow = (codePoint >= 0xDC00 && codePoint <= 0xDFFF);
+
+          if (isHigh) {
+            // Check if followed by low surrogate
+            BOOL hasPair = NO;
+            if (i + 11 < length && [string characterAtIndex:i + 6] == '\\' &&
+                [string characterAtIndex:i + 7] == 'u') {
+              NSString* lowHex = [string substringWithRange:NSMakeRange(i + 8, 4)];
+              unsigned int lowCode;
+              NSScanner* lowScanner = [NSScanner scannerWithString:lowHex];
+              if ([lowScanner scanHexInt:&lowCode]) {
+                if (lowCode >= 0xDC00 && lowCode <= 0xDFFF) {
+                  hasPair = YES;
+                }
+              }
+            }
+
+            if (hasPair) {
+              // Valid pair. Append strictly.
+              [result appendString:[string substringWithRange:NSMakeRange(i, 12)]];
+              i += 12;
+              continue;
+            } else {
+              // Unpaired high. Replace.
+              [result appendString:@"\\uFFFD"];
+              modified = YES;
+              i += 6;
+              continue;
+            }
+          } else if (isLow) {
+            // Unpaired low (if it was paired, it would be consumed by High check).
+            [result appendString:@"\\uFFFD"];
+            modified = YES;
+            i += 6;
+            continue;
+          }
+        }
+      } else {
+        // escaped char other than u (or incomplete u), consume backslash and next char
+        [result appendString:[string substringWithRange:NSMakeRange(i, 2)]];
+        i += 2;
+        continue;
+      }
+    }
+
+    // normal char
+    [result appendFormat:@"%C", c];
+    i++;
+  }
+
+  return modified ? result : string;
+}

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtilsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtilsTest.mm
@@ -1,0 +1,93 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterStringUtils.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(FlutterStringUtilsTest, HandlesNil) {
+  EXPECT_EQ(FlutterSanitizeUTF8ForJSON(nil), nil);
+}
+
+TEST(FlutterStringUtilsTest, PreservesValidUTF8) {
+  NSString* input = @"Hello, World!";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+
+  NSString* emoji = @"👋🌍";
+  NSData* emojiData = [emoji dataUsingEncoding:NSUTF8StringEncoding];
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(emojiData) isEqualToString:emoji]);
+}
+
+TEST(FlutterStringUtilsTest, SanitizesInvalidUTF8) {
+  // Invalid byte sequence (continuation byte without start)
+  const char bytes[] = "Hello \x80 World";
+  NSData* data = [NSData dataWithBytes:bytes length:strlen(bytes)];
+  NSString* sanitized = FlutterSanitizeUTF8ForJSON(data);
+  EXPECT_TRUE([sanitized isEqualToString:@"Hello \uFFFD World"]);
+}
+
+TEST(FlutterStringUtilsTest, PreservesValidJSONEscapes) {
+  NSString* input = @"\\\" \\\\ \\/ \\b \\f \\n \\r \\t";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+}
+
+TEST(FlutterStringUtilsTest, PreservesValidSurrogatePairs) {
+  // \uD83D\uDE00 is 😀
+  NSString* input = @"\\uD83D\\uDE00";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+
+  // Lowercase hex
+  NSString* inputLower = @"\\ud83d\\ude00";
+  NSData* dataLower = [inputLower dataUsingEncoding:NSUTF8StringEncoding];
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(dataLower) isEqualToString:inputLower]);
+}
+
+TEST(FlutterStringUtilsTest, SanitizesUnpairedHighSurrogates) {
+  // \uD800 is a high surrogate
+  NSString* input = @"Val: \\uD800 end";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  NSString* expected = @"Val: \\uFFFD end";
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+}
+
+TEST(FlutterStringUtilsTest, SanitizesUnpairedLowSurrogates) {
+  // \uDC00 is a low surrogate
+  NSString* input = @"Val: \\uDC00 end";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  NSString* expected = @"Val: \\uFFFD end";
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+}
+
+TEST(FlutterStringUtilsTest, SanitizesHighSurrogateFollowedByNonLow) {
+  // \uD800 followed by \u0020 (space) instead of low surrogate
+  NSString* input = @"\\uD800\\u0020";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  NSString* expected = @"\\uFFFD\\u0020";
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+}
+
+TEST(FlutterStringUtilsTest, SanitizesBrokenEscapeSequences) {
+  // String ending in middle of escape
+  NSString* input = @"test \\uD8";
+  NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
+  // Should be preserved as is (or handled gracefully), here it's valid UTF8 chars
+  // but not a complete escape. SanitizeJSON loop checks length.
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+}
+
+TEST(FlutterStringUtilsTest, MixedContent) {
+  // Valid text + Invalid UTF8 + Valid Escape + Lone Surrogate
+  // "H\x80 \u0041 \uD800"
+  // Expected: "H\uFFFD \u0041 \uFFFD"
+  const char bytes[] = "H\x80 \\u0041 \\uD800";
+  NSData* data = [NSData dataWithBytes:bytes length:strlen(bytes)];
+  NSString* expected = @"H\uFFFD \\u0041 \\uFFFD";
+  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+}
+
+}  // namespace

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtilsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/FlutterStringUtilsTest.mm
@@ -8,43 +8,43 @@
 namespace {
 
 TEST(FlutterStringUtilsTest, HandlesNil) {
-  EXPECT_EQ(FlutterSanitizeUTF8ForJSON(nil), nil);
+  EXPECT_EQ(FLTSanitizeUTF8ForJSON(nil), nil);
 }
 
 TEST(FlutterStringUtilsTest, PreservesValidUTF8) {
   NSString* input = @"Hello, World!";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:input]);
 
   NSString* emoji = @"👋🌍";
   NSData* emojiData = [emoji dataUsingEncoding:NSUTF8StringEncoding];
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(emojiData) isEqualToString:emoji]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(emojiData) isEqualToString:emoji]);
 }
 
 TEST(FlutterStringUtilsTest, SanitizesInvalidUTF8) {
   // Invalid byte sequence (continuation byte without start)
   const char bytes[] = "Hello \x80 World";
   NSData* data = [NSData dataWithBytes:bytes length:strlen(bytes)];
-  NSString* sanitized = FlutterSanitizeUTF8ForJSON(data);
+  NSString* sanitized = FLTSanitizeUTF8ForJSON(data);
   EXPECT_TRUE([sanitized isEqualToString:@"Hello \uFFFD World"]);
 }
 
 TEST(FlutterStringUtilsTest, PreservesValidJSONEscapes) {
   NSString* input = @"\\\" \\\\ \\/ \\b \\f \\n \\r \\t";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:input]);
 }
 
 TEST(FlutterStringUtilsTest, PreservesValidSurrogatePairs) {
   // \uD83D\uDE00 is 😀
   NSString* input = @"\\uD83D\\uDE00";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:input]);
 
   // Lowercase hex
   NSString* inputLower = @"\\ud83d\\ude00";
   NSData* dataLower = [inputLower dataUsingEncoding:NSUTF8StringEncoding];
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(dataLower) isEqualToString:inputLower]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(dataLower) isEqualToString:inputLower]);
 }
 
 TEST(FlutterStringUtilsTest, SanitizesUnpairedHighSurrogates) {
@@ -52,7 +52,7 @@ TEST(FlutterStringUtilsTest, SanitizesUnpairedHighSurrogates) {
   NSString* input = @"Val: \\uD800 end";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
   NSString* expected = @"Val: \\uFFFD end";
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:expected]);
 }
 
 TEST(FlutterStringUtilsTest, SanitizesUnpairedLowSurrogates) {
@@ -60,7 +60,7 @@ TEST(FlutterStringUtilsTest, SanitizesUnpairedLowSurrogates) {
   NSString* input = @"Val: \\uDC00 end";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
   NSString* expected = @"Val: \\uFFFD end";
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:expected]);
 }
 
 TEST(FlutterStringUtilsTest, SanitizesHighSurrogateFollowedByNonLow) {
@@ -68,7 +68,7 @@ TEST(FlutterStringUtilsTest, SanitizesHighSurrogateFollowedByNonLow) {
   NSString* input = @"\\uD800\\u0020";
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
   NSString* expected = @"\\uFFFD\\u0020";
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:expected]);
 }
 
 TEST(FlutterStringUtilsTest, SanitizesBrokenEscapeSequences) {
@@ -77,7 +77,7 @@ TEST(FlutterStringUtilsTest, SanitizesBrokenEscapeSequences) {
   NSData* data = [input dataUsingEncoding:NSUTF8StringEncoding];
   // Should be preserved as is (or handled gracefully), here it's valid UTF8 chars
   // but not a complete escape. SanitizeJSON loop checks length.
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:input]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:input]);
 }
 
 TEST(FlutterStringUtilsTest, MixedContent) {
@@ -87,7 +87,7 @@ TEST(FlutterStringUtilsTest, MixedContent) {
   const char bytes[] = "H\x80 \\u0041 \\uD800";
   NSData* data = [NSData dataWithBytes:bytes length:strlen(bytes)];
   NSString* expected = @"H\uFFFD \\u0041 \\uFFFD";
-  EXPECT_TRUE([FlutterSanitizeUTF8ForJSON(data) isEqualToString:expected]);
+  EXPECT_TRUE([FLTSanitizeUTF8ForJSON(data) isEqualToString:expected]);
 }
 
 }  // namespace

--- a/engine/src/flutter/shell/platform/darwin/common/framework_common.gni
+++ b/engine/src/flutter/shell/platform/darwin/common/framework_common.gni
@@ -8,6 +8,7 @@ framework_common_headers =
                     "framework/Headers/FlutterBinaryMessenger.h",
                     "framework/Headers/FlutterChannels.h",
                     "framework/Headers/FlutterCodecs.h",
+                    "framework/Headers/FlutterStringUtils.h",
                     "framework/Headers/FlutterHourFormat.h",
                     "framework/Headers/FlutterTexture.h",
                     "framework/Headers/FlutterDartProject.h",


### PR DESCRIPTION
This change addresses [https://github.com/flutter/flutter/issues/179727](https://github.com/flutter/flutter/issues/179727) by introducing `FlutterStringUtils`. With this approach, iOS and Android now behave consistently.

Please also refer to https://github.com/flutter/flutter/pull/179775 for the previous discussion and related context.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

[![talabat.com](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)

