### PR TITLE
Modify the SemanticTab class to create <a> element when the node has …

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/tabs.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/tabs.dart
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import '../dom.dart';
 import 'label_and_value.dart';
 import 'semantics.dart';
 
@@ -20,6 +20,33 @@ class SemanticTab extends SemanticRole {
       ) {
     setAriaRole('tab');
     addTappable();
+  }
+
+  @override
+  DomElement createElement() {
+    // When the tab has a link URL, render as an <a> element to enable
+    // proper link functionality (right-click copy, SEO indexing) while
+    // still using role="tab" for accessibility.
+    if (semanticsObject.hasLinkUrl) {
+      final DomElement element = domDocument.createElement('a');
+      element.style.display = 'block';
+      return element;
+    }
+    return super.createElement();
+  }
+
+  @override
+  void update() {
+    super.update();
+
+    // Update the href attribute when the link URL changes.
+    if (semanticsObject.isLinkUrlDirty) {
+      if (semanticsObject.hasLinkUrl) {
+        element.setAttribute('href', semanticsObject.linkUrl!);
+      } else {
+        element.removeAttribute('href');
+      }
+    }
   }
 
   @override

--- a/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -605,6 +605,91 @@ void _testEngineSemanticsOwner() {
     owner().updateSemantics(builder.build());
   }
 
+    test('tab with linkUrl renders as anchor element with href', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    const url = 'https://flutter.dev';
+    final tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      role: ui.SemanticsRole.tab,
+      linkUrl: url,
+      label: 'tab link label',
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    final SemanticsObject object = tester.getSemanticsObject(0);
+    expect(object.semanticRole?.kind, EngineSemanticsRole.tab);
+    expect(object.element.tagName.toLowerCase(), 'a');
+    expect(object.element.getAttribute('role'), 'tab');
+    expect(object.element.getAttribute('href'), url);
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('tab without linkUrl renders as default element', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      role: ui.SemanticsRole.tab,
+      label: 'regular tab',
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    final SemanticsObject object = tester.getSemanticsObject(0);
+    expect(object.semanticRole?.kind, EngineSemanticsRole.tab);
+    expect(object.element.tagName.toLowerCase(), isNot('a'));
+    expect(object.element.getAttribute('role'), 'tab');
+    expect(object.element.hasAttribute('href'), isFalse);
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('tab linkUrl can be updated dynamically', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    const url1 = 'https://flutter.dev';
+    const url2 = 'https://dart.dev';
+    final tester = SemanticsTester(owner());
+
+    // Initial state with linkUrl
+    tester.updateNode(
+      id: 0,
+      role: ui.SemanticsRole.tab,
+      linkUrl: url1,
+      label: 'tab link',
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    final SemanticsObject object = tester.getSemanticsObject(0);
+    expect(object.element.getAttribute('href'), url1);
+
+    // Update to different URL
+    tester.updateNode(
+      id: 0,
+      role: ui.SemanticsRole.tab,
+      linkUrl: url2,
+      label: 'tab link',
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    expect(object.element.getAttribute('href'), url2);
+
+    semantics().semanticsEnabled = false;
+  });
+
   void renderLabel(String label) {
     renderSemantics(label: label);
   }


### PR DESCRIPTION
## Enable link functionality for tabs with linkUrl on Flutter Web

This PR enables proper link functionality for tabs that have a `linkUrl` set on Flutter Web. Previously, when using tabs for navigation menus with URLs (e.g., wrapping a `Tab` with the `Link` widget from `url_launcher`), the link semantics were lost because `SemanticTab` always rendered as a generic `<flt-semantics>` element with `role="tab"`. fixes #180321

### Problem

When tabs are used for app navigation menus on web:
- Users cannot right-click or tap a menu item to copy its URL
- Links for menu items are not indexed by search engines
- The native browser link behavior is completely lost

### Solution

Modified `SemanticTab` to:
1. Render as an `<a>` element when `linkUrl` is present, while maintaining `role="tab"` for accessibility
2. Set the `href` attribute based on the `linkUrl` value
3. Update the `href` attribute dynamically when `linkUrl` changes

This results in HTML like `<a role="tab" href="https://example.com">Tab Label</a>`, which provides:
- ✅ Proper tab accessibility for screen readers (via `role="tab"`)
- ✅ Right-click to copy URL functionality
- ✅ Middle-click to open in new tab
- ✅ Search engine indexing of navigation links

### Before
```html
<flt-semantics role="tab">Tab Label</flt-semantics>
```

### After (when linkUrl is set)
```html
<a role="tab" href="https://example.com" style="display: block;">Tab Label</a>
```

Fixes https://github.com/flutter/flutter/issues/XXXXX

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

