### PR TITLE
Allow TabBar to receive a TabBarScrollController

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -884,7 +884,7 @@ final class TabBarScrollController extends ScrollController {
   /// Is null if this controller is not attached to a [TabBar].
   _TabBarState? _tabBar;
 
-  set _tabBarState(_TabBarState tabBarState) {
+  set _tabBarState(_TabBarState? tabBarState) {
     _tabBar = tabBarState;
   }
 
@@ -906,6 +906,12 @@ final class TabBarScrollController extends ScrollController {
       oldPosition: oldPosition,
       tabBar: _tabBarState,
     );
+  }
+
+  @override
+  void dispose() {
+    _tabBarState = null;
+    super.dispose();
   }
 }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -884,8 +884,14 @@ final class TabBarScrollController extends ScrollController {
   /// Is null if this controller is not attached to a [TabBar].
   _TabBarState? _tabBar;
 
-  void _attachToTabBar(_TabBarState tabBarState) {
+  set _tabBarState(_TabBarState tabBarState) {
     _tabBar = tabBarState;
+  }
+
+  _TabBarState get _tabBarState {
+    assert(_tabBar != null, 'TabBarScrollController is not attached to any TabBar.');
+
+    return _tabBar!;
   }
 
   @override
@@ -898,7 +904,7 @@ final class TabBarScrollController extends ScrollController {
       physics: physics,
       context: context,
       oldPosition: oldPosition,
-      tabBar: _tabBar!,
+      tabBar: _tabBarState,
     );
   }
 }
@@ -1701,6 +1707,8 @@ class _TabBarState extends State<TabBar> {
     super.didChangeDependencies();
     _updateTabController();
     _initIndicatorPainter();
+
+    _effectiveScrollController?._tabBarState = this;
   }
 
   @override
@@ -2116,7 +2124,7 @@ class _TabBarState extends State<TabBar> {
               start: _kStartOffset,
             ).add(widget.padding ?? EdgeInsets.zero)
           : widget.padding;
-      _effectiveScrollController?._attachToTabBar(this);
+
       tabBar = ScrollConfiguration(
         // The scrolling tabs should not show an overscroll indicator.
         behavior: ScrollConfiguration.of(context).copyWith(overscroll: false),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1096,7 +1096,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// will be used.
   final TabController? controller;
 
-  /// The [ScrollController] for this [TabBar].
+  /// The [TabBarScrollController] for this [TabBar].
   ///
   /// This controller can be used to manipulate the scroll position of the [TabBar].
   final TabBarScrollController? scrollController;
@@ -1558,9 +1558,9 @@ class _TabBarState extends State<TabBar> {
     }
   }
 
