### PR TITLE
fix(windows): use wcsnlen for defensive programming (CWE-126)

### DIFF
--- a/dev/benchmarks/complex_layout/windows/runner/utils.cpp
+++ b/dev/benchmarks/complex_layout/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/windows_startup_test/lib/main.dart
+++ b/dev/integration_tests/windows_startup_test/lib/main.dart
@@ -79,6 +79,26 @@ void main() async {
         return (converted == expected)
             ? 'success'
             : 'error: conversion of UTF16 string to UTF8 failed, expected "${expected.codeUnits}" but got "${converted.codeUnits}"';
+      } else if (message == 'verifyNullStringConversion') {
+        // Test that Utf8FromUtf16 handles nullptr gracefully by returning empty string.
+        final String converted = await testNullStringConversion();
+        return converted.isEmpty
+            ? 'success'
+            : 'error: nullptr conversion should return empty string, got "${converted.codeUnits}"';
+      } else if (message == 'verifyEmptyStringConversion') {
+        // Test that Utf8FromUtf16 handles empty string gracefully.
+        final String converted = await testEmptyStringConversion();
+        return converted.isEmpty
+            ? 'success'
+            : 'error: empty string conversion should return empty string, got "${converted.codeUnits}"';
+      } else if (message == 'verifyInvalidUtf16Conversion') {
+        // Test that Utf8FromUtf16 handles invalid UTF-16 (unpaired surrogate) gracefully.
+        // With WC_ERR_INVALID_CHARS flag, WideCharToMultiByte returns 0 for invalid input,
+        // so Utf8FromUtf16 should return an empty string.
+        final String converted = await testInvalidUtf16Conversion();
+        return converted.isEmpty
+            ? 'success'
+            : 'error: invalid UTF-16 conversion should return empty string, got "${converted.codeUnits}"';
       }
 
       throw 'Unrecognized message: $message';

--- a/dev/integration_tests/windows_startup_test/lib/windows.dart
+++ b/dev/integration_tests/windows_startup_test/lib/windows.dart
@@ -50,3 +50,33 @@ Future<String> testStringConversion(Int32List twoByteCodes) async {
 
   return converted;
 }
+
+/// Test that Utf8FromUtf16 handles nullptr gracefully.
+Future<String> testNullStringConversion() async {
+  final String? converted = await _kMethodChannel.invokeMethod<String?>('convertNullString');
+  if (converted == null) {
+    throw 'Method channel unavailable.';
+  }
+
+  return converted;
+}
+
+/// Test that Utf8FromUtf16 handles empty string gracefully.
+Future<String> testEmptyStringConversion() async {
+  final String? converted = await _kMethodChannel.invokeMethod<String?>('convertEmptyString');
+  if (converted == null) {
+    throw 'Method channel unavailable.';
+  }
+
+  return converted;
+}
+
+/// Test that Utf8FromUtf16 handles invalid UTF-16 (unpaired surrogate) gracefully.
+Future<String> testInvalidUtf16Conversion() async {
+  final String? converted = await _kMethodChannel.invokeMethod<String?>('convertInvalidUtf16');
+  if (converted == null) {
+    throw 'Method channel unavailable.';
+  }
+
+  return converted;
+}

--- a/dev/integration_tests/windows_startup_test/test_driver/main_test.dart
+++ b/dev/integration_tests/windows_startup_test/test_driver/main_test.dart
@@ -32,4 +32,31 @@ void main() {
 
     await driver.close();
   }, timeout: Timeout.none);
+
+  test('Windows app template Utf8FromUtf16 handles nullptr', () async {
+    final FlutterDriver driver = await FlutterDriver.connect(printCommunication: true);
+    final String result = await driver.requestData('verifyNullStringConversion');
+
+    expect(result, equals('success'));
+
+    await driver.close();
+  }, timeout: Timeout.none);
+
+  test('Windows app template Utf8FromUtf16 handles empty string', () async {
+    final FlutterDriver driver = await FlutterDriver.connect(printCommunication: true);
+    final String result = await driver.requestData('verifyEmptyStringConversion');
+
+    expect(result, equals('success'));
+
+    await driver.close();
+  }, timeout: Timeout.none);
+
+  test('Windows app template Utf8FromUtf16 handles invalid UTF-16', () async {
+    final FlutterDriver driver = await FlutterDriver.connect(printCommunication: true);
+    final String result = await driver.requestData('verifyInvalidUtf16Conversion');
+
+    expect(result, equals('success'));
+
+    await driver.close();
+  }, timeout: Timeout.none);
 }

--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
@@ -122,6 +122,21 @@ bool FlutterWindow::OnCreate() {
         wide_str.push_back((wchar_t)0);
         const std::string string = Utf8FromUtf16(wide_str.data());
         result->Success(string);
+      } else if (method == "convertNullString") {
+        // Test that Utf8FromUtf16 handles nullptr gracefully.
+        const std::string string = Utf8FromUtf16(nullptr);
+        result->Success(string);
+      } else if (method == "convertEmptyString") {
+        // Test that Utf8FromUtf16 handles empty string gracefully.
+        const wchar_t empty[] = L"";
+        const std::string string = Utf8FromUtf16(empty);
+        result->Success(string);
+      } else if (method == "convertInvalidUtf16") {
+        // Test that Utf8FromUtf16 handles invalid UTF-16 (unpaired surrogate).
+        // 0xD800 is a high surrogate without a matching low surrogate.
+        const wchar_t invalid[] = { 0xD800, 0 };
+        const std::string string = Utf8FromUtf16(invalid);
+        result->Success(string);
       } else {
         result->NotImplemented();
       }

