### PR TITLE
Make sure that a CupertinoTextSelectionToolbarButton doesn't crash in…

### DIFF
--- a/packages/flutter/test/cupertino/text_selection_toolbar_button_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_button_test.dart
@@ -86,4 +86,17 @@ void main() {
     final CupertinoButton button = tester.widget(find.byType(CupertinoButton));
     expect(button.enabled, isFalse);
   });
+
+  testWidgets('CupertinoTextSelectionToolbarButton does not crash at zero area', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: SizedBox.shrink(child: CupertinoTextSelectionToolbarButton(child: Text('X'))),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CupertinoTextSelectionToolbarButton)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CupertinoTextSelectionToolbarButton widget.