### PR TITLE
Pass canaryFeatures to BuildSettings

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -335,6 +335,7 @@ class WebAssetServer implements AssetReader {
                   appEntrypoint: packageConfig.toPackageUri(
                     fileSystem.file(entrypoint).absolute.uri,
                   ),
+                  canaryFeatures: canaryFeatures,
                 ),
                 packageConfigPath: buildInfo.packageConfigPath,
                 reloadedSourcesUri: server._baseUri.replace(
@@ -351,6 +352,7 @@ class WebAssetServer implements AssetReader {
                   appEntrypoint: packageConfig.toPackageUri(
                     fileSystem.file(entrypoint).absolute.uri,
                   ),
+                  canaryFeatures: canaryFeatures,
                 ),
                 packageConfigPath: buildInfo.packageConfigPath,
               ).strategy,


### PR DESCRIPTION
Previously, this made little difference as DWDS used this only in one case with expression evaluation but now that the load strategies have diverged based on this flag, we should correctly always pipe this flag. This fixes an issue with a future DWDS version.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
