### PR TITLE
Fix --no-hot flag not working on web-server

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -172,6 +172,8 @@ class ResidentWebRunner extends ResidentRunner {
 
   @override
   bool get reloadIsRestart =>
+      // When --no-hot is passed, hotMode is false, so reload should behave as restart.
+      !hotMode ||
       debuggingOptions.webUseWasm ||
       // Web behavior when not using the DDC library bundle format is to restart
       // when a reload is issued. We can't use `canHotReload` to signal this


### PR DESCRIPTION
Check hotMode in reloadIsRestart so that when --no-hot is passed, reload behaves as restart instead of hot reload.

Fixes #179448