### PR TITLE
Make sure that a DecoratedBox doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -779,6 +779,18 @@ void main() {
       matchesGoldenFile('container.clipBehaviour.with.shadow.png'),
     );
   });
+
+  testWidgets('DecoratedBox does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(child: DecoratedBox(decoration: BoxDecoration())),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DecoratedBox)), Size.zero);
+  });
 }
 
 class _MockPaintingContext extends Fake implements PaintingContext {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DecoratedBox widget.