### PR TITLE
fix(cmake): make native_assets install conditional

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -810,7 +810,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': '23suNuzNQCwRbDrysuR9RsOtSueebQ5qYnnh1PBkbrMC'
+        'version': 'nzgy72aZ9kvHxTDM6mXxJMJbiQ4D20S_v4N0P5MJxG8C'
        }
      ],
      'condition': 'download_fuchsia_deps and not download_fuchsia_sdk',

--- a/dev/integration_tests/windowing_test/linux/CMakeLists.txt
+++ b/dev/integration_tests/windowing_test/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/dev/integration_tests/windowing_test/windows/CMakeLists.txt
+++ b/dev/integration_tests/windowing_test/windows/CMakeLists.txt
@@ -89,9 +89,11 @@ endif()
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/api/linux/CMakeLists.txt
+++ b/examples/api/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/hello_world/linux/CMakeLists.txt
+++ b/examples/hello_world/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/layers/linux/CMakeLists.txt
+++ b/examples/layers/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/multiple_windows/linux/CMakeLists.txt
+++ b/examples/multiple_windows/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/multiple_windows/windows/CMakeLists.txt
+++ b/examples/multiple_windows/windows/CMakeLists.txt
@@ -89,9 +89,11 @@ endif()
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/platform_channel/linux/CMakeLists.txt
+++ b/examples/platform_channel/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/platform_view/linux/CMakeLists.txt
+++ b/examples/platform_view/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/examples/texture/linux/CMakeLists.txt
+++ b/examples/texture/linux/CMakeLists.txt
@@ -108,9 +108,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/packages/flutter_tools/lib/src/migrations/cmake_native_assets_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/cmake_native_assets_migration.dart
@@ -11,9 +11,11 @@ import '../cmake_project.dart';
 /// ```cmake
 /// # Copy the native assets provided by the build.dart from all packages.
 /// set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-/// install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-///    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-///    COMPONENT Runtime)
+/// if(EXISTS "${NATIVE_ASSETS_DIR}")
+///   install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+///     DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+///     COMPONENT Runtime)
+/// endif()
 /// ```
 class CmakeNativeAssetsMigration extends ProjectMigrator {
   CmakeNativeAssetsMigration(CmakeBasedProject project, this.os, super.logger)
@@ -41,9 +43,11 @@ class CmakeNativeAssetsMigration extends ProjectMigrator {
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "\${PROJECT_BUILD_DIR}native_assets/$os/")
-install(DIRECTORY "\${NATIVE_ASSETS_DIR}"
-  DESTINATION "\${INSTALL_BUNDLE_LIB_DIR}"
-  COMPONENT Runtime)
+if(EXISTS "\${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "\${NATIVE_ASSETS_DIR}"
+    DESTINATION "\${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 ''';
 
     // Insert the new command after the bundled libraries loop.

--- a/packages/flutter_tools/templates/app/linux.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/CMakeLists.txt.tmpl
@@ -112,9 +112,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/packages/flutter_tools/templates/app/windows.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/app/windows.tmpl/CMakeLists.txt.tmpl
@@ -93,9 +93,11 @@ endif()
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
-install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-   COMPONENT Runtime)
+if(EXISTS "${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/packages/flutter_tools/test/general.shard/migrations/cmake_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/cmake_project_migration_test.dart
@@ -262,9 +262,11 @@ endforeach(bundled_library)
 
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "\${PROJECT_BUILD_DIR}native_assets/$os/")
-install(DIRECTORY "\${NATIVE_ASSETS_DIR}"
-  DESTINATION "\${INSTALL_BUNDLE_LIB_DIR}"
-  COMPONENT Runtime)
+if(EXISTS "\${NATIVE_ASSETS_DIR}")
+  install(DIRECTORY "\${NATIVE_ASSETS_DIR}"
+    DESTINATION "\${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.


### PR DESCRIPTION
The install(DIRECTORY) command fails when native_assets/{linux,windows}/ directory doesn't exist, which is the case for projects that don't use Dart FFI native assets.

Wrap the install in an if(EXISTS) check to skip it when the directory is not present.

Fixes build failures for Flutter Linux/Windows apps that don't use native assets. Fixes #159199.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.