### PR TITLE
Fix an issue where the semantics announce event may be encoded as either an int32_t or an int64_t depending on its value

### DIFF
--- a/engine/src/flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/engine/src/flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -214,6 +215,23 @@ class EncodableValue : public internal::EncodableValueVariant {
       return std::get<int32_t>(*this);
     }
     return std::get<int64_t>(*this);
+  }
+
+  // Convenience method to simplify handling objects received from Flutter
+  // where the values may be larger than 32-bit, since they have the same type
+  // on the Dart side, but will be either 32-bit or 64-bit here depending on
+  // the value.
+  //
+  // Calling this method if the value doesn't contain either an int32_t or an
+  // int64_t will return std::nullopt.
+  std::optional<int64_t> TryGetLongValue() const {
+    if (std::holds_alternative<int32_t>(*this)) {
+      return std::get<int32_t>(*this);
+    }
+    if (std::holds_alternative<int64_t>(*this)) {
+      return std::get<int64_t>(*this);
+    }
+    return std::nullopt;
   }
 
 // The C++ Standard Library implementations can get into issues with recursive

--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -212,6 +212,7 @@ executable("flutter_windows_unittests") {
   # Common Windows test sources.
   sources = [
     "accessibility_bridge_windows_unittests.cc",
+    "accessibility_plugin_unittests.cc",
     "compositor_opengl_unittests.cc",
     "compositor_software_unittests.cc",
     "cursor_handler_unittests.cc",

--- a/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
@@ -69,21 +69,14 @@ void HandleMessage(AccessibilityPlugin* plugin, const EncodableValue& message) {
     }
 
     // The viewId may be encoded as either a 32-bit or 64-bit integer.
-    FlutterViewId view_id;
-    const auto* view_id_64 = std::get_if<FlutterViewId>(&view_itr->second);
-    const auto* view_id_32 = std::get_if<int32_t>(&view_itr->second);
-
-    if (view_id_64) {
-      view_id = *view_id_64;
-    } else if (view_id_32) {
-      view_id = static_cast<FlutterViewId>(*view_id_32);
-    } else {
+    auto const view_id = view_itr->second.TryGetLongValue();
+    if (!view_id) {
       FML_LOG(ERROR)
           << "Announce message 'viewId' property must be a FlutterViewId.";
       return;
     }
 
-    plugin->Announce(view_id, *message);
+    plugin->Announce(*view_id, *message);
   } else {
     FML_LOG(WARNING) << "Accessibility message type '" << *type
                      << "' is not supported.";

--- a/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
@@ -68,14 +68,22 @@ void HandleMessage(AccessibilityPlugin* plugin, const EncodableValue& message) {
       return;
     }
 
-    const auto* view_id_val = std::get_if<FlutterViewId>(&view_itr->second);
-    if (!view_id_val) {
+    // The viewId may be encoded as either a 32-bit or 64-bit integer.
+    FlutterViewId view_id;
+    const auto* view_id_64 = std::get_if<FlutterViewId>(&view_itr->second);
+    const auto* view_id_32 = std::get_if<int32_t>(&view_itr->second);
+
+    if (view_id_64) {
+      view_id = *view_id_64;
+    } else if (view_id_32) {
+      view_id = static_cast<FlutterViewId>(*view_id_32);
+    } else {
       FML_LOG(ERROR)
           << "Announce message 'viewId' property must be a FlutterViewId.";
       return;
     }
 
-    plugin->Announce(*view_id_val, *message);
+    plugin->Announce(view_id, *message);
   } else {
     FML_LOG(WARNING) << "Accessibility message type '" << *type
                      << "' is not supported.";

--- a/engine/src/flutter/shell/platform/windows/accessibility_plugin_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_plugin_unittests.cc
@@ -1,0 +1,152 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/accessibility_plugin.h"
+
+#include <memory>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
+#include "flutter/shell/platform/windows/testing/engine_modifier.h"
+#include "flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h"
+#include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
+#include "flutter/shell/platform/windows/testing/test_binary_messenger.h"
+#include "flutter/shell/platform/windows/testing/windows_test.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+namespace {
+
+using ::testing::_;
+using ::testing::NiceMock;
+
+static constexpr char kAccessibilityChannelName[] = "flutter/accessibility";
+
+class MockFlutterWindowsView : public FlutterWindowsView {
+ public:
+  MockFlutterWindowsView(FlutterWindowsEngine* engine,
+                         std::unique_ptr<WindowBindingHandler> window)
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(window)) {}
+
+  MOCK_METHOD(void, AnnounceAlert, (const std::wstring& text), ());
+};
+
+}  // namespace
+
+class AccessibilityPluginTest : public WindowsTest {
+ public:
+  AccessibilityPluginTest() = default;
+  virtual ~AccessibilityPluginTest() = default;
+
+ protected:
+  FlutterWindowsEngine* engine() { return engine_.get(); }
+  TestBinaryMessenger* messenger() { return &messenger_; }
+
+  void SetUp() override {
+    WindowsTest::SetUp();
+
+    FlutterWindowsEngineBuilder builder{GetContext()};
+    engine_ = builder.Build();
+
+    auto window = std::make_unique<NiceMock<MockWindowBindingHandler>>();
+    view_ = std::make_unique<NiceMock<MockFlutterWindowsView>>(
+        engine_.get(), std::move(window));
+
+    EngineModifier modifier{engine_.get()};
+    modifier.SetSemanticsEnabled(true);
+    modifier.SetImplicitView(view_.get());
+
+    plugin_ = std::make_unique<AccessibilityPlugin>(engine_.get());
+    AccessibilityPlugin::SetUp(&messenger_, plugin_.get());
+  }
+
+  void SendAnnounceMessage(const std::string& message, EncodableValue view_id) {
+    EncodableMap data;
+    data[EncodableValue{"message"}] = EncodableValue{message};
+    data[EncodableValue{"viewId"}] = view_id;
+
+    EncodableMap msg;
+    msg[EncodableValue{"type"}] = EncodableValue{"announce"};
+    msg[EncodableValue{"data"}] = EncodableValue{data};
+
+    auto encoded =
+        StandardMessageCodec::GetInstance().EncodeMessage(EncodableValue{msg});
+
+    bool handled = messenger_.SimulateEngineMessage(
+        kAccessibilityChannelName, encoded->data(), encoded->size(),
+        [](const uint8_t* reply, size_t reply_size) {});
+
+    EXPECT_TRUE(handled)
+        << "Message was not handled by the accessibility channel";
+  }
+
+  MockFlutterWindowsView* view() { return view_.get(); }
+
+ private:
+  std::unique_ptr<FlutterWindowsEngine> engine_;
+  std::unique_ptr<MockFlutterWindowsView> view_;
+  std::unique_ptr<AccessibilityPlugin> plugin_;
+  TestBinaryMessenger messenger_;
+};
+
+TEST_F(AccessibilityPluginTest, DirectAnnounceCall) {
+  // Test calling Announce directly, bypassing the message channel
+  EXPECT_CALL(*view(), AnnounceAlert(::testing::Eq(L"Direct"))).Times(1);
+
+  AccessibilityPlugin plugin(engine());
+  plugin.Announce(0, "Direct");
+
+  ::testing::Mock::VerifyAndClearExpectations(view());
+}
+
+TEST_F(AccessibilityPluginTest, AnnounceWithInt32ViewId) {
+  EXPECT_CALL(*view(), AnnounceAlert(::testing::Eq(L"Hello"))).Times(1);
+
+  SendAnnounceMessage("Hello", EncodableValue{static_cast<int32_t>(0)});
+
+  // Verify expectations are met
+  ::testing::Mock::VerifyAndClearExpectations(view());
+}
+
+TEST_F(AccessibilityPluginTest, AnnounceWithInt64ViewId) {
+  EXPECT_CALL(*view(), AnnounceAlert(::testing::Eq(L"Hello World"))).Times(1);
+
+  SendAnnounceMessage("Hello World", EncodableValue{static_cast<int64_t>(0)});
+
+  // Verify expectations are met
+  ::testing::Mock::VerifyAndClearExpectations(view());
+}
+
+TEST_F(AccessibilityPluginTest, AnnounceWithInvalidViewIdType) {
+  // Should not be called with invalid viewId type
+  EXPECT_CALL(*view(), AnnounceAlert(_)).Times(0);
+
+  SendAnnounceMessage("Hello", EncodableValue{"invalid"});
+}
+TEST_F(AccessibilityPluginTest, AnnounceWithMissingMessage) {
+  // Should not be called when message is missing
+  EXPECT_CALL(*view(), AnnounceAlert(_)).Times(0);
+
+  EncodableMap data;
+  data[EncodableValue{"viewId"}] = EncodableValue{static_cast<int32_t>(0)};
+
+  EncodableMap msg;
+  msg[EncodableValue{"type"}] = EncodableValue{"announce"};
+  msg[EncodableValue{"data"}] = EncodableValue{data};
+
+  auto encoded =
+      StandardMessageCodec::GetInstance().EncodeMessage(EncodableValue{msg});
+
+  messenger()->SimulateEngineMessage(
+      kAccessibilityChannelName, encoded->data(), encoded->size(),
+      [](const uint8_t* reply, size_t reply_size) {});
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_view.h
@@ -101,7 +101,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void SendInitialBounds();
 
   // Set the text of the alert, and create it if it does not yet exist.
-  void AnnounceAlert(const std::wstring& text);
+  virtual void AnnounceAlert(const std::wstring& text);
 
   // |WindowBindingHandlerDelegate|
   void OnHighContrastChanged() override;

--- a/engine/src/flutter/shell/platform/windows/testing/engine_modifier.h
+++ b/engine/src/flutter/shell/platform/windows/testing/engine_modifier.h
@@ -95,6 +95,10 @@ class EngineModifier {
     engine_->next_view_id_ = view_id;
   }
 
+  void SetSemanticsEnabled(bool enabled) {
+    engine_->semantics_enabled_ = enabled;
+  }
+
  private:
   FlutterWindowsEngine* engine_;
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/179563

## What's new?
- The viewId on the announce semantics event may be either an int32 or an int64, depending on what the codec perceives is best
- We should parse either one of them on the Win32 side of things

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

