### PR TITLE
Remove @override annotations from things which are not overrides

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -405,7 +405,6 @@ class DelegatingLogger implements Logger {
 /// the first delegate with the matching type.
 ///
 /// Throws a [StateError] if no matching delegate is found.
-@override
 T asLogger<T extends Logger>(Logger logger) {
   final original = logger;
   while (true) {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -1168,7 +1168,6 @@ class FakeIOSDeployDebugger extends Fake implements IOSDeployDebugger {
   }
 }
 
-@override
 class FakeXcode extends Fake implements Xcode {
   FakeXcode({this.version});
 


### PR DESCRIPTION
These annotations are applied to top-level elements, which override nothing.

A new warning from the Analyzer will start to report these.