### PR TITLE
Re-prioritize pipeline compile jobs and perform them eagerly instead of waiting.

### DIFF
--- a/engine/src/flutter/impeller/base/flags.h
+++ b/engine/src/flutter/impeller/base/flags.h
@@ -7,9 +7,6 @@
 
 namespace impeller {
 struct Flags {
-  /// Whether to defer PSO construction until first use. Usage Will introduce
-  /// raster jank.
-  bool lazy_shader_mode = false;
   /// When turned on DrawLine will use the experimental antialiased path.
   bool antialiased_lines = false;
 };

--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -52,6 +52,8 @@ impeller_component("renderer") {
     "pipeline.h",
     "pipeline_builder.cc",
     "pipeline_builder.h",
+    "pipeline_compile_queue.cc",
+    "pipeline_compile_queue.h",
     "pipeline_descriptor.cc",
     "pipeline_descriptor.h",
     "pipeline_library.cc",

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_library_vk.h
@@ -16,6 +16,7 @@
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/pipeline.h"
+#include "impeller/renderer/pipeline_compile_queue.h"
 #include "impeller/renderer/pipeline_library.h"
 
 namespace impeller {
@@ -48,6 +49,7 @@ class PipelineLibraryVK final
   PipelineKey pipeline_key_ IPLR_GUARDED_BY(pipelines_mutex_) = 1;
   bool is_valid_ = false;
   bool cache_dirty_ = false;
+  std::shared_ptr<PipelineCompileQueue> compile_queue_;
 
   PipelineLibraryVK(
       const std::shared_ptr<DeviceHolderVK>& device_holder,
@@ -75,6 +77,9 @@ class PipelineLibraryVK final
   // |PipelineLibrary|
   void RemovePipelinesWithEntryPoint(
       std::shared_ptr<const ShaderFunction> function) override;
+
+  // |PipelineLibrary|
+  PipelineCompileQueue* GetPipelineCompileQueue() const override;
 
   std::unique_ptr<ComputePipelineVK> CreateComputePipeline(
       const ComputePipelineDescriptor& desc,

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.cc
@@ -1,0 +1,118 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/pipeline_compile_queue.h"
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
+
+namespace impeller {
+
+std::shared_ptr<PipelineCompileQueue> PipelineCompileQueue::Create(
+    std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner) {
+  return std::shared_ptr<PipelineCompileQueue>(
+      new PipelineCompileQueue(std::move(worker_task_runner)));
+}
+
+PipelineCompileQueue::PipelineCompileQueue(
+    std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner)
+    : worker_task_runner_(std::move(worker_task_runner)) {}
+
+PipelineCompileQueue::~PipelineCompileQueue() {
+  FinishAllJobs();
+}
+
+bool PipelineCompileQueue::PostJobForDescriptor(const PipelineDescriptor& desc,
+                                                const fml::closure& job) {
+  if (!job) {
+    return false;
+  }
+
+  {
+    Lock lock(pending_jobs_mutex_);
+    auto insertion_result = pending_jobs_.insert(std::make_pair(desc, job));
+    if (!insertion_result.second) {
+      // This bit is being extremely conservative. If insertion did not take
+      // place, someone gave the compile queue a job for the same description.
+      // This is highly unusual but technically not impossible. Just run the job
+      // eagerly.
+      FML_LOG(ERROR) << "Got multiple compile jobs for the same descriptor. "
+                        "Running eagerly.";
+      // Don't invoke the job here has there are we have currently acquired a
+      // mutex.
+      worker_task_runner_->PostTask(job);
+      return true;
+    }
+  }
+
+  worker_task_runner_->PostTask([weak_queue = weak_from_this()]() {
+    if (auto queue = weak_queue.lock()) {
+      queue->DoOneJob();
+    }
+  });
+  return true;
+}
+
+fml::closure PipelineCompileQueue::TakeNextJob() {
+  Lock lock(pending_jobs_mutex_);
+  if (pending_jobs_.empty()) {
+    return nullptr;
+  }
+  auto job_iterator = pending_jobs_.begin();
+  auto job = job_iterator->second;
+  pending_jobs_.erase(job_iterator);
+  return job;
+}
+
+fml::closure PipelineCompileQueue::TakeJob(const PipelineDescriptor& desc) {
+  Lock lock(pending_jobs_mutex_);
+  auto found = pending_jobs_.find(desc);
+  if (found == pending_jobs_.end()) {
+    return nullptr;
+  }
+  // The pipeline compile job was somewhere in the task queue. However, a
+  // rendering operation needed the job to be done ASAP. Instead of waiting for
+  // the pipeline compile queue to eventually get to finishing job, the thread
+  // waiting on the job just decided to take the job from the queue and do it
+  // itself. If there were jobs ahead of this one, it means that they were
+  // mis-prioritized. This counter dumps the number of job re-prioritizations.
+  priorities_elevated_++;
+  FML_TRACE_COUNTER("impeller", "PipelineCompileQueue",
+                    reinterpret_cast<int64_t>(this),  // Trace Counter ID
+                    "PrioritiesElevated", priorities_elevated_);
+  auto job = found->second;
+  pending_jobs_.erase(found);
+  return job;
+}
+
+void PipelineCompileQueue::DoOneJob() {
+  if (auto job = TakeNextJob()) {
+    job();
+  }
+}
+
+void PipelineCompileQueue::FinishAllJobs() {
+  // This doesn't have to be fast. Just ensures the task queue is flushed when
+  // the compile queue is shutting down with jobs still in it.
+  while (true) {
+    bool has_jobs = false;
+    {
+      Lock lock(pending_jobs_mutex_);
+      has_jobs = !pending_jobs_.empty();
+    }
+    if (!has_jobs) {
+      return;
+    }
+    // Allow any remaining worker threads to take jobs from this queue.
+    DoOneJob();
+  }
+}
+
+void PipelineCompileQueue::PerformJobEagerly(const PipelineDescriptor& desc) {
+  if (auto job = TakeJob(desc)) {
+    job();
+  }
+}
+
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_compile_queue.h
@@ -1,0 +1,100 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_PIPELINE_COMPILE_QUEUE_H_
+#define FLUTTER_IMPELLER_RENDERER_PIPELINE_COMPILE_QUEUE_H_
+
+#include <unordered_map>
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/concurrent_message_loop.h"
+#include "impeller/base/thread.h"
+#include "impeller/renderer/pipeline_descriptor.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      A task queue designed for managing compilation of pipeline state
+///             objects.
+///
+///             The task queue attempts to perform compile jobs as quickly as
+///             possible by dispatching tasks to a concurrent task runner. These
+///             tasks are dispatched during renderer creation and usually
+///             complete before the first frame is rendered. In this ideal case,
+///             this queue is entirely unnecessary and and serves as a thin
+///             wrapper around just posting the compile jobs to a concurrent
+///             task runner.
+///
+///             If however, usually on lower end device, the compile jobs cannot
+///             be completed before the first frame is rendered, the implicit
+///             act of waiting for the compile job to be done can instead be
+///             augmented to take the pending job and perform it eagerly on the
+///             waiters thread. This effectively turns an idle wait into the job
+///             skipping to the front of the line and being done on the callers
+///             thread.
+///
+///             Again, the entire point of this class is the reduce startup
+///             times on the lowest end devices. On high end device, a queue is
+///             entirely optional. The queue skipping mechanism all assume the
+///             optional availability of a compile queue.
+///
+class PipelineCompileQueue final
+    : public std::enable_shared_from_this<PipelineCompileQueue> {
+ public:
+  static std::shared_ptr<PipelineCompileQueue> Create(
+      std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner);
+
+  virtual ~PipelineCompileQueue();
+
+  PipelineCompileQueue(const PipelineCompileQueue&) = delete;
+
+  PipelineCompileQueue& operator=(const PipelineCompileQueue&) = delete;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Post a compile job for the specified descriptor.
+  ///
+  /// @param[in]  desc  The description
+  /// @param[in]  job   The job
+  ///
+  /// @return     If the job was successfully posted to the parallel task
+  /// runners.
+  ///
+  bool PostJobForDescriptor(const PipelineDescriptor& desc,
+                            const fml::closure& job);
+
+  //----------------------------------------------------------------------------
+  /// @brief      If the task has not yet been done, perform it eagerly on the
+  ///             calling thread. This can be used in lieu of an idle wait for
+  ///             the task completion on the calling thread.
+  ///
+  /// @param[in]  desc  The description
+  ///
+  void PerformJobEagerly(const PipelineDescriptor& desc);
+
+ private:
+  std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner_;
+  Mutex pending_jobs_mutex_;
+  size_t priorities_elevated_ = {};
+
+  std::unordered_map<PipelineDescriptor,
+                     fml::closure,
+                     ComparableHash<PipelineDescriptor>,
+                     ComparableEqual<PipelineDescriptor>>
+      pending_jobs_ IPLR_GUARDED_BY(pending_jobs_mutex_);
+
+  explicit PipelineCompileQueue(
+      std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner);
+
+  fml::closure TakeJob(const PipelineDescriptor& desc);
+
+  fml::closure TakeNextJob();
+
+  void DoOneJob();
+
+  void FinishAllJobs();
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_PIPELINE_COMPILE_QUEUE_H_

--- a/engine/src/flutter/impeller/renderer/pipeline_library.cc
+++ b/engine/src/flutter/impeller/renderer/pipeline_library.cc
@@ -74,4 +74,8 @@ PipelineLibrary::GetPipelineUseCounts() const {
   return counts;
 }
 
+PipelineCompileQueue* PipelineLibrary::GetPipelineCompileQueue() const {
+  return nullptr;
+}
+
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/pipeline_library.h
+++ b/engine/src/flutter/impeller/renderer/pipeline_library.h
@@ -12,6 +12,7 @@
 #include "impeller/base/thread.h"
 #include "impeller/base/thread_safety.h"
 #include "impeller/renderer/pipeline.h"
+#include "impeller/renderer/pipeline_compile_queue.h"
 #include "impeller/renderer/pipeline_descriptor.h"
 
 namespace impeller {
@@ -85,6 +86,14 @@ class PipelineLibrary : public std::enable_shared_from_this<PipelineLibrary> {
                      ComparableHash<PipelineDescriptor>,
                      ComparableEqual<PipelineDescriptor>>
   GetPipelineUseCounts() const;
+
+  //----------------------------------------------------------------------------
+  /// @brief      If this library has a configurable compile queue, return a
+  ///             pointer to it.
+  ///
+  /// @return     The pipeline compile queue if one is present.
+  ///
+  virtual PipelineCompileQueue* GetPipelineCompileQueue() const;
 
  protected:
   PipelineLibrary();

--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
@@ -126,7 +126,6 @@ GetActualRenderingAPIForImpeller(
           .enable_surface_control = settings.enable_surface_control,
           .impeller_flags =
               {
-                  .lazy_shader_mode = settings.impeller_flags.lazy_shader_mode,
                   .antialiased_lines =
                       settings.impeller_flags.antialiased_lines,
               },

--- a/engine/src/flutter/shell/platform/android/platform_view_android.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android.cc
@@ -59,8 +59,6 @@ AndroidContext::ContextSettings CreateContextSettings(
   settings.enable_gpu_tracing = p_settings.enable_vulkan_gpu_tracing;
   settings.enable_validation = p_settings.enable_vulkan_validation;
   settings.enable_surface_control = p_settings.enable_surface_control;
-  settings.impeller_flags.lazy_shader_mode =
-      p_settings.impeller_enable_lazy_shader_mode;
   settings.impeller_flags.antialiased_lines =
       p_settings.impeller_antialiased_lines;
   return settings;

--- a/engine/src/flutter/shell/testing/tester_context_vk_factory.cc
+++ b/engine/src/flutter/shell/testing/tester_context_vk_factory.cc
@@ -54,9 +54,6 @@ class TesterContextVK : public TesterContext {
     context_settings.shader_libraries_data = ShaderLibraryMappings();
     context_settings.cache_directory = fml::paths::GetCachesDirectory();
     context_settings.enable_validation = enable_validation;
-    // Enable lazy shader mode for faster test execution as most tests
-    // will never render anything at all.
-    context_settings.flags.lazy_shader_mode = true;
 
     context_ = impeller::ContextVK::Create(std::move(context_settings));
     if (!context_ || !context_->IsValid()) {


### PR DESCRIPTION
Also, removes "lazy shader mode" and re-enables eager PSO pre-flight.

Impeller eagerly sets up the entire set of pipeline state objects (PSOs) it may need during renderer setup. This works fine on mid to high-end devices as the setup completes well before the first frame is rendered.

However on low-end devices, not all PSOs may be ready before the first frame is rendered. Low-end device usually don't have as much available concurrency and are slower to boot. On these devices, the rendering thread had to wait for the background compile job to be completed. It was also observed that the relatively higher priority render thread was waiting on a background thread to finish a PSO compile job. The PSO compile job could also be stuck behind another job that was not immediately needed. This made the situation on low end devices less than ideal.

To ameliorate this situation, a stop-gap was introduced called "lazy shader mode". This disabled PSO pre-flight entirely and only dispatched jobs when they were needed. This ameliorated somewhat the issue of unneeded jobs blocking the eagerly needed job but the other issues remained. It also meant that one could expect jank the first time a new PSO was needed. This mode was not widely used or advertised.

In this patch, the lazy shader mode has been entirely removed and eager PSO pre-flight is the default in all configurations. Pipeline compile jobs are now handled by a separate compile queue. This queue operates like a transparent concurrent worker pool job dispatcher in the usual case. However, when the pipeline for a specific descriptor is needed, instead of waiting for the job to complete, the queue allows the job for that descriptor to skip to the head of the queue and be performed on the calling thread. This effectively make the calling thread do the job instead of waiting. Another nice side effect of this behavior is that the higher priority thread is now doing the job it was previously waiting on.

This fixes all issues on lower end devices except one. During eager pre-flight, it would still be better if PSO compile jobs for that were somehow divined to be needed first were towards the front of the pre-flight queue. After all, only a handful of rendering features account for the majority of rendering operations. A future augmentation to the compile queue would be to allow higher prioritization of more widely used pipeline compile jobs as instrumented in https://github.com/flutter/flutter/issues/176660. This task is tracked in https://github.com/flutter/flutter/issues/176665.

This patch only wires up the compile queue for Vulkan. https://github.com/flutter/flutter/issues/176657 tracks doing the same for OpenGL.

The efficacy of the re-prioritizations can be traced using the 
PrioritiesElevated trace counter. On higher end devices, there should
be zero of these.

Fixes https://github.com/flutter/flutter/issues/176656
Fixes https://github.com/flutter/flutter/issues/176663
Fixes https://github.com/flutter/flutter/issues/176658