--- a/dev/manual_tests/windows/runner/utils.cpp
+++ b/dev/manual_tests/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/api/windows/runner/utils.cpp
+++ b/examples/api/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/flutter_view/windows/runner/utils.cpp
+++ b/examples/flutter_view/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/hello_world/windows/runner/utils.cpp
+++ b/examples/hello_world/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/multiple_windows/windows/runner/utils.cpp
+++ b/examples/multiple_windows/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/platform_channel/windows/runner/utils.cpp
+++ b/examples/platform_channel/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/platform_view/windows/runner/utils.cpp
+++ b/examples/platform_view/windows/runner/utils.cpp
@@ -49,18 +49,23 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/packages/flutter_tools/templates/app/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app/windows.tmpl/runner/utils.cpp
@@ -45,13 +45,17 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  unsigned int target_length = ::WideCharToMultiByte(
+  // First, find the length of the string with a safe upper bound (CWE-126).
+  // UNICODE_STRING_MAX_CHARS (32767) is the maximum length of a UNICODE_STRING.
+  int input_length = static_cast<int>(wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS));
+  // Now use that bounded length to determine the required buffer size.
+  // When an explicit length is passed, WideCharToMultiByte does not include
+  // the null terminator in its returned size.
+  int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr)
-    -1; // remove the trailing null character
-  int input_length = (int)wcslen(utf16_string);
+      input_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || static_cast<size_t>(target_length) > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);


### PR DESCRIPTION
## Description

This PR replaces `wcslen` with `wcsnlen` in the Windows runner template and all example/dev/integration test files to address CWE-126 (Buffer Over-read) flagged by static analysis tools (Semgrep/GitLab SAST).

## Changes

The `Utf8FromUtf16` function now uses `wcsnlen` with the `UNICODE_STRING_MAX_CHARS` constant (32767) as the maximum length, providing defensive programming against potential buffer over-reads.

**Key improvements:**
1. Calculate `input_length` **first** using `wcsnlen(utf16_string, UNICODE_STRING_MAX_CHARS)`
2. Use that bounded length for **both** `WideCharToMultiByte` calls (eliminates the `-1` unbounded read)
3. Remove the `-1` adjustment since explicit length excludes null terminator
4. Use `static_cast` instead of C-style casts per Google C++ Style Guide

## Test Coverage

Added comprehensive edge case tests for `Utf8FromUtf16` in `windows_startup_test`:
- **nullptr input**: Verifies function returns empty string
- **Empty string input**: Verifies function returns empty string  
- **Invalid UTF-16 (unpaired surrogate)**: Verifies function handles malformed input gracefully

These tests address reviewer feedback from @loic-sharma requesting coverage for corner cases.

## Files Updated

**Template (source of truth):**
- `packages/flutter_tools/templates/app/windows.tmpl/runner/utils.cpp`

**Integration tests (4 files):**
- `dev/integration_tests/flutter_gallery/windows/runner/utils.cpp`
- `dev/integration_tests/ui/windows/runner/utils.cpp`
- `dev/integration_tests/windowing_test/windows/runner/utils.cpp`
- `dev/integration_tests/windows_startup_test/windows/runner/utils.cpp`

**Examples and dev apps (10 files):**
- `examples/hello_world/windows/runner/utils.cpp`
- `examples/layers/windows/runner/utils.cpp`
- `examples/platform_view/windows/runner/utils.cpp`
- `examples/flutter_view/windows/runner/utils.cpp`
- `examples/platform_channel/windows/runner/utils.cpp`
- `examples/api/windows/runner/utils.cpp`
- `examples/multiple_windows/windows/runner/utils.cpp`
- `dev/manual_tests/windows/runner/utils.cpp`
- `dev/benchmarks/complex_layout/windows/runner/utils.cpp`
- `dev/a11y_assessments/windows/runner/utils.cpp`

**Test files (4 files):**
- `dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp`
- `dev/integration_tests/windows_startup_test/lib/main.dart`
- `dev/integration_tests/windows_startup_test/lib/windows.dart`
- `dev/integration_tests/windows_startup_test/test_driver/main_test.dart`

## Rationale

While the Windows API guarantees null-termination for strings returned by `CommandLineToArgvW`, using `wcsnlen` with an explicit bound is a defensive programming best practice that:
- Satisfies static analysis tools
- Provides an extra safety layer
- Follows the principle of defense in depth

The limit of 32767 (`UNICODE_STRING_MAX_CHARS`) is the maximum length of a `UNICODE_STRING` structure and is far beyond any realistic command-line argument length.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/180418

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and labeled this PR with `severe: API break` if it contains a breaking change.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#breaking-changes