### PR TITLE
Add SnackBarTheme

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -3049,12 +3049,11 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
 
     // SnackBar set by ScaffoldMessenger
     if (_messengerSnackBar != null) {
+      final SnackBarThemeData snackBarTheme = SnackBarTheme.of(context);
       final SnackBarBehavior snackBarBehavior =
-          _messengerSnackBar?._widget.behavior ??
-          themeData.snackBarTheme.behavior ??
-          SnackBarBehavior.fixed;
+          _messengerSnackBar?._widget.behavior ?? snackBarTheme.behavior ?? SnackBarBehavior.fixed;
       isSnackBarFloating = snackBarBehavior == SnackBarBehavior.floating;
-      snackBarWidth = _messengerSnackBar?._widget.width ?? themeData.snackBarTheme.width;
+      snackBarWidth = _messengerSnackBar?._widget.width ?? snackBarTheme.width;
 
       _addIfNonNull(
         children,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -159,7 +159,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
     final SnackBarThemeData defaults = Theme.of(context).useMaterial3
         ? _SnackbarDefaultsM3(context)
         : _SnackbarDefaultsM2(context);
-    final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
+    final SnackBarThemeData snackBarTheme = SnackBarTheme.of(context);
 
     WidgetStateColor resolveForegroundColor() {
       if (widget.textColor != null) {
@@ -309,8 +309,8 @@ class SnackBar extends StatefulWidget {
 
   /// The snack bar's background color.
   ///
-  /// If not specified, it will use [SnackBarThemeData.backgroundColor] of
-  /// [ThemeData.snackBarTheme]. If that is not specified it will default to a
+  /// If not specified, the ambient [SnackBarThemeData.backgroundColor] is used.
+  /// If that is not specified it will default to a
   /// dark variation of [ColorScheme.surface] for light themes, or
   /// [ColorScheme.onSurface] for dark themes.
   final Color? backgroundColor;
@@ -320,9 +320,8 @@ class SnackBar extends StatefulWidget {
   ///
   /// Defines the card's [Material.elevation].
   ///
-  /// If this property is null, then [SnackBarThemeData.elevation] of
-  /// [ThemeData.snackBarTheme] is used, if that is also null, the default value
-  /// is 6.0.
+  /// If this property is null, then the ambient [SnackBarThemeData.elevation]
+  /// is used, if that is also null, the default value is 6.0.
   final double? elevation;
 
   /// Empty space to surround the snack bar.
@@ -330,8 +329,8 @@ class SnackBar extends StatefulWidget {
   /// This property is only used when [behavior] is [SnackBarBehavior.floating].
   /// It can not be used if [width] is specified.
   ///
-  /// If this property is null, then [SnackBarThemeData.insetPadding] of
-  /// [ThemeData.snackBarTheme] is used. If that is also null, then the default is
+  /// If this property is null, then the ambient [SnackBarThemeData.insetPadding]
+  /// is used. If that is also null, then the default is
   /// `EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 10.0)`.
   ///
   /// If this property is not null and [hitTestBehavior] is null, then [hitTestBehavior] default is [HitTestBehavior.deferToChild].
@@ -371,17 +370,17 @@ class SnackBar extends StatefulWidget {
   /// available space. This property is only used when [behavior] is
   /// [SnackBarBehavior.floating]. It can not be used if [margin] is specified.
   ///
-  /// If this property is null, then [SnackBarThemeData.width] of
-  /// [ThemeData.snackBarTheme] is used. If that is null, the snack bar will
-  /// take up the full device width less the margin.
+  /// If this property is null, then the ambient [SnackBarThemeData.width]
+  /// is used. If that is null, the snack bar will take up the full device
+  /// width less the margin.
   final double? width;
 
   /// The shape of the snack bar's [Material].
   ///
   /// Defines the snack bar's [Material.shape].
   ///
-  /// If this property is null then [SnackBarThemeData.shape] of
-  /// [ThemeData.snackBarTheme] is used. If that's null then the shape will
+  /// If this property is null, then the ambient [SnackBarThemeData.shape]
+  /// is used. If that's null then the shape will
   /// depend on the [SnackBarBehavior]. For [SnackBarBehavior.fixed], no
   /// overriding shape is specified, so the [SnackBar] is rectangular. For
   /// [SnackBarBehavior.floating], it uses a [RoundedRectangleBorder] with a
@@ -390,8 +389,9 @@ class SnackBar extends StatefulWidget {
 
   /// Defines how the snack bar area, including margin, will behave during hit testing.
   ///
-  /// If this property is null, and [margin] is not null or [SnackBarThemeData.insetPadding] of
-  /// [ThemeData.snackBarTheme] is not null, then [HitTestBehavior.deferToChild] is used by default.
+  /// If this property is null, and [margin] is not null or the ambient
+  /// [SnackBarThemeData.insetPadding] is not null, then
+  /// [HitTestBehavior.deferToChild] is used by default.
   ///
   /// Please refer to [HitTestBehavior] for a detailed explanation of every behavior.
   final HitTestBehavior? hitTestBehavior;
@@ -402,9 +402,8 @@ class SnackBar extends StatefulWidget {
   /// location should be adjusted when the scaffold also includes a
   /// [FloatingActionButton] or a [BottomNavigationBar]
   ///
-  /// If this property is null, then [SnackBarThemeData.behavior] of
-  /// [ThemeData.snackBarTheme] is used. If that is null, then the default is
-  /// [SnackBarBehavior.fixed].
+  /// If this property is null, then the ambient [SnackBarThemeData.behavior]
+  /// is used. If that is null, then the default is [SnackBarBehavior.fixed].
   ///
   /// If this value is [SnackBarBehavior.floating], the length of the bar
   /// is defined by either [width] or [margin].
@@ -438,9 +437,8 @@ class SnackBar extends StatefulWidget {
   /// An optional color for the close icon, if [showCloseIcon] is
   /// true.
   ///
-  /// If this property is null, then [SnackBarThemeData.closeIconColor] of
-  /// [ThemeData.snackBarTheme] is used. If that is null, then the default is
-  /// inverse surface.
+  /// If this property is null, then the ambient [SnackBarThemeData.closeIconColor]
+  /// is used. If that is null, then the default is inverse surface.
   ///
   /// If [closeIconColor] is a [WidgetStateColor], then the icon color will be
   /// resolved against the set of [WidgetState]s that the action text
@@ -486,9 +484,8 @@ class SnackBar extends StatefulWidget {
 
   /// The direction in which the SnackBar can be dismissed.
   ///
-  /// If this property is null, then [SnackBarThemeData.dismissDirection] of
-  /// [ThemeData.snackBarTheme] is used. If that is null, then the default is
-  /// [DismissDirection.down].
+  /// If this property is null, then the ambient [SnackBarThemeData.dismissDirection]
+  /// is used. If that is null, then the default is [DismissDirection.down].
   final DismissDirection? dismissDirection;
 
   /// {@macro flutter.material.Material.clipBehavior}
@@ -628,7 +625,7 @@ class _SnackBarState extends State<SnackBar> {
     assert(widget.animation != null);
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
-    final SnackBarThemeData snackBarTheme = theme.snackBarTheme;
+    final SnackBarThemeData snackBarTheme = SnackBarTheme.of(context);
     final isThemeDark = theme.brightness == Brightness.dark;
     final Color buttonColor = isThemeDark ? colorScheme.primary : colorScheme.secondary;
     final SnackBarThemeData defaults = theme.useMaterial3

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -18,6 +18,9 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
+// Examples can assume:
+// late BuildContext context;
+
 /// Defines where a [SnackBar] should appear within a [Scaffold] and how its
 /// location should be adjusted when the scaffold also includes a
 /// [FloatingActionButton] or a [BottomNavigationBar].
@@ -44,7 +47,7 @@ enum SnackBarBehavior {
 /// Customizes default property values for [SnackBar] widgets.
 ///
 /// Descendant widgets obtain the current [SnackBarThemeData] object using
-/// `Theme.of(context).snackBarTheme`. Instances of [SnackBarThemeData] can be
+/// [SnackBarTheme.of]. Instances of [SnackBarThemeData] can be
 /// customized with [SnackBarThemeData.copyWith].
 ///
 /// Typically a [SnackBarThemeData] is specified as part of the overall [Theme]
@@ -341,4 +344,43 @@ class SnackBarThemeData with Diagnosticable {
       ),
     );
   }
+}
+
+/// An inherited widget that defines the configuration for
+/// [SnackBar]s in this widget's subtree.
+///
+/// Values specified here are used for [SnackBar] properties that are not
+/// given an explicit non-null value.
+class SnackBarTheme extends InheritedTheme {
+  /// Creates a snackbar theme that controls the configurations for
+  /// [SnackBar]s in its widget subtree.
+  const SnackBarTheme({super.key, required this.data, required super.child});
+
+  /// The properties for descendant [SnackBar] widgets.
+  final SnackBarThemeData data;
+
+  /// The closest instance of this class's [data] value that encloses the given
+  /// context.
+  ///
+  /// If there is no ancestor, it returns [ThemeData.snackBarTheme]. Applications
+  /// can assume that the returned value will not be null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// SnackBarThemeData theme = SnackBarTheme.of(context);
+  /// ```
+  static SnackBarThemeData of(BuildContext context) {
+    final SnackBarTheme? snackBarTheme = context
+        .dependOnInheritedWidgetOfExactType<SnackBarTheme>();
+    return snackBarTheme?.data ?? Theme.of(context).snackBarTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return SnackBarTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(SnackBarTheme oldWidget) => data != oldWidget.data;
 }

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -286,6 +286,136 @@ void main() {
     expect(snackBarBottomRight.dx, (800 + snackBarWidth) / 2); // Device width is 800.
   });
 
+  testWidgets('Local SnackBarTheme properties are used', (WidgetTester tester) async {
+    const Color backgroundColor = Colors.purple;
+    const Color textColor = Colors.pink;
+    const elevation = 7.0;
+    const action = 'ACTION';
+    const ShapeBorder shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(9.0)),
+    );
+    const snackBarWidth = 400.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SnackBarTheme(
+          data: const SnackBarThemeData(
+            backgroundColor: backgroundColor,
+            behavior: SnackBarBehavior.floating,
+            width: snackBarWidth,
+            elevation: elevation,
+            shape: shape,
+            showCloseIcon: false,
+            actionTextColor: textColor,
+          ),
+          child: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(label: action, onPressed: () {}),
+                      ),
+                    );
+                  },
+                  child: const Text('X'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Finder materialFinder = _getSnackBarMaterialFinder(tester);
+    final Material material = _getSnackBarMaterial(tester);
+    final RenderParagraph button = _getSnackBarActionTextRenderObject(tester, action);
+
+    expect(material.color, backgroundColor);
+    expect(material.elevation, elevation);
+    expect(material.shape, shape);
+    expect(button.text.style!.color, textColor);
+    expect(_getSnackBarIconFinder(tester), findsNothing);
+    // Assert width.
+    final Offset snackBarBottomLeft = tester.getBottomLeft(materialFinder.first);
+    final Offset snackBarBottomRight = tester.getBottomRight(materialFinder.first);
+    expect(snackBarBottomLeft.dx, (800 - snackBarWidth) / 2); // Device width is 800.
+    expect(snackBarBottomRight.dx, (800 + snackBarWidth) / 2); // Device width is 800.
+  });
+
+  testWidgets('SnackBar widget properties take priority over local theme', (
+    WidgetTester tester,
+  ) async {
+    const Color backgroundColor = Colors.purple;
+    const Color textColor = Colors.pink;
+    const elevation = 7.0;
+    const action = 'ACTION';
+    const ShapeBorder shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(9.0)),
+    );
+    const snackBarWidth = 400.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SnackBarTheme(
+          data: _snackBarTheme(showCloseIcon: true),
+          child: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        backgroundColor: backgroundColor,
+                        behavior: SnackBarBehavior.floating,
+                        width: snackBarWidth,
+                        elevation: elevation,
+                        shape: shape,
+                        content: const Text('I am a snack bar.'),
+                        duration: const Duration(seconds: 2),
+                        action: SnackBarAction(
+                          textColor: textColor,
+                          label: action,
+                          onPressed: () {},
+                        ),
+                        showCloseIcon: false,
+                      ),
+                    );
+                  },
+                  child: const Text('X'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Finder materialFinder = _getSnackBarMaterialFinder(tester);
+    final Material material = _getSnackBarMaterial(tester);
+    final RenderParagraph button = _getSnackBarActionTextRenderObject(tester, action);
+
+    expect(material.color, backgroundColor);
+    expect(material.elevation, elevation);
+    expect(material.shape, shape);
+    expect(button.text.style!.color, textColor);
+    expect(_getSnackBarIconFinder(tester), findsNothing);
+    // Assert width.
+    final Offset snackBarBottomLeft = tester.getBottomLeft(materialFinder.first);
+    final Offset snackBarBottomRight = tester.getBottomRight(materialFinder.first);
+    expect(snackBarBottomLeft.dx, (800 - snackBarWidth) / 2); // Device width is 800.
+    expect(snackBarBottomRight.dx, (800 + snackBarWidth) / 2); // Device width is 800.
+  });
+
   testWidgets('SnackBarAction uses actionBackgroundColor', (WidgetTester tester) async {
     final actionBackgroundColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.disabled)) {


### PR DESCRIPTION
## Description

This PR adds the `SnackBarTheme` subclass of InheritedTheme. Similarly to other theme classes.

Despite missing, this class was mentioned in [flutter.dev/go/material-theme-system-updates](http://flutter.dev/go/material-theme-system-updates):
"SnackBarTheme and SnackBarThemeData are conformant.. "


## Related Issue
Fixes [Missing SnackBarTheme](https://github.com/flutter/flutter/issues/180000)

## Tests

Adds 2 tests.