-  TabBarScrollController? get _effectiveScrollController {
+  TabBarScrollController get _effectiveScrollController {
     if (widget.scrollController != null) {
-      return widget.scrollController;
+      return widget.scrollController!;
     }
 
     return _internalScrollController ??= TabBarScrollController();
@@ -1708,7 +1708,7 @@ class _TabBarState extends State<TabBar> {
     _updateTabController();
     _initIndicatorPainter();
 
-    _effectiveScrollController?._tabBarState = this;
+    _effectiveScrollController._tabBarState = this;
   }
 
   @override
@@ -1719,11 +1719,9 @@ class _TabBarState extends State<TabBar> {
       _updateTabController();
       _initIndicatorPainter();
 
-      final TabBarScrollController? scrollController = _effectiveScrollController;
-
       // Adjust scroll position.
-      if (scrollController != null && scrollController.hasClients) {
-        final ScrollPosition position = scrollController.position;
+      if (_effectiveScrollController.hasClients) {
+        final ScrollPosition position = _effectiveScrollController.position;
         if (position is _TabBarScrollPosition) {
           position.markNeedsPixelsCorrection();
         }
@@ -1781,12 +1779,8 @@ class _TabBarState extends State<TabBar> {
     return clampDouble(tabCenter + paddingStart - viewportWidth / 2.0, minExtent, maxExtent);
   }
 
-  double? _tabCenteredScrollOffset(int index) {
-    final ScrollPosition? position = _effectiveScrollController?.position;
-
-    if (position == null) {
-      return null;
-    }
+  double _tabCenteredScrollOffset(int index) {
+    final ScrollPosition position = _effectiveScrollController.position;
 
     return _tabScrollOffset(
       index,
@@ -1801,27 +1795,19 @@ class _TabBarState extends State<TabBar> {
   }
 
   void _scrollToCurrentIndex() {
-    final double? offset = _tabCenteredScrollOffset(_currentIndex!);
+    final double offset = _tabCenteredScrollOffset(_currentIndex!);
 
-    if (offset == null) {
-      return;
-    }
-
-    _effectiveScrollController?.animateTo(offset, duration: kTabScrollDuration, curve: Curves.ease);
+    _effectiveScrollController.animateTo(offset, duration: kTabScrollDuration, curve: Curves.ease);
   }
 
   void _scrollToControllerValue() {
     final double? leadingPosition = _currentIndex! > 0
         ? _tabCenteredScrollOffset(_currentIndex! - 1)
         : null;
-    final double? middlePosition = _tabCenteredScrollOffset(_currentIndex!);
+    final double middlePosition = _tabCenteredScrollOffset(_currentIndex!);
     final double? trailingPosition = _currentIndex! < maxTabIndex
         ? _tabCenteredScrollOffset(_currentIndex! + 1)
         : null;
-
-    if (middlePosition == null) {
-      return;
-    }
 
     final double index = _controller!.index.toDouble();
     final double value = _controller!.animation!.value;
@@ -1839,7 +1825,7 @@ class _TabBarState extends State<TabBar> {
             : lerpDouble(middlePosition, trailingPosition, value - index)!,
     };
 
-    _effectiveScrollController?.jumpTo(offset);
+    _effectiveScrollController.jumpTo(offset);
   }
 
   void _handleTabControllerAnimationTick() {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -894,6 +894,10 @@ final class TabBarScrollController extends ScrollController {
     return _tabBar!;
   }
 
+  /// Whether this controller is currently attached to a [TabBar]'s [State].
+  @visibleForTesting
+  bool get debugHasTabBarState => _tabBar != null;
+
   @override
   ScrollPosition createScrollPosition(
     ScrollPhysics physics,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -877,12 +877,16 @@ class _TabBarScrollPosition extends ScrollPositionWithSingleContext {
   }
 }
 
-// This class, and TabBarScrollPosition, only exist to handle the case
-// where a scrollable TabBar has a non-zero initialIndex.
-class _TabBarScrollController extends ScrollController {
-  _TabBarScrollController(this.tabBar);
+/// The [ScrollController] for a [TabBar] widget.
+final class TabBarScrollController extends ScrollController {
+  /// The state of the [TabBar] widget to which this controller is attached.
+  ///
+  /// Is null if this controller is not attached to a [TabBar].
+  _TabBarState? _tabBar;
 
-  final _TabBarState tabBar;
+  void _attachToTabBar(_TabBarState tabBarState) {
+    _tabBar = tabBarState;
+  }
 
   @override
   ScrollPosition createScrollPosition(
@@ -894,7 +898,7 @@ class _TabBarScrollController extends ScrollController {
       physics: physics,
       context: context,
       oldPosition: oldPosition,
-      tabBar: tabBar,
+      tabBar: _tabBar!,
     );
   }
 }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1719,6 +1719,29 @@ class _TabBarState extends State<TabBar> {
       _updateTabController();
       _initIndicatorPainter();
 
+      if (oldWidget.scrollController == null) {
+        // The old controller was null,
+        // meaning the internal scroll controller cannot be null.
+        // Dispose of the internal scroll controller.
+        assert(_internalScrollController != null);
+        assert(widget.scrollController != null);
+
+        _internalScrollController!.detach(_internalScrollController!.position);
+        _internalScrollController!.dispose();
+        _internalScrollController = null;
+      } else {
+        // The old controller was not null, detach.
+        oldWidget.scrollController!.detach(oldWidget.scrollController!.position);
+        if (widget.scrollController == null) {
+          // If the new controller is null,
+          // set up the internal TabBarScrollController.
+          _internalScrollController = TabBarScrollController().._tabBarState = this;
+        }
+      }
+
+      // Attach the updated effective scroll controller.
+      _effectiveScrollController.attach(_effectiveScrollController.position);
+
       // Adjust scroll position.
       if (_effectiveScrollController.hasClients) {
         final ScrollPosition position = _effectiveScrollController.position;

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1669,13 +1669,15 @@ class _TabBarState extends State<TabBar> {
     }
   }
 
-  void _updateScrollController() {
+  void _updateScrollController({TabBarScrollController? oldScrollController}) {
     if (widget.scrollController != null) {
+      _internalScrollController?._tabBarState = null;
       widget.scrollController?._tabBarState = this;
 
       return;
     }
 
+    oldScrollController?._tabBarState = null;
     _internalScrollController ??= TabBarScrollController();
     _internalScrollController?._tabBarState = this;
   }
@@ -1732,7 +1734,7 @@ class _TabBarState extends State<TabBar> {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller ||
         widget.scrollController != oldWidget.scrollController) {
-      _updateScrollController();
+      _updateScrollController(oldScrollController: oldWidget.scrollController);
       _updateTabController();
       _initIndicatorPainter();
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -896,11 +896,7 @@ final class TabBarScrollController extends ScrollController {
 
   /// Asserts that this controller is currently attached to a [TabBar]'s [State].
   ///
-  /// To invoke this function, use the following pattern:
-  ///
-  /// ```dart
-  /// assert(debugCheckHasTabBarState());
-  /// ```
+  /// To invoke this function, wrap it in an assert: `assert(debugCheckHasTabBarState());`
   ///
   /// Does nothing if asserts are disabled. Always returns true.
   bool debugCheckHasTabBarState() {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1569,6 +1569,9 @@ class _TabBarState extends State<TabBar> {
 
   TabBarScrollController get _effectiveScrollController {
     if (widget.scrollController != null) {
+      _internalScrollController?.dispose();
+      _internalScrollController = null;
+
       return widget.scrollController!;
     }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -882,17 +882,7 @@ final class TabBarScrollController extends ScrollController {
   /// The state of the [TabBar] widget to which this controller is attached.
   ///
   /// Is null if this controller is not attached to a [TabBar].
-  _TabBarState? _tabBar;
-
-  set _tabBarState(_TabBarState? tabBarState) {
-    _tabBar = tabBarState;
-  }
-
-  _TabBarState get _tabBarState {
-    assert(debugCheckHasTabBarState());
-
-    return _tabBar!;
-  }
+  _TabBarState? _tabBarState;
 
   /// Asserts that this controller is currently attached to a [TabBar]'s [State].
   ///
@@ -900,7 +890,7 @@ final class TabBarScrollController extends ScrollController {
   ///
   /// Does nothing if asserts are disabled. Always returns true.
   bool debugCheckHasTabBarState() {
-    assert(_tabBar != null, 'This TabBarScrollController is not attached to any TabBar.');
+    assert(_tabBarState != null, 'This TabBarScrollController is not attached to any TabBar.');
 
     return true;
   }
@@ -911,11 +901,13 @@ final class TabBarScrollController extends ScrollController {
     ScrollContext context,
     ScrollPosition? oldPosition,
   ) {
+    assert(debugCheckHasTabBarState());
+
     return _TabBarScrollPosition(
       physics: physics,
       context: context,
       oldPosition: oldPosition,
-      tabBar: _tabBarState,
+      tabBar: _tabBarState!,
     );
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1681,16 +1681,16 @@ class _TabBarState extends State<TabBar> {
   }
 
   void _updateScrollController({TabBarScrollController? oldScrollController}) {
+    if (oldScrollController != widget.scrollController) {
+      oldScrollController?._tabBarState = null;
+    }
     if (widget.scrollController != null) {
       _internalScrollController?._tabBarState = null;
       widget.scrollController?._tabBarState = this;
-
-      return;
+    } else {
+      _internalScrollController ??= TabBarScrollController();
+      _internalScrollController?._tabBarState = this;
     }
-
-    oldScrollController?._tabBarState = null;
-    _internalScrollController ??= TabBarScrollController();
-    _internalScrollController?._tabBarState = this;
   }
 
   void _initIndicatorPainter() {
@@ -1786,6 +1786,7 @@ class _TabBarState extends State<TabBar> {
     }
     _controller = null;
     _internalScrollController?.dispose();
+    widget.scrollController?._tabBarState = null;
     // We don't own the _controller Animation, so it's not disposed here.
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -889,14 +889,25 @@ final class TabBarScrollController extends ScrollController {
   }
 
   _TabBarState get _tabBarState {
-    assert(_tabBar != null, 'TabBarScrollController is not attached to any TabBar.');
+    assert(debugCheckHasTabBarState());
 
     return _tabBar!;
   }
 
-  /// Whether this controller is currently attached to a [TabBar]'s [State].
-  @visibleForTesting
-  bool get debugHasTabBarState => _tabBar != null;
+  /// Asserts that this controller is currently attached to a [TabBar]'s [State].
+  ///
+  /// To invoke this function, use the following pattern:
+  ///
+  /// ```dart
+  /// assert(debugCheckHasTabBarState());
+  /// ```
+  ///
+  /// Does nothing if asserts are disabled. Always returns true.
+  bool debugCheckHasTabBarState() {
+    assert(_tabBar != null, 'This TabBarScrollController is not attached to any TabBar.');
+
+    return true;
+  }
 
   @override
   ScrollPosition createScrollPosition(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2800,6 +2800,50 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/124608
+  testWidgets('TabBar can show scrollbar on hover', (WidgetTester tester) async {
+    final tabs = List<Tab>.generate(6, (int index) {
+      return Tab(text: 'TAB #$index');
+    });
+
+    final TabController tabBarController = createTabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+      initialIndex: tabs.length - 1,
+    );
+    final tabScrollController = TabBarScrollController();
+    addTearDown(tabScrollController.dispose);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: RawScrollbar(
+          controller: tabScrollController,
+          child: TabBar(
+            isScrollable: true,
+            controller: tabBarController,
+            scrollController: tabScrollController,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    final Finder tab1 = find.text('TAB #1');
+    expect(tab1, findsOneWidget);
+
+    // Hover over the tab bar and verify that the scrollbar is shown.
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(tab1));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RawScrollbar), paints..rect());
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Scrollable TabBar with a non-zero TabController initialIndex', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2737,6 +2737,69 @@ void main() {
     expect(position, equals(20));
   });
 
+  testWidgets('TabBar accepts external TabBarController', (WidgetTester tester) async {
+    final tabs = List<Tab>.generate(6, (int index) {
+      return Tab(text: 'TAB #$index');
+    });
+
+    final TabController tabBarController = createTabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+      initialIndex: tabs.length - 1,
+    );
+    final tabScrollController = TabBarScrollController();
+    addTearDown(tabScrollController.dispose);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(
+          isScrollable: true,
+          controller: tabBarController,
+          scrollController: tabScrollController,
+          tabs: tabs,
+        ),
+      ),
+    );
+
+    final ScrollableState scrollableState = tester.state<ScrollableState>(find.byType(Scrollable));
+
+    tabScrollController.jumpTo(50);
+    await tester.pump();
+
+    expect(scrollableState.position.pixels, 50);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/124608
+  testWidgets('TabBar can be wrapped with RawScrollbar', (WidgetTester tester) async {
+    final tabs = List<Tab>.generate(6, (int index) {
+      return Tab(text: 'TAB #$index');
+    });
+
+    final TabController tabBarController = createTabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+      initialIndex: tabs.length - 1,
+    );
+    final tabScrollController = TabBarScrollController();
+    addTearDown(tabScrollController.dispose);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: RawScrollbar(
+          controller: tabScrollController,
+          child: TabBar(
+            isScrollable: true,
+            controller: tabBarController,
+            scrollController: tabScrollController,
+            tabs: tabs,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Scrollable TabBar with a non-zero TabController initialIndex', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2737,7 +2737,7 @@ void main() {
     expect(position, equals(20));
   });
 
-  testWidgets('TabBar accepts external TabBarController', (WidgetTester tester) async {
+  testWidgets('TabBar accepts external TabBarScrollController', (WidgetTester tester) async {
     final tabs = List<Tab>.generate(6, (int index) {
       return Tab(text: 'TAB #$index');
     });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2862,6 +2862,73 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('TabBar correctly detaches old external TabBarScrollController when switched to a new one', (WidgetTester tester) async {
+    final List<Tab> tabs = <Tab>[
+      for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
+    ];
+
+    final TabBarScrollController controllerA = TabBarScrollController();
+    final TabBarScrollController controllerB = TabBarScrollController();
+    addTearDown(controllerA.dispose);
+    addTearDown(controllerB.dispose);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(
+          isScrollable: true,
+          controller: TabController(length: tabs.length, vsync: const TestVSync()),
+          scrollController: controllerA,
+          tabs: tabs,
+        ),
+      ),
+    );
+
+    expect(controllerA.debugCheckHasTabBarState(), isTrue);
+    expect(() => controllerB.debugCheckHasTabBarState(), throwsAssertionError);
+
+    // Switch to controllerB
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(
+          isScrollable: true,
+          controller: TabController(length: tabs.length, vsync: const TestVSync()),
+          scrollController: controllerB,
+          tabs: tabs,
+        ),
+      ),
+    );
+
+    expect(controllerB.debugCheckHasTabBarState(), isTrue);
+    expect(() => controllerA.debugCheckHasTabBarState(), throwsAssertionError);
+  });
+
+  testWidgets('TabBar correctly detaches external TabBarScrollController when disposed', (WidgetTester tester) async {
+    final List<Tab> tabs = <Tab>[
+      for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
+    ];
+
+    final TabBarScrollController controller = TabBarScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(
+          isScrollable: true,
+          controller: TabController(length: tabs.length, vsync: const TestVSync()),
+          scrollController: controller,
+          tabs: tabs,
+        ),
+      ),
+    );
+
+    expect(controller.debugCheckHasTabBarState(), isTrue);
+
+    // Dispose the TabBar by pumping a different widget
+    await tester.pumpWidget(boilerplate(child: const SizedBox.shrink()));
+
+    expect(() => controller.debugCheckHasTabBarState(), throwsAssertionError);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/124608
   testWidgets('TabBar can be wrapped with RawScrollbar', (WidgetTester tester) async {
     final tabs = List<Tab>.generate(6, (int index) {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2862,50 +2862,51 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('TabBar correctly detaches old external TabBarScrollController when switched to a new one', (WidgetTester tester) async {
-    final tabs = <Tab>[
-      for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
-    ];
+  testWidgets(
+    'TabBar correctly detaches old external TabBarScrollController when switched to a new one',
+    (WidgetTester tester) async {
+      final tabs = <Tab>[for (int i = 0; i < 10; i++) Tab(text: 'Tab $i')];
 
-    final controllerA = TabBarScrollController();
-    final controllerB = TabBarScrollController();
-    addTearDown(controllerA.dispose);
-    addTearDown(controllerB.dispose);
+      final controllerA = TabBarScrollController();
+      final controllerB = TabBarScrollController();
+      addTearDown(controllerA.dispose);
+      addTearDown(controllerB.dispose);
 
-    await tester.pumpWidget(
-      boilerplate(
-        child: TabBar(
-          isScrollable: true,
-          controller: TabController(length: tabs.length, vsync: const TestVSync()),
-          scrollController: controllerA,
-          tabs: tabs,
+      await tester.pumpWidget(
+        boilerplate(
+          child: TabBar(
+            isScrollable: true,
+            controller: TabController(length: tabs.length, vsync: const TestVSync()),
+            scrollController: controllerA,
+            tabs: tabs,
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(controllerA.debugCheckHasTabBarState(), isTrue);
-    expect(() => controllerB.debugCheckHasTabBarState(), throwsAssertionError);
+      expect(controllerA.debugCheckHasTabBarState(), isTrue);
+      expect(() => controllerB.debugCheckHasTabBarState(), throwsAssertionError);
 
-    // Switch to controllerB
-    await tester.pumpWidget(
-      boilerplate(
-        child: TabBar(
-          isScrollable: true,
-          controller: TabController(length: tabs.length, vsync: const TestVSync()),
-          scrollController: controllerB,
-          tabs: tabs,
+      // Switch to controllerB
+      await tester.pumpWidget(
+        boilerplate(
+          child: TabBar(
+            isScrollable: true,
+            controller: TabController(length: tabs.length, vsync: const TestVSync()),
+            scrollController: controllerB,
+            tabs: tabs,
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(controllerB.debugCheckHasTabBarState(), isTrue);
-    expect(() => controllerA.debugCheckHasTabBarState(), throwsAssertionError);
-  });
+      expect(controllerB.debugCheckHasTabBarState(), isTrue);
+      expect(() => controllerA.debugCheckHasTabBarState(), throwsAssertionError);
+    },
+  );
 
-  testWidgets('TabBar correctly detaches external TabBarScrollController when disposed', (WidgetTester tester) async {
-    final tabs = <Tab>[
-      for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
-    ];
+  testWidgets('TabBar correctly detaches external TabBarScrollController when disposed', (
+    WidgetTester tester,
+  ) async {
+    final tabs = <Tab>[for (int i = 0; i < 10; i++) Tab(text: 'Tab $i')];
 
     final controller = TabBarScrollController();
     addTearDown(controller.dispose);

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2867,6 +2867,9 @@ void main() {
     (WidgetTester tester) async {
       final tabs = <Tab>[for (int i = 0; i < 10; i++) Tab(text: 'Tab $i')];
 
+      final tabController = TabController(length: tabs.length, vsync: const TestVSync());
+      addTearDown(tabController.dispose);
+
       final controllerA = TabBarScrollController();
       final controllerB = TabBarScrollController();
       addTearDown(controllerA.dispose);
@@ -2876,7 +2879,7 @@ void main() {
         boilerplate(
           child: TabBar(
             isScrollable: true,
-            controller: TabController(length: tabs.length, vsync: const TestVSync()),
+            controller: tabController,
             scrollController: controllerA,
             tabs: tabs,
           ),
@@ -2891,7 +2894,7 @@ void main() {
         boilerplate(
           child: TabBar(
             isScrollable: true,
-            controller: TabController(length: tabs.length, vsync: const TestVSync()),
+            controller: tabController,
             scrollController: controllerB,
             tabs: tabs,
           ),
@@ -2908,6 +2911,8 @@ void main() {
   ) async {
     final tabs = <Tab>[for (int i = 0; i < 10; i++) Tab(text: 'Tab $i')];
 
+    final tabController = TabController(length: tabs.length, vsync: const TestVSync());
+    addTearDown(tabController.dispose);
     final controller = TabBarScrollController();
     addTearDown(controller.dispose);
 
@@ -2915,7 +2920,7 @@ void main() {
       boilerplate(
         child: TabBar(
           isScrollable: true,
-          controller: TabController(length: tabs.length, vsync: const TestVSync()),
+          controller: tabController,
           scrollController: controller,
           tabs: tabs,
         ),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2811,7 +2811,7 @@ void main() {
 
     // The pixels of the new position should be the same as before the update.
     expect(scrollableState.position.pixels, oldPixels);
-    expect(tabScrollController.debugHasTabBarState, isFalse);
+    expect(tabScrollController.debugCheckHasTabBarState, throwsAssertionError);
   });
 
   testWidgets('TabBar attaches state to external TabBarScrollController in didUpdateWidget', (
@@ -2856,7 +2856,10 @@ void main() {
 
     // The pixels of the new position should be the same as before the update.
     expect(scrollableState.position.pixels, oldPixels);
-    expect(tabScrollController.debugHasTabBarState, isTrue);
+
+    // This should not throw, since the tab bar is attached to the external controller.
+    expect(tabScrollController.debugCheckHasTabBarState(), isTrue);
+    expect(tester.takeException(), isNull);
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/124608

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2863,12 +2863,12 @@ void main() {
   });
 
   testWidgets('TabBar correctly detaches old external TabBarScrollController when switched to a new one', (WidgetTester tester) async {
-    final List<Tab> tabs = <Tab>[
+    final tabs = <Tab>[
       for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
     ];
 
-    final TabBarScrollController controllerA = TabBarScrollController();
-    final TabBarScrollController controllerB = TabBarScrollController();
+    final controllerA = TabBarScrollController();
+    final controllerB = TabBarScrollController();
     addTearDown(controllerA.dispose);
     addTearDown(controllerB.dispose);
 
@@ -2903,11 +2903,11 @@ void main() {
   });
 
   testWidgets('TabBar correctly detaches external TabBarScrollController when disposed', (WidgetTester tester) async {
-    final List<Tab> tabs = <Tab>[
+    final tabs = <Tab>[
       for (int i = 0; i < 10; i++) Tab(text: 'Tab $i'),
     ];
 
-    final TabBarScrollController controller = TabBarScrollController();
+    final controller = TabBarScrollController();
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(


### PR DESCRIPTION
This pull request makes `TabBarScrollController` public, and allows a `TabBar` widget to receive one.

Fixes https://github.com/flutter/flutter/issues/123965
Fixes https://github.com/flutter/flutter/issues/124608
Related to https://github.com/flutter/flutter/pull/180120

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
