### PR TITLE
Fix Drawer.child docstring to say ListView instead of SliverList

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -221,7 +221,7 @@ class Drawer extends StatelessWidget {
 
   /// The widget below this widget in the tree.
   ///
-  /// Typically a [SliverList].
+  /// Typically a [ListView].
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;


### PR DESCRIPTION
## Description

The docstring says "Typically a [SliverList]" but the class example uses `ListView`. 

`SliverList` is used inside `CustomScrollView`, not as a direct child of `Drawer`.

## Related Issue

Fixes #100268