### PR TITLE
[web] Fix autofill in iOS 26 (reuse form)

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/dom.dart
@@ -446,6 +446,8 @@ extension type DomElement._(JSObject _) implements DomNode {
   // ignore: annotate_redeclares
   external void remove();
 
+  external void replaceWith(DomNode node);
+
   @JS('setAttribute')
   external void _setAttribute(String name, JSAny value);
   void setAttribute(String name, Object value) => _setAttribute(name, value.toJSAnyDeep);

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2052,13 +2052,21 @@ class TextInput {
       final TextInputClient client = _currentConnection!._client;
       final AutofillScope? scope = client.currentAutofillScope;
       final editingValue = args[1] as Map<String, dynamic>;
+      print('[framework] TextInputClient.updateEditingStateWithTag:');
       for (final String tag in editingValue.keys) {
         final textEditingValue = TextEditingValue.fromJSON(
           editingValue[tag] as Map<String, dynamic>,
         );
         final AutofillClient? client = scope?.getAutofillClient(tag);
+        print('  ($tag) => "${textEditingValue.text}"');
         if (client != null && client.textInputConfiguration.autofillConfiguration.enabled) {
+          print('  -> client.autofill(...)');
           client.autofill(textEditingValue);
+        } else {
+          print(
+            '  -> client != null ${client != null}, '
+            'autofill enabled: ${client?.textInputConfiguration.autofillConfiguration.enabled}',
+          );
         }
       }
 


### PR DESCRIPTION
This is the 3rd or 4th iteration to fix this issue, and I'm still not happy with the end result.

As explained in my comment [here](https://github.com/flutter/flutter/issues/177248#issuecomment-3633430999), Safari on iOS 26 changed the focus management of inputs during autofill.

## Prior to this PR:

- The user clicks on a text field.
- The user selects to autofill.
- The OS shows a popup of the password manager, and blurs the input field.
- As soon as focus is lost, the engine requests that the framework disconnect the input client.
- The OS then comes back and focuses the input field again, and autofills the values.
- This newly gained focus goes unnoticed since the engine has no mechanism to re-establish an input connection with the framework.
- This problem doesn't happen when semantics is turned on because semantics *_has_* a mechanism (`SemanticsAction.focus`) to re-focus the input.
- When the user clicks again on the text field, the framework will override it with out-of-date values.

## What this PR does:

Simply put, this PR tackles the last bullet point above. It makes it so that the autofilled values override the framework's out-of-date values, instead of vice versa.

This PR also fixes few other minor issues.

Remaining problems:
- There are still cases where the autofilled value gets accidentally overridden. Example:
    - Click username text field.
    - Autofill it.
    - Click again on username text field.
    - Switch to the password field.
    - Start typing.
    - Notice the password gets erased.

- The autofilled values don't reflect immediately until the user clicks on one of the fields again. This is a problem I'm seeing in other non-Flutter websites too, due to the weird new focus behavior that Safari is doing.

## Can we fully fix it?

I believe we can fully fix, but it may require a bigger change. Here are 2 ideas that should help:

    - Make `TextInputClient.updateEditingStateWithTag` work even when there's no active connection.
    - Introduce a mechanism for the engine to re-establish a connection.

<hr>

Fixes https://github.com/flutter/flutter/issues/177248