### PR TITLE
[ Web ] Pass `--enable-experimental-ffi` when compiling WASM tests

### DIFF
--- a/engine/src/flutter/lib/web_ui/dev/steps/compile_bundle_step.dart
+++ b/engine/src/flutter/lib/web_ui/dev/steps/compile_bundle_step.dart
@@ -260,9 +260,9 @@ class Dart2WasmCompiler extends TestCompiler {
 
     final arguments = <String>[
       environment.dart2wasmSnapshotPath,
-
       '--libraries-spec=${environment.dartSdkDir.path}/lib/libraries.json',
       '--enable-asserts',
+      '--enable-experimental-ffi',
       '--enable-experimental-wasm-interop',
 
       '-DFLUTTER_WEB_USE_SKIA=${renderer == Renderer.canvaskit}',

--- a/engine/src/flutter/lib/web_ui/dev/steps/compile_bundle_step.dart
+++ b/engine/src/flutter/lib/web_ui/dev/steps/compile_bundle_step.dart
@@ -260,6 +260,7 @@ class Dart2WasmCompiler extends TestCompiler {
 
     final arguments = <String>[
       environment.dart2wasmSnapshotPath,
+
       '--libraries-spec=${environment.dartSdkDir.path}/lib/libraries.json',
       '--enable-asserts',
       '--enable-experimental-ffi',


### PR DESCRIPTION
The CFE will start treating unsupported library imports as errors in an upcoming change (see https://github.com/dart-lang/sdk/issues/62125) which will cause web engine compilation tests to fail without the `--enable-experimental-ffi` flag.

This change passes `--enable-experimental-ffi` to `dart2wasm` in preparation for this change in behavior.