### PR TITLE
Partial update for `CHANGELOG` for 3.38.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 - [flutter/179139](https://github.com/flutter/flutter/issues/179139) - `flutter widget-preview start` creates new cached build artifacts on each run, resulting in increasing disk usage after each run.
 - [flutter/178896](https://github.com/flutter/flutter/issues/178896) - Apps crash during launch on Windows when run from paths containing non-ASCII characters.
-- [flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run test on macOS 15 or 15.7.2 for Flutter's CI.
-- [flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps created with  3.40.0 or below require action to upgrade to AGP 9.0.0.
+- [flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run tests on macOS 15 or 15.7.2 for Flutter's CI.
+- [flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps that upgrade to AGP 9.0.0 require migration steps.
 
 ### [3.38.5](https://github.com/flutter/flutter/releases/tag/3.38.5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,10 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 ### [3.38.6](https://github.com/flutter/flutter/releases/tag/3.38.6)
 
-[flutter/179139](https://github.com/flutter/flutter/issues/179139) - `flutter widget-preview start` creates new cached build artifacts on each run, resulting in increasing disk usage after each run.
-[flutter/178896](https://github.com/flutter/flutter/issues/178896) - Apps crash during launch on Windows when run from paths containing non-ASCII characters.
-[flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run test on macOS 15 or 15.7.2 for Flutter's CI.
-[flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps created with  3.40.0 or below require action to upgrade to AGP 9.0.0.
+- [flutter/179139](https://github.com/flutter/flutter/issues/179139) - `flutter widget-preview start` creates new cached build artifacts on each run, resulting in increasing disk usage after each run.
+- [flutter/178896](https://github.com/flutter/flutter/issues/178896) - Apps crash during launch on Windows when run from paths containing non-ASCII characters.
+- [flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run test on macOS 15 or 15.7.2 for Flutter's CI.
+- [flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps created with  3.40.0 or below require action to upgrade to AGP 9.0.0.
 
 ### [3.38.5](https://github.com/flutter/flutter/releases/tag/3.38.5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,16 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 ## Flutter 3.38 Changes
 
+### [3.38.6](https://github.com/flutter/flutter/releases/tag/3.38.6)
+
+[flutter/179139](https://github.com/flutter/flutter/issues/179139) - `flutter widget-preview start` creates new cached build artifacts on each run, resulting in increasing disk usage after each run.
+[flutter/178896](https://github.com/flutter/flutter/issues/178896) - Apps crash during launch on Windows when run from paths containing non-ASCII characters.
+[flutter/176943](https://github.com/flutter/flutter/issues/176943) - Configuration changes to run test on macOS 15 or 15.7.2 for Flutter's CI.
+[flutter/179914](https://github.com/flutter/flutter/issues/179914) - Flutter Android apps created with  3.40.0 or below require action to upgrade to AGP 9.0.0.
+
 ### [3.38.5](https://github.com/flutter/flutter/releases/tag/3.38.5)
 
-- [flutter/179700](https://github.com/flutter/flutter/issues/179700) Update dart to 3.10.4.
+- [flutter/179700](https://github.com/flutter/flutter/issues/179700) Update Dart to 3.10.4.
 
 ### [3.38.4](https://github.com/flutter/flutter/releases/tag/3.38.4)
 


### PR DESCRIPTION
Updates `CHANGELOG` with commits I landed this week to be included in the 3.38.6 release due in a few weeks.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
