### PR TITLE
Make sure that a CheckedModeBanner doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -339,4 +339,16 @@ void main() {
     expect(painter.shadow.blurRadius, 8.0);
     debugDisableShadows = true;
   });
+
+  testWidgets('CheckedModeBanner does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(child: CheckedModeBanner(child: Text('X'))),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(CheckedModeBanner)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the CheckedModeBanner widget.