### PR TITLE
Fix misleading error message for color/decoration conflict

### DIFF
--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -149,14 +149,14 @@ class CupertinoSearchTextField extends StatefulWidget {
   }) : assert(
          !((decoration != null) && (backgroundColor != null)),
          'Cannot provide both a background color and a decoration\n'
-         'To provide both, use "decoration: BoxDecoration(color: '
-         'backgroundColor)"',
+         'The backgroundColor argument is just a shorthand for '
+         '"decoration: BoxDecoration(color: backgroundColor)".',
        ),
        assert(
          !((decoration != null) && (borderRadius != null)),
          'Cannot provide both a border radius and a decoration\n'
-         'To provide both, use "decoration: BoxDecoration(borderRadius: '
-         'borderRadius)"',
+         'The borderRadius argument is just a shorthand for '
+         '"decoration: BoxDecoration(borderRadius: borderRadius)".',
        );
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -150,13 +150,15 @@ class CupertinoSearchTextField extends StatefulWidget {
          !((decoration != null) && (backgroundColor != null)),
          'Cannot provide both a background color and a decoration\n'
          'The backgroundColor argument is just a shorthand for '
-         '"decoration: BoxDecoration(color: backgroundColor)".',
+         '"decoration: BoxDecoration(color: backgroundColor)".\n'
+         'To use both a backgroundColor and other decoration properties, set the color in the BoxDecoration instead.',',
        ),
        assert(
          !((decoration != null) && (borderRadius != null)),
          'Cannot provide both a border radius and a decoration\n'
          'The borderRadius argument is just a shorthand for '
-         '"decoration: BoxDecoration(borderRadius: borderRadius)".',
+         '"decoration: BoxDecoration(borderRadius: borderRadius)".\n'
+         'To use both a radius and other decoration properties, set the radius in the BoxDecoration instead.',
        );
 
   /// Controls the text being edited.


### PR DESCRIPTION
## Description

Fixes the contradictory error message that says "Cannot provide both... To provide both".

Updated wording to match `Ink` and `AnimatedContainer` widgets which use clearer phrasing.

## Related Issue

Fixes #119484