### PR TITLE
Fix the issue on macOS where, after a hot restart with multiple windows, unresponsive windows are left behind.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -153,14 +153,6 @@ constexpr char kTextPlainFormat[] = "text/plain";
 - (void)engineCallbackOnPlatformMessage:(const FlutterPlatformMessage*)message;
 
 /**
- * Invoked right before the engine is restarted.
- *
- * This should reset states to as if the application has just started.  It
- * usually indicates a hot restart (Shift-R in Flutter CLI.)
- */
-- (void)engineCallbackOnPreEngineRestart;
-
-/**
  * Requests that the task be posted back the to the Flutter engine at the target time. The target
  * time is in the clock used by the Flutter engine.
  */

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -1289,6 +1289,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   while ((nextViewController = [viewControllerEnumerator nextObject])) {
     [nextViewController onPreEngineRestart];
   }
+  [_windowController closeAllWindows];
   [_platformViewController reset];
   _keyboardManager = [[FlutterKeyboardManager alloc] initWithDelegate:self];
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -268,6 +268,13 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  */
 + (nullable FlutterEngine*)engineForIdentifier:(int64_t)identifier;
 
+/**
+ * Invoked right before the engine is restarted.
+ *
+ * This should reset states to as if the application has just started.  It
+ * usually indicates a hot restart (Shift-R in Flutter CLI.)
+ */
+- (void)engineCallbackOnPreEngineRestart;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
@@ -16,10 +16,6 @@
 
 @property(nonatomic, weak) FlutterEngine* engine;
 
-@end
-
-@interface FlutterWindowController (Testing)
-
 - (void)closeAllWindows;
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -201,4 +201,43 @@ TEST_F(FlutterWindowControllerTest, WindowStates) {
   CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);
   EXPECT_EQ(window.miniaturized, YES);
 }
+
+TEST_F(FlutterWindowControllerTest, CloseAllWindows) {
+  FlutterWindowCreationRequest request{
+      .has_size = true,
+      .size = {.width = 800, .height = 600},
+      .on_should_close = [] {},
+      .on_will_close = [] {},
+      .notify_listeners = [] {},
+  };
+
+  FlutterEngine* engine = GetFlutterEngine();
+  int64_t engine_id = reinterpret_cast<int64_t>(engine);
+
+  IsolateScope isolate_scope(isolate());
+
+  // Create multiple windows
+  int64_t handle1 = InternalFlutter_WindowController_CreateRegularWindow(engine_id, &request);
+  int64_t handle2 = InternalFlutter_WindowController_CreateRegularWindow(engine_id, &request);
+  int64_t handle3 = InternalFlutter_WindowController_CreateRegularWindow(engine_id, &request);
+
+  // Verify windows are created
+  FlutterViewController* viewController1 = [engine viewControllerForIdentifier:handle1];
+  FlutterViewController* viewController2 = [engine viewControllerForIdentifier:handle2];
+  FlutterViewController* viewController3 = [engine viewControllerForIdentifier:handle3];
+  EXPECT_NE(viewController1, nil);
+  EXPECT_NE(viewController2, nil);
+  EXPECT_NE(viewController3, nil);
+
+  // Close all windows
+  [engine.windowController closeAllWindows];
+
+  // Verify all windows are closed and view controllers are disposed
+  viewController1 = [engine viewControllerForIdentifier:handle1];
+  viewController2 = [engine viewControllerForIdentifier:handle2];
+  viewController3 = [engine viewControllerForIdentifier:handle3];
+  EXPECT_EQ(viewController1, nil);
+  EXPECT_EQ(viewController2, nil);
+  EXPECT_EQ(viewController3, nil);
+}
 }  // namespace flutter::testing

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -202,7 +202,7 @@ TEST_F(FlutterWindowControllerTest, WindowStates) {
   EXPECT_EQ(window.miniaturized, YES);
 }
 
-TEST_F(FlutterWindowControllerTest, CloseAllWindows) {
+TEST_F(FlutterWindowControllerTest, ClosesAllWindowsOnEngineRestart) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},
@@ -229,8 +229,8 @@ TEST_F(FlutterWindowControllerTest, CloseAllWindows) {
   EXPECT_NE(viewController2, nil);
   EXPECT_NE(viewController3, nil);
 
-  // Close all windows
-  [engine.windowController closeAllWindows];
+  // Close all windows on engine restart
+  [engine engineCallbackOnPreEngineRestart];
 
   // Verify all windows are closed and view controllers are disposed
   viewController1 = [engine viewControllerForIdentifier:handle1];


### PR DESCRIPTION
There is currently an issue with multiple windows on macOS: after a hot restart, new windows are created, but the original windows are not closed. You can reproduce this by running examples/multiple_windows and then performing a hot restart.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
