### PR TITLE
flutter_tools: Copy vendored frameworks from plugin podspecs in ios/macos-framework builds

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -395,10 +395,8 @@ List<String> parseVendoredFrameworks(String podspecContents) {
   final String? singleValue = lastMatch.group(1);
   final String? arrayContent = lastMatch.group(2);
 
-  if (singleValue != null) {
-    if (singleValue.isNotEmpty) {
-      results.add(singleValue);
-    }
+  if (singleValue != null && singleValue.isNotEmpty) {
+    results.add(singleValue);
   } else if (arrayContent != null) {
     // Extract individual paths from the array content.
     final pathPattern = RegExp(r'''["']([^"']+)["']''');

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -353,13 +353,9 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
         }
       } else if (frameworkName.endsWith('.framework')) {
         // Create an xcframework from the single framework
-        final Directory xcframeworkOutput = modeDirectory.childDirectory(
-          '$binaryName.xcframework',
-        );
+        final Directory xcframeworkOutput = modeDirectory.childDirectory('$binaryName.xcframework');
         if (!xcframeworkOutput.existsSync()) {
-          globals.logger.printTrace(
-            'Creating xcframework from vendored framework: $frameworkName',
-          );
+          globals.logger.printTrace('Creating xcframework from vendored framework: $frameworkName');
           await BuildFrameworkCommand.produceXCFramework(
             <Directory>[frameworkEntity],
             binaryName,
@@ -931,11 +927,7 @@ end
       }
 
       // Copy vendored frameworks from CocoaPods plugins.
-      await copyVendoredFrameworks(
-        modeDirectory,
-        project.ios.hostAppRoot,
-        globals.plistParser,
-      );
+      await copyVendoredFrameworks(modeDirectory, project.ios.hostAppRoot, globals.plistParser);
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -22,6 +22,7 @@ import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../ios/xcodeproj.dart';
 import '../macos/cocoapod_utils.dart';
+import '../plugins.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
 import '../version.dart';
 import 'build.dart';
@@ -276,6 +277,140 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
       );
     }
   }
+
+  /// Copies vendored frameworks from plugin podspecs to the output directory.
+  ///
+  /// Parses each plugin's podspec to find vendored_frameworks entries,
+  /// locates the framework files in the plugin directory, and copies them
+  /// to the output directory as xcframeworks.
+  Future<void> copyVendoredFrameworks(Directory modeDirectory, String platform) async {
+    final List<Plugin> plugins = await findPlugins(project);
+    final processedFrameworks = <String>{};
+
+    for (final plugin in plugins) {
+      final String? podspecPath = plugin.pluginPodspecPath(globals.fs, platform);
+      if (podspecPath == null) {
+        continue;
+      }
+
+      final File podspecFile = globals.fs.file(podspecPath);
+      if (!podspecFile.existsSync()) {
+        continue;
+      }
+
+      final String podspecContents = await podspecFile.readAsString();
+      final List<String> vendoredPaths = parseVendoredFrameworks(podspecContents);
+
+      if (vendoredPaths.isEmpty) {
+        continue;
+      }
+
+      // The vendored path is relative to the podspec file's directory
+      final Directory podspecDir = podspecFile.parent;
+
+      for (final vendoredPath in vendoredPaths) {
+        // Skip placeholder paths (used by Flutter's own podhelper.rb)
+        if (vendoredPath.contains('path/to/nothing')) {
+          continue;
+        }
+
+        // The vendored path is relative to the podspec file's directory
+        final String frameworkPath = globals.fs.path.join(podspecDir.path, vendoredPath);
+        final FileSystemEntity frameworkEntity = globals.fs.directory(frameworkPath);
+
+        if (!frameworkEntity.existsSync()) {
+          globals.logger.printTrace('Vendored framework not found: $frameworkPath');
+          continue;
+        }
+
+        final String frameworkName = globals.fs.path.basename(vendoredPath);
+        final String binaryName = globals.fs.path.basenameWithoutExtension(frameworkName);
+
+        // Skip if we've already processed this framework name
+        if (processedFrameworks.contains(binaryName)) {
+          continue;
+        }
+        processedFrameworks.add(binaryName);
+
+        // Check if it's already an xcframework
+        if (frameworkName.endsWith('.xcframework')) {
+          // Copy the xcframework directly
+          final source = frameworkEntity as Directory;
+          final Directory destination = modeDirectory.childDirectory(frameworkName);
+          if (!destination.existsSync()) {
+            globals.logger.printTrace('Copying vendored xcframework: $frameworkName');
+            copyDirectory(source, destination);
+          }
+        } else if (frameworkName.endsWith('.framework')) {
+          // Create an xcframework from the single framework
+          final Directory xcframeworkOutput = modeDirectory.childDirectory(
+            '$binaryName.xcframework',
+          );
+          if (!xcframeworkOutput.existsSync()) {
+            globals.logger.printTrace(
+              'Creating xcframework from vendored framework: $frameworkName',
+            );
+            await BuildFrameworkCommand.produceXCFramework(
+              <Directory>[frameworkEntity as Directory],
+              binaryName,
+              modeDirectory,
+              globals.processManager,
+            );
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Parses a podspec file and returns a list of vendored framework paths.
+///
+/// The vendored_frameworks value in a podspec can be:
+/// - A single string: `s.vendored_frameworks = 'Path/To/Framework.framework'`
+/// - An array: `s.vendored_frameworks = ['Framework1.framework', 'Framework2.framework']`
+///
+/// In Ruby, the last assignment wins, so if there are multiple assignments,
+/// only the last one is used.
+///
+/// Returns an empty list if no vendored_frameworks are found.
+List<String> parseVendoredFrameworks(String podspecContents) {
+  // This regex finds all assignments to `vendored_frameworks`.
+  // It captures either a single quoted string or an array literal.
+  // Group 1: single string content, Group 2: array content
+  final pattern = RegExp(
+    r'''^\s*[a-zA-Z_]+\.vendored_frameworks\s*=\s*(?:["']([^"']+)["']|\[([^\]]*)\])''',
+    multiLine: true,
+  );
+
+  final List<RegExpMatch> matches = pattern.allMatches(podspecContents).toList();
+  if (matches.isEmpty) {
+    return <String>[];
+  }
+
+  // In Ruby, the last assignment wins.
+  final RegExpMatch lastMatch = matches.last;
+  final results = <String>[];
+
+  // Group 1 is single string content, group 2 is array content.
+  final String? singleValue = lastMatch.group(1);
+  final String? arrayContent = lastMatch.group(2);
+
+  if (singleValue != null) {
+    if (singleValue.isNotEmpty) {
+      results.add(singleValue);
+    }
+  } else if (arrayContent != null) {
+    // Extract individual paths from the array content.
+    final pathPattern = RegExp(r'''["']([^"']+)["']''');
+    for (final RegExpMatch pathMatch in pathPattern.allMatches(arrayContent)) {
+      final String? path = pathMatch.group(1);
+      if (path != null && path.isNotEmpty) {
+        results.add(path);
+      }
+    }
+  }
+
+  return results;
 }
 
 /// Produces a .framework for integration into a host iOS app. The .framework
@@ -746,6 +881,9 @@ end
           );
         }
       }
+
+      // Copy vendored frameworks from plugin podspecs.
+      await copyVendoredFrameworks(modeDirectory, 'ios');
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -20,9 +20,9 @@ import '../convert.dart';
 import '../darwin/darwin.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
+import '../ios/plist_parser.dart';
 import '../ios/xcodeproj.dart';
 import '../macos/cocoapod_utils.dart';
-import '../plugins.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;
 import '../version.dart';
 import 'build.dart';
@@ -278,133 +278,183 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     }
   }
 
