### PR TITLE
Fix `FocusableActionDetector` example in DartPad not working with `ENTER` key

### DIFF
--- a/examples/api/lib/widgets/actions/focusable_action_detector.0.dart
+++ b/examples/api/lib/widgets/actions/focusable_action_detector.0.dart
@@ -45,6 +45,9 @@ class _FadButtonState extends State<FadButton> {
       ActivateIntent: CallbackAction<Intent>(
         onInvoke: (Intent intent) => _toggleState(),
       ),
+      ButtonActivateIntent: CallbackAction<Intent>(
+        onInvoke: (Intent intent) => _toggleState(),
+      ),
     };
   }
 

--- a/examples/api/test/widgets/actions/focusable_action_detector.0_test.dart
+++ b/examples/api/test/widgets/actions/focusable_action_detector.0_test.dart
@@ -77,4 +77,40 @@ void main() {
 
     expect(redContainerFinder, findsNothing);
   });
+
+  testWidgets(
+    'Hits on the Enter key when "And Me" is focused toggle the red box',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.FocusableActionDetectorExampleApp(),
+      );
+
+      expect(
+        find.widgetWithText(AppBar, 'FocusableActionDetector Example'),
+        findsOne,
+      );
+
+      expect(redContainerFinder, findsNothing);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(redContainerFinder, findsNothing);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(redContainerFinder, findsNothing);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(redContainerFinder, findsOne);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(redContainerFinder, findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
fixes : #105843

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
