### PR TITLE
Add RenderSliver.getMaxPaintRect

### DIFF
--- a/packages/flutter/test/rendering/sliver_max_paint_rect_test.dart
+++ b/packages/flutter/test/rendering/sliver_max_paint_rect_test.dart
@@ -1,0 +1,320 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  TestRenderingFlutterBinding.ensureInitialized();
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.down', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 100.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.down scrolled', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 50.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 50.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 50.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // Rect should be shifted up by scrollOffset.
+    // Rect.fromLTWH(0.0, -50.0, 100.0, 100.0)
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, -50.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.up', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 100.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.up,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.up scrolled', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 50.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.up,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 50.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 50.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // For Up:
+    // rect = (0, -50, 100, 100)
+    // paintExtent = 50
+    // Result L: 0
+    // Result T: 50 - 100 = -50? No.
+    // Code: paintExtent - rect.bottom
+    // rect.bottom = 50. paintExtent = 50. Result T = 0.
+    // Result R: 100
+    // Result B: paintExtent - rect.top
+    // rect.top = -50. Result B = 50 - (-50) = 100.
+    // Rect(0, 0, 100, 100)
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.right', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 100.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.right,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.down,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.right scrolled', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 50.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.right,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 50.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 50.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.down,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // Horizontal axis.
+    // rect = (-50, 0, 100, 100)
+    // Right: returns rect.
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(-50.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.left', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 100.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.left,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.down,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.left scrolled', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 50.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.left,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 50.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 50.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.down,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // Horizontal axis.
+    // rect = (-50, 0, 100, 100). Left: -50, Right: 50.
+    // Left direction:
+    // L: paintExtent - rect.right = 50 - 50 = 0.
+    // T: rect.top = 0.
+    // R: paintExtent - rect.left = 50 - (-50) = 100.
+    // B: rect.bottom = 100.
+    // Rect(0, 0, 100, 100)
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect pinned', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(
+        scrollExtent: 100.0,
+        paintExtent: 10.0,
+        maxPaintExtent: 100.0,
+        maxScrollObstructionExtent: 10.0,
+      ),
+    );
+
+    // Scroll offset 95. Pinned at 10.
+    // clampedScrollOffset should be min(95, 100 - 10) = 90.
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 95.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 10.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // Rect.fromLTWH(0.0, -90.0, 100.0, 100.0)
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, -90.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect infinite maxPaintExtent', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(
+        scrollExtent: double.infinity,
+        paintExtent: 100.0,
+        maxPaintExtent: double.infinity,
+        cacheExtent: 150.0,
+      ),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 50.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 200.0,
+        cacheOrigin: -50.0,
+      ),
+    );
+
+    // maxPaintExtent = scrollOffset + cacheExtent + cacheOrigin
+    // = 50 + 150 + (-50) = 150.
+    // Rect.fromLTWH(0.0, -50.0, 100.0, 150.0)
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, -50.0, 100.0, 150.0));
+  });
+}
+
+/// A [RenderSliver] that allows setting its [geometry] directly for testing purposes.
+class _TestRenderSliver extends RenderSliver {
+  _TestRenderSliver(this._geometry);
+
+  final SliverGeometry _geometry;
+
+  @override
+  void performLayout() {
+    geometry = _geometry;
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {}
+
+  @override
+  Rect getMaxPaintRect() => super.getMaxPaintRect();
+}

--- a/packages/flutter/test/rendering/sliver_max_paint_rect_test.dart
+++ b/packages/flutter/test/rendering/sliver_max_paint_rect_test.dart
@@ -23,7 +23,32 @@ void main() {
         scrollOffset: 0.0,
         precedingScrollExtent: 0.0,
         overlap: 0.0,
-        remainingPaintExtent: 100.0,
+        remainingPaintExtent: 300.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect AxisDirection.down and GrowthDirection.reverse', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 100.0, paintExtent: 100.0, maxPaintExtent: 100.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.reverse,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 300.0,
         crossAxisExtent: 100.0,
         crossAxisDirection: AxisDirection.right,
         viewportMainAxisExtent: 100.0,
@@ -75,7 +100,7 @@ void main() {
         scrollOffset: 0.0,
         precedingScrollExtent: 0.0,
         overlap: 0.0,
-        remainingPaintExtent: 100.0,
+        remainingPaintExtent: 300.0,
         crossAxisExtent: 100.0,
         crossAxisDirection: AxisDirection.right,
         viewportMainAxisExtent: 100.0,
@@ -136,7 +161,7 @@ void main() {
         scrollOffset: 0.0,
         precedingScrollExtent: 0.0,
         overlap: 0.0,
-        remainingPaintExtent: 100.0,
+        remainingPaintExtent: 300.0,
         crossAxisExtent: 100.0,
         crossAxisDirection: AxisDirection.down,
         viewportMainAxisExtent: 100.0,
@@ -189,7 +214,7 @@ void main() {
         scrollOffset: 0.0,
         precedingScrollExtent: 0.0,
         overlap: 0.0,
-        remainingPaintExtent: 100.0,
+        remainingPaintExtent: 300.0,
         crossAxisExtent: 100.0,
         crossAxisDirection: AxisDirection.down,
         viewportMainAxisExtent: 100.0,
@@ -285,7 +310,7 @@ void main() {
         scrollOffset: 50.0,
         precedingScrollExtent: 0.0,
         overlap: 0.0,
-        remainingPaintExtent: 100.0,
+        remainingPaintExtent: 300.0,
         crossAxisExtent: 100.0,
         crossAxisDirection: AxisDirection.right,
         viewportMainAxisExtent: 100.0,
@@ -298,6 +323,62 @@ void main() {
     // = 50 + 150 + (-50) = 150.
     // Rect.fromLTWH(0.0, -50.0, 100.0, 150.0)
     expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, -50.0, 100.0, 150.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect with crossAxisExtent set (e.g. SliverCrossAxisGroup)', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(
+        scrollExtent: 100.0,
+        paintExtent: 100.0,
+        maxPaintExtent: 100.0,
+        crossAxisExtent: 50.0,
+      ),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 300.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 50.0, 100.0));
+  });
+
+  test('RenderSliver.getMaxPaintRect maxPaintExtent > remainingPaintExtent', () {
+    final sliver = _TestRenderSliver(
+      const SliverGeometry(scrollExtent: 200.0, paintExtent: 100.0, maxPaintExtent: 150.0),
+    );
+
+    sliver.layout(
+      const SliverConstraints(
+        axisDirection: AxisDirection.down,
+        growthDirection: GrowthDirection.forward,
+        userScrollDirection: ScrollDirection.idle,
+        scrollOffset: 0.0,
+        precedingScrollExtent: 0.0,
+        overlap: 0.0,
+        remainingPaintExtent: 100.0,
+        crossAxisExtent: 100.0,
+        crossAxisDirection: AxisDirection.right,
+        viewportMainAxisExtent: 100.0,
+        remainingCacheExtent: 100.0,
+        cacheOrigin: 0.0,
+      ),
+    );
+
+    // getMaxPaintRect should use maxPaintExtent (150.0) regardless of remainingPaintExtent (100.0).
+    expect(sliver.getMaxPaintRect(), const Rect.fromLTWH(0.0, 0.0, 100.0, 150.0));
   });
 }
 


### PR DESCRIPTION
This PR extracts the `getMaxPaintRect` logic into a shared method in `RenderSliver`. This helper is required for upcoming changes in #179003 and #179802 to avoid code duplication.

Cc @Piinks 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