-  /// Copies vendored frameworks from plugin podspecs to the output directory.
+  /// Copies vendored frameworks from CocoaPods plugins to the output directory.
   ///
-  /// Parses each plugin's podspec to find vendored_frameworks entries,
-  /// locates the framework files in the plugin directory, and copies them
-  /// to the output directory as xcframeworks.
-  Future<void> copyVendoredFrameworks(Directory modeDirectory, String platform) async {
-    final List<Plugin> plugins = await findPlugins(project);
+  /// Parses the Pods.xcodeproj/project.pbxproj to find vendored frameworks
+  /// in PBXGroups named "Frameworks", then copies them to the output directory.
+  /// This approach is more reliable than parsing podspecs because CocoaPods
+  /// has already resolved all paths, wildcards, and platform-specific entries.
+  ///
+  /// Note: This only copies frameworks from CocoaPods-based plugins.
+  /// Swift Package Manager support will be added in a separate command.
+  Future<void> copyVendoredFrameworks(
+    Directory modeDirectory,
+    Directory hostAppRoot,
+    PlistParser plistParser,
+  ) async {
+    final File projectFile = hostAppRoot
+        .childDirectory('Pods')
+        .childDirectory('Pods.xcodeproj')
+        .childFile('project.pbxproj');
+
+    if (!projectFile.existsSync()) {
+      globals.logger.printTrace('Pods.xcodeproj not found, skipping vendored frameworks');
+      return;
+    }
+
+    final List<String> frameworkPaths = parseVendoredFrameworksFromPbxproj(
+      projectFile,
+      plistParser,
+      globals.logger,
+    );
+
+    if (frameworkPaths.isEmpty) {
+      return;
+    }
+
     final processedFrameworks = <String>{};
+    final Directory podsRoot = hostAppRoot.childDirectory('Pods');
 
-    for (final plugin in plugins) {
-      final String? podspecPath = plugin.pluginPodspecPath(globals.fs, platform);
-      if (podspecPath == null) {
+    for (final frameworkPath in frameworkPaths) {
+      // Skip Flutter's own frameworks
+      if (frameworkPath.contains('Flutter.framework') ||
+          frameworkPath.contains('Flutter.xcframework') ||
+          frameworkPath.contains('App.framework') ||
+          frameworkPath.contains('App.xcframework')) {
         continue;
       }
 
-      final File podspecFile = globals.fs.file(podspecPath);
-      if (!podspecFile.existsSync()) {
+      // Framework path is relative to the Pods directory
+      final String absolutePath = globals.fs.path.normalize(
+        globals.fs.path.join(podsRoot.path, frameworkPath),
+      );
+      final Directory frameworkEntity = globals.fs.directory(absolutePath);
+
+      if (!frameworkEntity.existsSync()) {
+        globals.logger.printTrace('Vendored framework not found: $absolutePath');
         continue;
       }
 
-      final String podspecContents = await podspecFile.readAsString();
-      final List<String> vendoredPaths = parseVendoredFrameworks(podspecContents);
+      final String frameworkName = globals.fs.path.basename(frameworkPath);
+      final String binaryName = globals.fs.path.basenameWithoutExtension(frameworkName);
 
-      if (vendoredPaths.isEmpty) {
+      // Skip if we've already processed this framework name
+      if (processedFrameworks.contains(binaryName)) {
         continue;
       }
+      processedFrameworks.add(binaryName);
 
-      // The vendored path is relative to the podspec file's directory
-      final Directory podspecDir = podspecFile.parent;
-
-      for (final vendoredPath in vendoredPaths) {
-        // Skip placeholder paths (used by Flutter's own podhelper.rb)
-        if (vendoredPath.contains('path/to/nothing')) {
-          continue;
+      // Check if it's already an xcframework
+      if (frameworkName.endsWith('.xcframework')) {
+        final Directory destination = modeDirectory.childDirectory(frameworkName);
+        if (!destination.existsSync()) {
+          globals.logger.printTrace('Copying vendored xcframework: $frameworkName');
+          copyDirectory(frameworkEntity, destination);
         }
-
-        // The vendored path is relative to the podspec file's directory
-        final String frameworkPath = globals.fs.path.join(podspecDir.path, vendoredPath);
-        final FileSystemEntity frameworkEntity = globals.fs.directory(frameworkPath);
-
-        if (!frameworkEntity.existsSync()) {
-          globals.logger.printTrace('Vendored framework not found: $frameworkPath');
-          continue;
-        }
-
-        final String frameworkName = globals.fs.path.basename(vendoredPath);
-        final String binaryName = globals.fs.path.basenameWithoutExtension(frameworkName);
-
-        // Skip if we've already processed this framework name
-        if (processedFrameworks.contains(binaryName)) {
-          continue;
-        }
-        processedFrameworks.add(binaryName);
-
-        // Check if it's already an xcframework
-        if (frameworkName.endsWith('.xcframework')) {
-          // Copy the xcframework directly
-          final source = frameworkEntity as Directory;
-          final Directory destination = modeDirectory.childDirectory(frameworkName);
-          if (!destination.existsSync()) {
-            globals.logger.printTrace('Copying vendored xcframework: $frameworkName');
-            copyDirectory(source, destination);
-          }
-        } else if (frameworkName.endsWith('.framework')) {
-          // Create an xcframework from the single framework
-          final Directory xcframeworkOutput = modeDirectory.childDirectory(
-            '$binaryName.xcframework',
+      } else if (frameworkName.endsWith('.framework')) {
+        // Create an xcframework from the single framework
+        final Directory xcframeworkOutput = modeDirectory.childDirectory(
+          '$binaryName.xcframework',
+        );
+        if (!xcframeworkOutput.existsSync()) {
+          globals.logger.printTrace(
+            'Creating xcframework from vendored framework: $frameworkName',
           );
-          if (!xcframeworkOutput.existsSync()) {
-            globals.logger.printTrace(
-              'Creating xcframework from vendored framework: $frameworkName',
-            );
-            await BuildFrameworkCommand.produceXCFramework(
-              <Directory>[frameworkEntity as Directory],
-              binaryName,
-              modeDirectory,
-              globals.processManager,
-            );
-          }
+          await BuildFrameworkCommand.produceXCFramework(
+            <Directory>[frameworkEntity],
+            binaryName,
+            modeDirectory,
+            globals.processManager,
+          );
         }
       }
     }
   }
 }
 
-/// Parses a podspec file and returns a list of vendored framework paths.
+/// Parses vendored framework paths from a Pods.xcodeproj/project.pbxproj file.
 ///
-/// The vendored_frameworks value in a podspec can be:
-/// - A single string: `s.vendored_frameworks = 'Path/To/Framework.framework'`
-/// - An array: `s.vendored_frameworks = ['Framework1.framework', 'Framework2.framework']`
+/// This function uses PlistParser to parse the project.pbxproj file and finds
+/// all framework/xcframework references in PBXGroups named "Frameworks".
 ///
-/// In Ruby, the last assignment wins, so if there are multiple assignments,
-/// only the last one is used.
-///
-/// Returns an empty list if no vendored_frameworks are found.
-List<String> parseVendoredFrameworks(String podspecContents) {
-  // This regex finds all assignments to `vendored_frameworks`.
-  // It captures either a single quoted string or an array literal.
-  // Group 1: single string content, Group 2: array content
-  final pattern = RegExp(
-    r'''^\s*[a-zA-Z_]+\.vendored_frameworks\s*=\s*(?:["']([^"']+)["']|\[([^\]]*)\])''',
-    multiLine: true,
-  );
-
-  final List<RegExpMatch> matches = pattern.allMatches(podspecContents).toList();
-  if (matches.isEmpty) {
+/// Returns a list of framework paths relative to the Pods directory.
+@visibleForTesting
+List<String> parseVendoredFrameworksFromPbxproj(
+  File projectFile,
+  PlistParser plistParser,
+  Logger logger,
+) {
+  final String? jsonContent = plistParser.plistJsonContent(projectFile.path);
+  if (jsonContent == null) {
+    logger.printTrace('Failed to parse project.pbxproj');
     return <String>[];
   }
 
-  // In Ruby, the last assignment wins.
-  final RegExpMatch lastMatch = matches.last;
+  final Map<String, Object?> projectData;
+  try {
+    projectData = json.decode(jsonContent) as Map<String, Object?>;
+  } on FormatException catch (e) {
+    logger.printTrace('Failed to decode project.pbxproj JSON: $e');
+    return <String>[];
+  }
+
+  final objects = projectData['objects'] as Map<String, Object?>?;
+  if (objects == null) {
+    return <String>[];
+  }
+
   final results = <String>[];
+  final fileReferenceIds = <String>{};
 
-  // Group 1 is single string content, group 2 is array content.
-  final String? singleValue = lastMatch.group(1);
-  final String? arrayContent = lastMatch.group(2);
+  // Find all PBXGroups named "Frameworks" and collect their children
+  for (final MapEntry<String, Object?> entry in objects.entries) {
+    final objectValue = entry.value as Map<String, Object?>?;
+    if (objectValue == null) {
+      continue;
+    }
 
-  if (singleValue != null && singleValue.isNotEmpty) {
-    results.add(singleValue);
-  } else if (arrayContent != null) {
-    // Extract individual paths from the array content.
-    final pathPattern = RegExp(r'''["']([^"']+)["']''');
-    for (final RegExpMatch pathMatch in pathPattern.allMatches(arrayContent)) {
-      final String? path = pathMatch.group(1);
-      if (path != null && path.isNotEmpty) {
-        results.add(path);
+    final isa = objectValue['isa'] as String?;
+    if (isa != 'PBXGroup') {
+      continue;
+    }
+
+    final name = objectValue['name'] as String?;
+    if (name != 'Frameworks') {
+      continue;
+    }
+
+    final children = objectValue['children'] as List<Object?>?;
+    if (children == null) {
+      continue;
+    }
+
+    for (final Object? child in children) {
+      if (child is String) {
+        fileReferenceIds.add(child);
       }
+    }
+  }
+
+  // Look up the file paths for each file reference
+  for (final refId in fileReferenceIds) {
+    final fileRef = objects[refId] as Map<String, Object?>?;
+    if (fileRef == null) {
+      continue;
+    }
+
+    final isa = fileRef['isa'] as String?;
+    if (isa != 'PBXFileReference') {
+      continue;
+    }
+
+    final path = fileRef['path'] as String?;
+    if (path == null) {
+      continue;
+    }
+
+    // Only include .framework and .xcframework files
+    if (path.endsWith('.framework') || path.endsWith('.xcframework')) {
+      results.add(path);
     }
   }
 
@@ -880,8 +930,12 @@ end
         }
       }
 
-      // Copy vendored frameworks from plugin podspecs.
-      await copyVendoredFrameworks(modeDirectory, 'ios');
+      // Copy vendored frameworks from CocoaPods plugins.
+      await copyVendoredFrameworks(
+        modeDirectory,
+        project.ios.hostAppRoot,
+        globals.plistParser,
+      );
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -317,16 +317,17 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
 
     for (final frameworkPath in frameworkPaths) {
       // Skip Flutter's own frameworks
-      if (frameworkPath.contains('Flutter.framework') ||
-          frameworkPath.contains('Flutter.xcframework') ||
-          frameworkPath.contains('App.framework') ||
-          frameworkPath.contains('App.xcframework')) {
+      if (frameworkPath.contains('/Flutter.framework') ||
+          frameworkPath.contains('/Flutter.xcframework') ||
+          frameworkPath.contains('/App.framework') ||
+          frameworkPath.contains('/App.xcframework')) {
         continue;
       }
 
-      // Framework path is relative to the Pods directory
+      // Framework paths from CocoaPods virtual groups (e.g. "Development Pods/[plugin]/Frameworks")
+      // may have a "../../../" prefix. Strip it so the path resolves correctly relative to Pods.
       final String absolutePath = globals.fs.path.normalize(
-        globals.fs.path.join(podsRoot.path, frameworkPath),
+        globals.fs.path.join(podsRoot.path, frameworkPath.replaceFirst('../../../', '')),
       );
       final Directory frameworkEntity = globals.fs.directory(absolutePath);
 
@@ -352,16 +353,10 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
           copyDirectory(frameworkEntity, destination);
         }
       } else if (frameworkName.endsWith('.framework')) {
-        // Create an xcframework from the single framework
-        final Directory xcframeworkOutput = modeDirectory.childDirectory('$binaryName.xcframework');
-        if (!xcframeworkOutput.existsSync()) {
-          globals.logger.printTrace('Creating xcframework from vendored framework: $frameworkName');
-          await BuildFrameworkCommand.produceXCFramework(
-            <Directory>[frameworkEntity],
-            binaryName,
-            modeDirectory,
-            globals.processManager,
-          );
+        final Directory destination = modeDirectory.childDirectory(frameworkName);
+        if (!destination.existsSync()) {
+          globals.logger.printTrace('Copying vendored framework: $frameworkName');
+          copyDirectory(frameworkEntity, destination);
         }
       }
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -316,11 +316,13 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     final Directory podsRoot = hostAppRoot.childDirectory('Pods');
 
     for (final frameworkPath in frameworkPaths) {
-      // Skip Flutter's own frameworks
-      if (frameworkPath.contains('/Flutter.framework') ||
-          frameworkPath.contains('/Flutter.xcframework') ||
-          frameworkPath.contains('/App.framework') ||
-          frameworkPath.contains('/App.xcframework')) {
+      final String frameworkName = globals.fs.path.basename(frameworkPath);
+
+      // Skip Flutter's own frameworks.
+      if (frameworkName == 'Flutter.framework' ||
+          frameworkName == 'Flutter.xcframework' ||
+          frameworkName == 'App.framework' ||
+          frameworkName == 'App.xcframework') {
         continue;
       }
 
@@ -336,7 +338,6 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
         continue;
       }
 
-      final String frameworkName = globals.fs.path.basename(frameworkPath);
       final String binaryName = globals.fs.path.basenameWithoutExtension(frameworkName);
 
       // Skip if we've already processed this framework name
@@ -345,20 +346,20 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
       }
       processedFrameworks.add(binaryName);
 
-      // Check if it's already an xcframework
-      if (frameworkName.endsWith('.xcframework')) {
-        final Directory destination = modeDirectory.childDirectory(frameworkName);
-        if (!destination.existsSync()) {
-          globals.logger.printTrace('Copying vendored xcframework: $frameworkName');
-          copyDirectory(frameworkEntity, destination);
-        }
-      } else if (frameworkName.endsWith('.framework')) {
-        final Directory destination = modeDirectory.childDirectory(frameworkName);
-        if (!destination.existsSync()) {
-          globals.logger.printTrace('Copying vendored framework: $frameworkName');
-          copyDirectory(frameworkEntity, destination);
-        }
+      final bool isXcframework = frameworkName.endsWith('.xcframework');
+      final bool isFramework = frameworkName.endsWith('.framework');
+      if (!isXcframework && !isFramework) {
+        continue;
       }
+
+      final Directory destination = modeDirectory.childDirectory(frameworkName);
+      if (destination.existsSync()) {
+        continue;
+      }
+
+      final kind = isXcframework ? 'xcframework' : 'framework';
+      globals.logger.printTrace('Copying vendored $kind: $frameworkName');
+      copyDirectory(frameworkEntity, destination);
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -361,8 +361,12 @@ end
         }
       }
 
-      // Copy vendored frameworks from plugin podspecs.
-      await copyVendoredFrameworks(modeDirectory, 'macos');
+      // Copy vendored frameworks from CocoaPods plugins.
+      await copyVendoredFrameworks(
+        modeDirectory,
+        project.macos.hostAppRoot,
+        globals.plistParser,
+      );
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -360,6 +360,9 @@ end
           );
         }
       }
+
+      // Copy vendored frameworks from plugin podspecs.
+      await copyVendoredFrameworks(modeDirectory, 'macos');
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -362,11 +362,7 @@ end
       }
 
       // Copy vendored frameworks from CocoaPods plugins.
-      await copyVendoredFrameworks(
-        modeDirectory,
-        project.macos.hostAppRoot,
-        globals.plistParser,
-      );
+      await copyVendoredFrameworks(modeDirectory, project.macos.hostAppRoot, globals.plistParser);
     } finally {
       status.stop();
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -1011,10 +1011,9 @@ void main() {
     });
 
     testWithoutContext('returns empty list when no Frameworks group exists', () {
-      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
-      fakePlistParser.setJsonContent(
-        projectFile.path,
-        '''
+      final File projectFile = fileSystem.file('/test/project.pbxproj')
+        ..createSync(recursive: true);
+      fakePlistParser.setJsonContent(projectFile.path, '''
 {
   "objects": {
     "ABC123": {
@@ -1024,8 +1023,7 @@ void main() {
     }
   }
 }
-''',
-      );
+''');
 
       final List<String> result = parseVendoredFrameworksFromPbxproj(
         projectFile,
@@ -1037,10 +1035,9 @@ void main() {
     });
 
     testWithoutContext('parses frameworks from Frameworks group', () {
-      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
-      fakePlistParser.setJsonContent(
-        projectFile.path,
-        '''
+      final File projectFile = fileSystem.file('/test/project.pbxproj')
+        ..createSync(recursive: true);
+      fakePlistParser.setJsonContent(projectFile.path, '''
 {
   "objects": {
     "GROUP1": {
@@ -1058,8 +1055,7 @@ void main() {
     }
   }
 }
-''',
-      );
+''');
 
       final List<String> result = parseVendoredFrameworksFromPbxproj(
         projectFile,
@@ -1071,10 +1067,9 @@ void main() {
     });
 
     testWithoutContext('skips non-framework files in Frameworks group', () {
-      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
-      fakePlistParser.setJsonContent(
-        projectFile.path,
-        '''
+      final File projectFile = fileSystem.file('/test/project.pbxproj')
+        ..createSync(recursive: true);
+      fakePlistParser.setJsonContent(projectFile.path, '''
 {
   "objects": {
     "GROUP1": {
@@ -1096,8 +1091,7 @@ void main() {
     }
   }
 }
-''',
-      );
+''');
 
       final List<String> result = parseVendoredFrameworksFromPbxproj(
         projectFile,
@@ -1109,10 +1103,9 @@ void main() {
     });
 
     testWithoutContext('handles multiple Frameworks groups', () {
-      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
-      fakePlistParser.setJsonContent(
-        projectFile.path,
-        '''
+      final File projectFile = fileSystem.file('/test/project.pbxproj')
+        ..createSync(recursive: true);
+      fakePlistParser.setJsonContent(projectFile.path, '''
 {
   "objects": {
     "GROUP1": {
@@ -1135,8 +1128,7 @@ void main() {
     }
   }
 }
-''',
-      );
+''');
 
       final List<String> result = parseVendoredFrameworksFromPbxproj(
         projectFile,
@@ -1148,7 +1140,8 @@ void main() {
     });
 
     testWithoutContext('handles invalid JSON gracefully', () {
-      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      final File projectFile = fileSystem.file('/test/project.pbxproj')
+        ..createSync(recursive: true);
       fakePlistParser.setJsonContent(projectFile.path, 'not valid json');
 
       final List<String> result = parseVendoredFrameworksFromPbxproj(
@@ -1160,16 +1153,540 @@ void main() {
       expect(result, isEmpty);
     });
   });
+
+  group('copyVendoredFrameworks', () {
+    late MemoryFileSystem fileSystem;
+    late FakeProcessManager fakeProcessManager;
+    late FakePlatform fakePlatform;
+    late BufferLogger logger;
+    late FakePlistParser fakePlistParser;
+    late Directory modeDirectory;
+    late Directory hostAppRoot;
+    late Cache cache;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      fakeProcessManager = FakeProcessManager.empty();
+      fakePlatform = FakePlatform(operatingSystem: 'macos');
+      logger = BufferLogger.test();
+      fakePlistParser = FakePlistParser();
+      cache = Cache.test(fileSystem: fileSystem, processManager: FakeProcessManager.any());
+
+      modeDirectory = fileSystem.directory('/output/Debug')..createSync(recursive: true);
+      hostAppRoot = fileSystem.directory('/project/ios')..createSync(recursive: true);
+    });
+
+    testUsingContext(
+      'does nothing when Pods.xcodeproj does not exist',
+      () async {
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should not create any frameworks in output
+        expect(modeDirectory.listSync(), isEmpty);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'does nothing when parseVendoredFrameworksFromPbxproj returns empty list',
+      () async {
+        // Create project.pbxproj but with no frameworks
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "ABC123": {
+      "isa": "PBXGroup",
+      "name": "Sources",
+      "children": []
+    }
+  }
+}
+''');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should not create any frameworks in output
+        expect(modeDirectory.listSync(), isEmpty);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'skips Flutter.framework, Flutter.xcframework, App.framework, App.xcframework',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1", "REF2", "REF3", "REF4"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "Flutter.framework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "Flutter.xcframework"
+    },
+    "REF3": {
+      "isa": "PBXFileReference",
+      "path": "App.framework"
+    },
+    "REF4": {
+      "isa": "PBXFileReference",
+      "path": "App.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the framework directories in Pods (though they should be skipped)
+        final Directory podsDir = hostAppRoot.childDirectory('Pods');
+        podsDir.childDirectory('Flutter.framework').createSync(recursive: true);
+        podsDir.childDirectory('Flutter.xcframework').createSync(recursive: true);
+        podsDir.childDirectory('App.framework').createSync(recursive: true);
+        podsDir.childDirectory('App.xcframework').createSync(recursive: true);
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should not copy any of the Flutter/App frameworks
+        expect(modeDirectory.listSync(), isEmpty);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'copies xcframework directly to output',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "MySDK.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the xcframework with some content
+        final Directory xcframework =
+            hostAppRoot.childDirectory('Pods').childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework.childFile('Info.plist').writeAsStringSync('plist content');
+        xcframework.childDirectory('ios-arm64').createSync();
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should copy the xcframework
+        expect(modeDirectory.childDirectory('MySDK.xcframework').existsSync(), isTrue);
+        expect(
+          modeDirectory.childDirectory('MySDK.xcframework').childFile('Info.plist').existsSync(),
+          isTrue,
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'creates xcframework from .framework using xcodebuild',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "MySDK.framework"
+    }
+  }
+}
+''');
+
+        // Create the framework
+        final Directory framework =
+            hostAppRoot.childDirectory('Pods').childDirectory('MySDK.framework')
+              ..createSync(recursive: true);
+        framework.childFile('MySDK').writeAsStringSync('binary');
+
+        fakeProcessManager.addCommand(
+          FakeCommand(
+            command: <String>[
+              'xcrun',
+              'xcodebuild',
+              '-create-xcframework',
+              '-framework',
+              framework.path,
+              '-output',
+              modeDirectory.childDirectory('MySDK.xcframework').path,
+            ],
+          ),
+        );
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'skips framework that does not exist on disk',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "NonExistent.xcframework"
+    }
+  }
+}
+''');
+
+        // Don't create the framework - it should be skipped
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should not create anything in output
+        expect(modeDirectory.listSync(), isEmpty);
+        // Should log trace message
+        expect(logger.traceText, contains('Vendored framework not found'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'skips duplicate frameworks with same binary name',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1", "REF2"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "path1/MySDK.xcframework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "path2/MySDK.xcframework"
+    }
+  }
+}
+''');
+
+        // Create both xcframeworks
+        final Directory podsDir = hostAppRoot.childDirectory('Pods');
+        final Directory xcframework1 =
+            podsDir.childDirectory('path1').childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework1.childFile('Info.plist').writeAsStringSync('plist1');
+
+        final Directory xcframework2 =
+            podsDir.childDirectory('path2').childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework2.childFile('Info.plist').writeAsStringSync('plist2');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should only copy once
+        expect(modeDirectory.childDirectory('MySDK.xcframework').existsSync(), isTrue);
+        // Content should be from first one
+        expect(
+          modeDirectory
+              .childDirectory('MySDK.xcframework')
+              .childFile('Info.plist')
+              .readAsStringSync(),
+          'plist1',
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'does not re-copy xcframework if already exists in output',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "MySDK.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the source xcframework
+        final Directory xcframework =
+            hostAppRoot.childDirectory('Pods').childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework.childFile('Info.plist').writeAsStringSync('source plist');
+
+        // Create existing xcframework in output with different content
+        final Directory existingXcframework = modeDirectory.childDirectory('MySDK.xcframework')
+          ..createSync(recursive: true);
+        existingXcframework.childFile('Info.plist').writeAsStringSync('existing plist');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should not overwrite existing
+        expect(
+          modeDirectory
+              .childDirectory('MySDK.xcframework')
+              .childFile('Info.plist')
+              .readAsStringSync(),
+          'existing plist',
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'handles nested framework paths',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "SomePlugin/Frameworks/Vendored/MySDK.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the nested xcframework
+        final Directory podsDir = hostAppRoot.childDirectory('Pods');
+        final Directory xcframework =
+            podsDir
+                .childDirectory('SomePlugin')
+                .childDirectory('Frameworks')
+                .childDirectory('Vendored')
+                .childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework.childFile('Info.plist').writeAsStringSync('nested plist');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Should copy the xcframework to output
+        expect(modeDirectory.childDirectory('MySDK.xcframework').existsSync(), isTrue);
+        expect(
+          modeDirectory
+              .childDirectory('MySDK.xcframework')
+              .childFile('Info.plist')
+              .readAsStringSync(),
+          'nested plist',
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+  });
 }
 
 /// A fake PlistParser for testing that returns pre-configured JSON content.
 class FakePlistParser extends PlistParser {
   FakePlistParser()
-      : super(
-          fileSystem: MemoryFileSystem.test(),
-          logger: BufferLogger.test(),
-          processManager: FakeProcessManager.any(),
-        );
+    : super(
+        fileSystem: MemoryFileSystem.test(),
+        logger: BufferLogger.test(),
+        processManager: FakeProcessManager.any(),
+      );
 
   final Map<String, String?> _jsonContentByPath = <String, String?>{};
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -984,4 +984,92 @@ void main() {
       });
     });
   });
+
+  group('parseVendoredFrameworks', () {
+    testWithoutContext('returns empty list when no vendored_frameworks', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.name = 'test'
+  s.version = '1.0.0'
+end
+''';
+      expect(parseVendoredFrameworks(podspec), isEmpty);
+    });
+
+    testWithoutContext('parses single string value with single quotes', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.name = 'test'
+  s.vendored_frameworks = 'Frameworks/SomeSDK.framework'
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['Frameworks/SomeSDK.framework']);
+    });
+
+    testWithoutContext('parses single string value with double quotes', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.name = "test"
+  s.vendored_frameworks = "Frameworks/SomeSDK.framework"
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['Frameworks/SomeSDK.framework']);
+    });
+
+    testWithoutContext('parses array value', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.name = 'test'
+  s.vendored_frameworks = ['First.framework', 'Second.framework']
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['First.framework', 'Second.framework']);
+    });
+
+    testWithoutContext('parses array with mixed quotes', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.vendored_frameworks = ['First.framework', "Second.framework"]
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['First.framework', 'Second.framework']);
+    });
+
+    testWithoutContext('parses with spec variable name', () {
+      const podspec = '''
+Pod::Spec.new do |spec|
+  spec.vendored_frameworks = 'SDK.framework'
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['SDK.framework']);
+    });
+
+    testWithoutContext('handles paths with subdirectories', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.vendored_frameworks = 'FairDynamicFlutter/Products/FairDynamicFlutter.framework'
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['FairDynamicFlutter/Products/FairDynamicFlutter.framework']);
+    });
+
+    testWithoutContext('handles xcframework extension', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.vendored_frameworks = 'SDK.xcframework'
+end
+''';
+      expect(parseVendoredFrameworks(podspec), ['SDK.xcframework']);
+    });
+
+    testWithoutContext('parses placeholder path', () {
+      const podspec = '''
+Pod::Spec.new do |s|
+  s.vendored_frameworks = 'path/to/nothing'
+end
+''';
+      // The function returns all paths; filtering of 'path/to/nothing' is done in _copyVendoredFrameworks
+      expect(parseVendoredFrameworks(podspec), ['path/to/nothing']);
+    });
+  });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -1282,10 +1282,26 @@ void main() {
 
         // Create the framework directories in Pods (though they should be skipped)
         final Directory podsDir = hostAppRoot.childDirectory('Pods');
-        podsDir.childDirectory('some').childDirectory('path').childDirectory('Flutter.framework').createSync(recursive: true);
-        podsDir.childDirectory('some').childDirectory('path').childDirectory('Flutter.xcframework').createSync(recursive: true);
-        podsDir.childDirectory('some').childDirectory('path').childDirectory('App.framework').createSync(recursive: true);
-        podsDir.childDirectory('some').childDirectory('path').childDirectory('App.xcframework').createSync(recursive: true);
+        podsDir
+            .childDirectory('some')
+            .childDirectory('path')
+            .childDirectory('Flutter.framework')
+            .createSync(recursive: true);
+        podsDir
+            .childDirectory('some')
+            .childDirectory('path')
+            .childDirectory('Flutter.xcframework')
+            .createSync(recursive: true);
+        podsDir
+            .childDirectory('some')
+            .childDirectory('path')
+            .childDirectory('App.framework')
+            .createSync(recursive: true);
+        podsDir
+            .childDirectory('some')
+            .childDirectory('path')
+            .childDirectory('App.xcframework')
+            .createSync(recursive: true);
 
         final command = BuildIOSFrameworkCommand(
           logger: logger,
@@ -1635,14 +1651,12 @@ void main() {
 
         // Create the frameworks
         final Directory podsDir = hostAppRoot.childDirectory('Pods');
-        final Directory fairFramework =
-            podsDir.childDirectory('FairDynamicFlutter.framework')
-              ..createSync(recursive: true);
+        final Directory fairFramework = podsDir.childDirectory('FairDynamicFlutter.framework')
+          ..createSync(recursive: true);
         fairFramework.childFile('FairDynamicFlutter').writeAsStringSync('binary');
 
-        final Directory appAuthFramework =
-            podsDir.childDirectory('AppAuth.xcframework')
-              ..createSync(recursive: true);
+        final Directory appAuthFramework = podsDir.childDirectory('AppAuth.xcframework')
+          ..createSync(recursive: true);
         appAuthFramework.childFile('Info.plist').writeAsStringSync('plist');
 
         final command = BuildIOSFrameworkCommand(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_ios_framework.dart';
 import 'package:flutter_tools/src/commands/build_macos_framework.dart';
+import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/version.dart';
 
 import '../../src/common.dart';
@@ -985,91 +986,199 @@ void main() {
     });
   });
 
-  group('parseVendoredFrameworks', () {
-    testWithoutContext('returns empty list when no vendored_frameworks', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.name = 'test'
-  s.version = '1.0.0'
-end
-''';
-      expect(parseVendoredFrameworks(podspec), isEmpty);
+  group('parseVendoredFrameworksFromPbxproj', () {
+    late MemoryFileSystem fileSystem;
+    late BufferLogger logger;
+    late FakePlistParser fakePlistParser;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      logger = BufferLogger.test();
+      fakePlistParser = FakePlistParser();
     });
 
-    testWithoutContext('parses single string value with single quotes', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.name = 'test'
-  s.vendored_frameworks = 'Frameworks/SomeSDK.framework'
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['Frameworks/SomeSDK.framework']);
+    testWithoutContext('returns empty list when project file does not exist', () {
+      final File projectFile = fileSystem.file('/nonexistent/project.pbxproj');
+      fakePlistParser.setJsonContent(projectFile.path, null);
+
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
+
+      expect(result, isEmpty);
     });
 
-    testWithoutContext('parses single string value with double quotes', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.name = "test"
-  s.vendored_frameworks = "Frameworks/SomeSDK.framework"
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['Frameworks/SomeSDK.framework']);
+    testWithoutContext('returns empty list when no Frameworks group exists', () {
+      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      fakePlistParser.setJsonContent(
+        projectFile.path,
+        '''
+{
+  "objects": {
+    "ABC123": {
+      "isa": "PBXGroup",
+      "name": "Sources",
+      "children": ["DEF456"]
+    }
+  }
+}
+''',
+      );
+
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
+
+      expect(result, isEmpty);
     });
 
-    testWithoutContext('parses array value', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.name = 'test'
-  s.vendored_frameworks = ['First.framework', 'Second.framework']
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['First.framework', 'Second.framework']);
+    testWithoutContext('parses frameworks from Frameworks group', () {
+      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      fakePlistParser.setJsonContent(
+        projectFile.path,
+        '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1", "REF2"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "MySDK.xcframework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "AnotherSDK.framework"
+    }
+  }
+}
+''',
+      );
+
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
+
+      expect(result, containsAll(<String>['MySDK.xcframework', 'AnotherSDK.framework']));
     });
 
-    testWithoutContext('parses array with mixed quotes', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.vendored_frameworks = ['First.framework', "Second.framework"]
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['First.framework', 'Second.framework']);
+    testWithoutContext('skips non-framework files in Frameworks group', () {
+      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      fakePlistParser.setJsonContent(
+        projectFile.path,
+        '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1", "REF2", "REF3"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "MySDK.xcframework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "libsomething.a"
+    },
+    "REF3": {
+      "isa": "PBXFileReference",
+      "path": "something.dylib"
+    }
+  }
+}
+''',
+      );
+
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
+
+      expect(result, <String>['MySDK.xcframework']);
     });
 
-    testWithoutContext('parses with spec variable name', () {
-      const podspec = '''
-Pod::Spec.new do |spec|
-  spec.vendored_frameworks = 'SDK.framework'
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['SDK.framework']);
+    testWithoutContext('handles multiple Frameworks groups', () {
+      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      fakePlistParser.setJsonContent(
+        projectFile.path,
+        '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "GROUP2": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF2"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "SDK1.xcframework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "SDK2.xcframework"
+    }
+  }
+}
+''',
+      );
+
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
+
+      expect(result, containsAll(<String>['SDK1.xcframework', 'SDK2.xcframework']));
     });
 
-    testWithoutContext('handles paths with subdirectories', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.vendored_frameworks = 'FairDynamicFlutter/Products/FairDynamicFlutter.framework'
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['FairDynamicFlutter/Products/FairDynamicFlutter.framework']);
-    });
+    testWithoutContext('handles invalid JSON gracefully', () {
+      final File projectFile = fileSystem.file('/test/project.pbxproj')..createSync(recursive: true);
+      fakePlistParser.setJsonContent(projectFile.path, 'not valid json');
 
-    testWithoutContext('handles xcframework extension', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.vendored_frameworks = 'SDK.xcframework'
-end
-''';
-      expect(parseVendoredFrameworks(podspec), ['SDK.xcframework']);
-    });
+      final List<String> result = parseVendoredFrameworksFromPbxproj(
+        projectFile,
+        fakePlistParser,
+        logger,
+      );
 
-    testWithoutContext('parses placeholder path', () {
-      const podspec = '''
-Pod::Spec.new do |s|
-  s.vendored_frameworks = 'path/to/nothing'
-end
-''';
-      // The function returns all paths; filtering of 'path/to/nothing' is done in _copyVendoredFrameworks
-      expect(parseVendoredFrameworks(podspec), ['path/to/nothing']);
+      expect(result, isEmpty);
     });
   });
+}
+
+/// A fake PlistParser for testing that returns pre-configured JSON content.
+class FakePlistParser extends PlistParser {
+  FakePlistParser()
+      : super(
+          fileSystem: MemoryFileSystem.test(),
+          logger: BufferLogger.test(),
+          processManager: FakeProcessManager.any(),
+        );
+
+  final Map<String, String?> _jsonContentByPath = <String, String?>{};
+
+  void setJsonContent(String path, String? content) {
+    _jsonContentByPath[path] = content;
+  }
+
+  @override
+  String? plistJsonContent(String filePath) {
+    return _jsonContentByPath[filePath];
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -1262,19 +1262,19 @@ void main() {
     },
     "REF1": {
       "isa": "PBXFileReference",
-      "path": "Flutter.framework"
+      "path": "some/path/Flutter.framework"
     },
     "REF2": {
       "isa": "PBXFileReference",
-      "path": "Flutter.xcframework"
+      "path": "some/path/Flutter.xcframework"
     },
     "REF3": {
       "isa": "PBXFileReference",
-      "path": "App.framework"
+      "path": "some/path/App.framework"
     },
     "REF4": {
       "isa": "PBXFileReference",
-      "path": "App.xcframework"
+      "path": "some/path/App.xcframework"
     }
   }
 }
@@ -1282,10 +1282,10 @@ void main() {
 
         // Create the framework directories in Pods (though they should be skipped)
         final Directory podsDir = hostAppRoot.childDirectory('Pods');
-        podsDir.childDirectory('Flutter.framework').createSync(recursive: true);
-        podsDir.childDirectory('Flutter.xcframework').createSync(recursive: true);
-        podsDir.childDirectory('App.framework').createSync(recursive: true);
-        podsDir.childDirectory('App.xcframework').createSync(recursive: true);
+        podsDir.childDirectory('some').childDirectory('path').childDirectory('Flutter.framework').createSync(recursive: true);
+        podsDir.childDirectory('some').childDirectory('path').childDirectory('Flutter.xcframework').createSync(recursive: true);
+        podsDir.childDirectory('some').childDirectory('path').childDirectory('App.framework').createSync(recursive: true);
+        podsDir.childDirectory('some').childDirectory('path').childDirectory('App.xcframework').createSync(recursive: true);
 
         final command = BuildIOSFrameworkCommand(
           logger: logger,
@@ -1366,7 +1366,7 @@ void main() {
     );
 
     testUsingContext(
-      'creates xcframework from .framework using xcodebuild',
+      'copies .framework directly to output',
       () async {
         final File projectFile =
             hostAppRoot
@@ -1396,20 +1396,6 @@ void main() {
               ..createSync(recursive: true);
         framework.childFile('MySDK').writeAsStringSync('binary');
 
-        fakeProcessManager.addCommand(
-          FakeCommand(
-            command: <String>[
-              'xcrun',
-              'xcodebuild',
-              '-create-xcframework',
-              '-framework',
-              framework.path,
-              '-output',
-              modeDirectory.childDirectory('MySDK.xcframework').path,
-            ],
-          ),
-        );
-
         final command = BuildIOSFrameworkCommand(
           logger: logger,
           buildSystem: TestBuildSystem.all(BuildResult(success: true)),
@@ -1421,7 +1407,12 @@ void main() {
 
         await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
 
-        expect(fakeProcessManager, hasNoRemainingExpectations);
+        // Should copy the framework directly (not create xcframework)
+        expect(modeDirectory.childDirectory('MySDK.framework').existsSync(), isTrue);
+        expect(
+          modeDirectory.childDirectory('MySDK.framework').childFile('MySDK').readAsStringSync(),
+          'binary',
+        );
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
@@ -1604,6 +1595,131 @@ void main() {
               .childFile('Info.plist')
               .readAsStringSync(),
           'existing plist',
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'does not skip frameworks whose names contain Flutter or App as a substring',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1", "REF2"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "FairDynamicFlutter.framework"
+    },
+    "REF2": {
+      "isa": "PBXFileReference",
+      "path": "AppAuth.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the frameworks
+        final Directory podsDir = hostAppRoot.childDirectory('Pods');
+        final Directory fairFramework =
+            podsDir.childDirectory('FairDynamicFlutter.framework')
+              ..createSync(recursive: true);
+        fairFramework.childFile('FairDynamicFlutter').writeAsStringSync('binary');
+
+        final Directory appAuthFramework =
+            podsDir.childDirectory('AppAuth.xcframework')
+              ..createSync(recursive: true);
+        appAuthFramework.childFile('Info.plist').writeAsStringSync('plist');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        // Both should be copied, not skipped
+        expect(modeDirectory.childDirectory('FairDynamicFlutter.framework').existsSync(), isTrue);
+        expect(modeDirectory.childDirectory('AppAuth.xcframework').existsSync(), isTrue);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => fakeProcessManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'resolves paths with ../../../ prefix from CocoaPods virtual groups',
+      () async {
+        final File projectFile =
+            hostAppRoot
+                .childDirectory('Pods')
+                .childDirectory('Pods.xcodeproj')
+                .childFile('project.pbxproj')
+              ..createSync(recursive: true);
+        fakePlistParser.setJsonContent(projectFile.path, '''
+{
+  "objects": {
+    "GROUP1": {
+      "isa": "PBXGroup",
+      "name": "Frameworks",
+      "children": ["REF1"]
+    },
+    "REF1": {
+      "isa": "PBXFileReference",
+      "path": "../../../SomePlugin/Frameworks/MySDK.xcframework"
+    }
+  }
+}
+''');
+
+        // Create the framework at the resolved path (Pods/SomePlugin/Frameworks/MySDK.xcframework)
+        final Directory podsDir = hostAppRoot.childDirectory('Pods');
+        final Directory xcframework =
+            podsDir
+                .childDirectory('SomePlugin')
+                .childDirectory('Frameworks')
+                .childDirectory('MySDK.xcframework')
+              ..createSync(recursive: true);
+        xcframework.childFile('Info.plist').writeAsStringSync('resolved plist');
+
+        final command = BuildIOSFrameworkCommand(
+          logger: logger,
+          buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+          platform: fakePlatform,
+          flutterVersion: FakeFlutterVersion(),
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        await command.copyVendoredFrameworks(modeDirectory, hostAppRoot, fakePlistParser);
+
+        expect(modeDirectory.childDirectory('MySDK.xcframework').existsSync(), isTrue);
+        expect(
+          modeDirectory
+              .childDirectory('MySDK.xcframework')
+              .childFile('Info.plist')
+              .readAsStringSync(),
+          'resolved plist',
         );
       },
       overrides: <Type, Generator>{


### PR DESCRIPTION
Fixes #125530

When running `flutter build ios-framework` or `flutter build macos-framework`, vendored frameworks declared in plugin podspecs (via `s.vendored_frameworks`) were not being copied to the output directory.

This PR adds support for parsing plugin podspecs to find vendored_frameworks entries and copying them to the output directory. Single .framework files are wrapped into xcframeworks to match the output format.

Changes:
- Added `copyVendoredFrameworks` method to `BuildFrameworkCommand` base class
- Added `parseVendoredFrameworks` function to parse podspec Ruby files
- Called from both iOS and macOS framework build commands
- Added unit tests for the podspec parser

I'm happy to adjust the approach if there's a better way to handle this - particularly around the regex-based podspec parsing. Let me know if this looks reasonable or if you'd prefer a different strategy.