### PR TITLE
[Web] Fix IME and selection by syncing more text styles

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -67,6 +67,7 @@ void _setStaticStyleAttributes(DomHTMLElement domElement) {
     ..position = 'absolute'
     ..top = '0'
     ..left = '0'
+    ..margin = '0'
     ..padding = '0'
     ..opacity = '1'
     ..color = 'transparent'
@@ -107,6 +108,7 @@ void _styleAutofillElements(
   final DomCSSStyleDeclaration elementStyle = domElement.style;
   elementStyle
     ..whiteSpace = 'pre-wrap'
+    ..margin = '0'
     ..padding = '0'
     ..opacity = '1'
     ..color = 'transparent'

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -2501,6 +2501,9 @@ class EditableTextStyle {
     required this.textAlign,
     required this.fontFamily,
     required this.fontWeight,
+    required this.letterSpacing,
+    required this.wordSpacing,
+    required this.lineHeight,
   });
 
   factory EditableTextStyle.fromFrameworkMessage(Map<String, dynamic> flutterStyle) {
@@ -2527,6 +2530,9 @@ class EditableTextStyle {
       textAlign: ui.TextAlign.values[textAlignIndex],
       textDirection: ui.TextDirection.values[textDirectionIndex],
       fontWeight: fontWeight,
+      letterSpacing: flutterStyle.tryDouble('letterSpacing'),
+      wordSpacing: flutterStyle.tryDouble('wordSpacing'),
+      lineHeight: flutterStyle.tryDouble('lineHeight'),
     );
   }
 
@@ -2537,6 +2543,9 @@ class EditableTextStyle {
   final String? fontFamily;
   final ui.TextAlign textAlign;
   final ui.TextDirection textDirection;
+  final double? letterSpacing;
+  final double? wordSpacing;
+  final double? lineHeight;
 
   String? get align => textAlignToCssValue(textAlign, textDirection);
 
@@ -2545,7 +2554,10 @@ class EditableTextStyle {
   void applyToDomElement(DomHTMLElement domElement) {
     domElement.style
       ..textAlign = align!
-      ..font = cssFont;
+      ..font = cssFont
+      ..letterSpacing = letterSpacing != null ? '${letterSpacing}px' : ''
+      ..wordSpacing = wordSpacing != null ? '${wordSpacing}px' : ''
+      ..lineHeight = lineHeight != null ? '${lineHeight}px' : 'normal';
   }
 }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1299,6 +1299,9 @@ abstract class DefaultTextEditingStrategy
   /// Size and transform of the editable text on the page.
   EditableTextGeometry? geometry;
 
+  /// The scroll top of the editable text on the page.
+  final Map<String, double> _preservedScrollTops = <String, double>{};
+
   OnChangeCallback? onChange;
   OnActionCallback? onAction;
 
@@ -1454,6 +1457,11 @@ abstract class DefaultTextEditingStrategy
   @override
   void disable() {
     assert(isEnabled);
+    // Preserve the internal scroll position.
+    if (geometry != null && lastEditingState != null) {
+      final key = '${geometry!.hashCode}_${lastEditingState!.text.hashCode}';
+      _preservedScrollTops[key] = activeDomElement.scrollTop;
+    }
 
     isEnabled = false;
     lastEditingState = null;
@@ -1657,6 +1665,12 @@ abstract class DefaultTextEditingStrategy
 
     // Re-focuses after setting editing state.
     moveFocusToActiveDomElement();
+
+    // Restore the internal scroll position.
+    if (geometry != null && lastEditingState != null) {
+      final key = '${geometry!.hashCode}_${lastEditingState!.text.hashCode}';
+      activeDomElement.scrollTop = _preservedScrollTops.remove(key) ?? 0.0;
+    }
   }
 
   /// Prevent default behavior for mouse down, up and move.
@@ -2617,4 +2631,18 @@ class EditableTextGeometry {
       ..height = '${height}px'
       ..transform = cssTransform;
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is EditableTextGeometry &&
+        other.width == width &&
+        other.height == height &&
+        listEquals<double>(other.globalTransform, globalTransform);
+  }
+
+  @override
+  int get hashCode => Object.hash(width, height, Object.hashAll(globalTransform));
 }

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -74,6 +74,25 @@ Future<void> testMain() async {
     await waitForTextStrategyStopPropagation();
   });
 
+  group('EditableTextStyle', () {
+    test('applies lineHeight (px) if provided', () {
+      final style = <String, dynamic>{
+        'fontFamily': 'Roboto',
+        'fontSize': 10.0,
+        'fontWeightIndex': 0,
+        'textAlignIndex': 0,
+        'textDirectionIndex': 0,
+        'lineHeight': 20.0,
+      };
+
+      final editableTextStyle = EditableTextStyle.fromFrameworkMessage(style);
+      final DomHTMLInputElement element = createDomHTMLInputElement();
+      editableTextStyle.applyToDomElement(element);
+
+      expect(element.style.lineHeight, '20px');
+    });
+  });
+
   group('$GloballyPositionedTextEditingStrategy', () {
     late HybridTextEditing testTextEditing;
 
@@ -1953,6 +1972,41 @@ Future<void> testMain() async {
       setStyle = configureSetStyleMethodCall(12, 'foo bar baz', 4, 4, 1);
       sendFrameworkMessage(codec.encodeMethodCall(setStyle));
       expect(input.style.fontFamily, canonicalizeFontFamily('foo bar baz'));
+
+      hideKeyboard();
+    });
+
+    test('Applies lineHeight, letterSpacing, and wordSpacing', () {
+      showKeyboard(inputType: 'multiline', isMultiline: true);
+      final DomHTMLElement input = textEditing!.strategy.domElement!;
+
+      const setStyle = MethodCall('TextInput.setStyle', <String, dynamic>{
+        'fontSize': 12.0,
+        'fontFamily': 'sans-serif',
+        'textAlignIndex': 0,
+        'textDirectionIndex': 0,
+        'letterSpacing': 1.5,
+        'wordSpacing': 2.5,
+        'lineHeight': 16.0,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setStyle));
+
+      expect(input.style.letterSpacing, '1.5px');
+      expect(input.style.wordSpacing, '2.5px');
+      expect(input.style.lineHeight, '16px');
+
+      const setStyleDefault = MethodCall('TextInput.setStyle', <String, dynamic>{
+        'fontSize': 12.0,
+        'fontFamily': 'sans-serif',
+        'textAlignIndex': 0,
+        'textDirectionIndex': 0,
+        // letterSpacing, wordSpacing, lineHeight missing/null
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setStyleDefault));
+
+      expect(input.style.letterSpacing, '');
+      expect(input.style.wordSpacing, '');
+      expect(input.style.lineHeight, 'normal');
 
       hideKeyboard();
     });

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1655,6 +1655,10 @@ class TextInputConnection {
   /// This information is used by the Flutter Web Engine to change the style
   /// of the hidden native input's content. Hence, the content size will match
   /// to the size of the editable widget's content.
+  @Deprecated(
+    'Use setStyleWithMetrics instead. '
+    'This feature was deprecated after v3.40.0-0.2.pre.',
+  )
   void setStyle({
     required String? fontFamily,
     required double? fontSize,
@@ -1662,9 +1666,7 @@ class TextInputConnection {
     required TextDirection textDirection,
     required TextAlign textAlign,
   }) {
-    assert(attached);
-
-    TextInput._instance._setStyle(
+    setStyleWithMetrics(
       fontFamily: fontFamily,
       fontSize: fontSize,
       fontWeight: fontWeight,
@@ -1690,6 +1692,38 @@ class TextInputConnection {
   void connectionClosedReceived() {
     TextInput._instance._currentConnection = null;
     assert(!attached);
+  }
+}
+
+/// Extension to add [setStyleWithMetrics] to [TextInputConnection].
+extension TextInputConnectionExt on TextInputConnection {
+  /// Send text styling information.
+  ///
+  /// This information is used by the Flutter Web Engine to change the style
+  /// of the hidden native input's content. Hence, the content size will match
+  /// to the size of the editable widget's content.
+  void setStyleWithMetrics({
+    required String? fontFamily,
+    required double? fontSize,
+    required FontWeight? fontWeight,
+    required TextDirection textDirection,
+    required TextAlign textAlign,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? lineHeight,
+  }) {
+    assert(attached);
+
+    TextInput._instance._setStyle(
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      textDirection: textDirection,
+      textAlign: textAlign,
+      letterSpacing: letterSpacing,
+      wordSpacing: wordSpacing,
+      lineHeight: lineHeight,
+    );
   }
 }
 
@@ -2225,14 +2259,20 @@ class TextInput {
     required FontWeight? fontWeight,
     required TextDirection textDirection,
     required TextAlign textAlign,
+    required double? letterSpacing,
+    required double? wordSpacing,
+    required double? lineHeight,
   }) {
     for (final TextInputControl control in _inputControls) {
-      control.setStyle(
+      control.setStyleWithMetrics(
         fontFamily: fontFamily,
         fontSize: fontSize,
         fontWeight: fontWeight,
         textDirection: textDirection,
         textAlign: textAlign,
+        letterSpacing: letterSpacing,
+        wordSpacing: wordSpacing,
+        lineHeight: lineHeight,
       );
     }
   }
@@ -2424,6 +2464,10 @@ mixin TextInputControl {
   ///
   /// This method is called on the when the attached input client's text style
   /// changes.
+  @Deprecated(
+    'Use setStyleWithMetrics instead. '
+    'This feature was deprecated after v3.40.0-0.2.pre.',
+  )
   void setStyle({
     required String? fontFamily,
     required double? fontSize,
@@ -2431,6 +2475,29 @@ mixin TextInputControl {
     required TextDirection textDirection,
     required TextAlign textAlign,
   }) {}
+
+  /// Informs the text input control about text style changes.
+  ///
+  /// This method is called on the when the attached input client's text style
+  /// changes.
+  void setStyleWithMetrics({
+    required String? fontFamily,
+    required double? fontSize,
+    required FontWeight? fontWeight,
+    required TextDirection textDirection,
+    required TextAlign textAlign,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? lineHeight,
+  }) {
+    setStyle(
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      textDirection: textDirection,
+      textAlign: textAlign,
+    );
+  }
 
   /// Requests autofill from the text input control.
   ///
@@ -2557,12 +2624,35 @@ class _PlatformTextInputControl with TextInputControl {
     required TextDirection textDirection,
     required TextAlign textAlign,
   }) {
+    setStyleWithMetrics(
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      fontWeight: fontWeight,
+      textDirection: textDirection,
+      textAlign: textAlign,
+    );
+  }
+
+  @override
+  void setStyleWithMetrics({
+    required String? fontFamily,
+    required double? fontSize,
+    required FontWeight? fontWeight,
+    required TextDirection textDirection,
+    required TextAlign textAlign,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? lineHeight,
+  }) {
     _channel.invokeMethod<void>('TextInput.setStyle', <String, dynamic>{
       'fontFamily': fontFamily,
       'fontSize': fontSize,
       'fontWeightIndex': fontWeight?.index,
       'textAlignIndex': textAlign.index,
       'textDirectionIndex': textDirection.index,
+      'letterSpacing': letterSpacing,
+      'wordSpacing': wordSpacing,
+      'lineHeight': lineHeight,
     });
   }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2507,7 +2507,7 @@ mixin TextInputControl {
   /// changes.
   @Deprecated(
     'Use updateStyle instead. '
-    'This feature was deprecated after v3.40.0-0.2.pre.',
+    'This feature was deprecated after v3.41.0-0.0.pre.',
   )
   void setStyle({
     required String? fontFamily,

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1598,6 +1598,20 @@ final class TextInputStyle {
     );
   }
 
+  /// Returns a representation of this object as a JSON object.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'fontFamily': fontFamily,
+      'fontSize': fontSize,
+      'fontWeightIndex': fontWeight?.index,
+      'textAlignIndex': textAlign.index,
+      'textDirectionIndex': textDirection.index,
+      'letterSpacing': letterSpacing,
+      'wordSpacing': wordSpacing,
+      'lineHeight': lineHeight,
+    };
+  }
+
   @override
   String toString() {
     return 'TextInputStyle('
@@ -2676,16 +2690,7 @@ class _PlatformTextInputControl with TextInputControl {
 
   @override
   void updateStyle(TextInputStyle style) {
-    _channel.invokeMethod<void>('TextInput.setStyle', <String, dynamic>{
-      'fontFamily': style.fontFamily,
-      'fontSize': style.fontSize,
-      'fontWeightIndex': style.fontWeight?.index,
-      'textAlignIndex': style.textAlign.index,
-      'textDirectionIndex': style.textDirection.index,
-      'letterSpacing': style.letterSpacing,
-      'wordSpacing': style.wordSpacing,
-      'lineHeight': style.lineHeight,
-    });
+    _channel.invokeMethod<void>('TextInput.setStyle', style.toJson());
   }
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1540,14 +1540,29 @@ final class TextInputStyle {
     this.lineHeight,
   });
 
-
+  /// The name of the font to use when painting the text (e.g., Roboto).
   final String? fontFamily;
+
+  /// The size of fonts (in logical pixels) to use when painting the text.
   final double? fontSize;
+
+  /// The typeface thickness to use when painting the text (e.g., bold).
   final FontWeight? fontWeight;
+
+  /// The directionality of the text.
   final TextDirection textDirection;
+
+  /// How the text should be aligned horizontally.
   final TextAlign textAlign;
+
+  /// The amount of space (in logical pixels) to add between each letter.
   final double? letterSpacing;
+
+  /// The amount of space (in logical pixels) to add at each sequence of
+  /// white-space (i.e. between each word).
   final double? wordSpacing;
+
+  /// The line height in logical pixels.
   final double? lineHeight;
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1746,16 +1746,6 @@ class TextInputConnection {
 
   /// Send text styling information.
   ///
-  /// This information is used by the Flutter Engine to change the style of the
-  /// hidden native input's content. Hence, the content size will match to the
-  /// size of the editable widget's content.
-  void updateStyle(TextInputStyle style) {
-    assert(attached);
-    TextInput._instance._updateStyle(style);
-  }
-
-  /// Send text styling information.
-  ///
   /// This information is used by the Flutter Web Engine to change the style
   /// of the hidden native input's content. Hence, the content size will match
   /// to the size of the editable widget's content.
@@ -1779,6 +1769,16 @@ class TextInputConnection {
         textAlign: textAlign,
       ),
     );
+  }
+
+  /// Send text styling information.
+  ///
+  /// This information is used by the Flutter Web Engine to change the style
+  /// of the hidden native input's content. Hence, the content size will match
+  /// to the size of the editable widget's content.
+  void updateStyle(TextInputStyle style) {
+    assert(attached);
+    TextInput._instance._updateStyle(style);
   }
 
   /// Stop interacting with the text input control.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1527,7 +1527,7 @@ mixin DeltaTextInputClient implements TextInputClient {
 ///  * [TextInputControl.updateStyle], which receives this style information
 ///    in custom text input controls.
 @immutable
-final class TextInputStyle {
+final class TextInputStyle with Diagnosticable {
   /// Creates text styling information for the current input client.
   const TextInputStyle({
     this.fontFamily,
@@ -1613,16 +1613,16 @@ final class TextInputStyle {
   }
 
   @override
-  String toString() {
-    return 'TextInputStyle('
-        'fontFamily: $fontFamily, '
-        'fontSize: $fontSize, '
-        'fontWeight: $fontWeight, '
-        'textDirection: $textDirection, '
-        'textAlign: $textAlign, '
-        'letterSpacing: $letterSpacing, '
-        'wordSpacing: $wordSpacing, '
-        'lineHeight: $lineHeight)';
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('fontFamily', fontFamily, defaultValue: null));
+    properties.add(DoubleProperty('fontSize', fontSize, defaultValue: null));
+    properties.add(DiagnosticsProperty<FontWeight>('fontWeight', fontWeight, defaultValue: null));
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection));
+    properties.add(EnumProperty<TextAlign>('textAlign', textAlign));
+    properties.add(DoubleProperty('letterSpacing', letterSpacing, defaultValue: null));
+    properties.add(DoubleProperty('wordSpacing', wordSpacing, defaultValue: null));
+    properties.add(DoubleProperty('lineHeight', lineHeight, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3409,12 +3409,15 @@ class EditableTextState extends State<EditableText>
           ? widget.style.merge(const TextStyle(fontWeight: FontWeight.bold))
           : widget.style;
       if (_hasInputConnection) {
-        _textInputConnection!.setStyle(
+        _textInputConnection!.setStyleWithMetrics(
           fontFamily: _style.fontFamily,
           fontSize: _style.fontSize,
           fontWeight: _style.fontWeight,
           textDirection: _textDirection,
           textAlign: widget.textAlign,
+          letterSpacing: _style.letterSpacing,
+          wordSpacing: _style.wordSpacing,
+          lineHeight: renderEditable.preferredLineHeight,
         );
       }
     }
@@ -3959,12 +3962,15 @@ class EditableTextState extends State<EditableText>
       _updateSizeAndTransform();
       _schedulePeriodicPostFrameCallbacks();
       _textInputConnection!
-        ..setStyle(
+        ..setStyleWithMetrics(
           fontFamily: _style.fontFamily,
           fontSize: _style.fontSize,
           fontWeight: _style.fontWeight,
           textDirection: _textDirection,
           textAlign: widget.textAlign,
+          letterSpacing: _style.letterSpacing,
+          wordSpacing: _style.wordSpacing,
+          lineHeight: renderEditable.preferredLineHeight,
         )
         ..setEditingState(localValue)
         ..show();
@@ -4029,12 +4035,15 @@ class EditableTextState extends State<EditableText>
 
     newConnection
       ..show()
-      ..setStyle(
+      ..setStyleWithMetrics(
         fontFamily: _style.fontFamily,
         fontSize: _style.fontSize,
         fontWeight: _style.fontWeight,
         textDirection: _textDirection,
         textAlign: widget.textAlign,
+        letterSpacing: _style.letterSpacing,
+        wordSpacing: _style.wordSpacing,
+        lineHeight: renderEditable.preferredLineHeight,
       )
       ..setEditingState(_value);
     _lastKnownRemoteTextEditingValue = _value;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3417,19 +3417,21 @@ class EditableTextState extends State<EditableText>
           }
           final double? letterSpacingOverride = MediaQuery.maybeLetterSpacingOverrideOf(context);
           final double? wordSpacingOverride = MediaQuery.maybeWordSpacingOverrideOf(context);
-          _textInputConnection!.setStyleWithMetrics(
-            fontFamily: _style.fontFamily,
-            fontSize: _style.fontSize,
-            fontWeight: _style.fontWeight,
-            textDirection: _textDirection,
-            textAlign: widget.textAlign,
-            letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
-            wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
-            // preferredLineHeight already includes lineHeightScaleFactor from
-            // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
-            lineHeight: renderEditable.preferredLineHeight,
+          _textInputConnection!.updateStyle(
+            TextInputStyle(
+              fontFamily: _style.fontFamily,
+              fontSize: _style.fontSize,
+              fontWeight: _style.fontWeight,
+              textDirection: _textDirection,
+              textAlign: widget.textAlign,
+              letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
+              wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
+              // preferredLineHeight already includes lineHeightScaleFactor from
+              // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
+              lineHeight: renderEditable.preferredLineHeight,
+            ),
           );
-        }, debugLabel: 'EditableText.setStyleWithMetrics');
+        }, debugLabel: 'EditableText.updateStyle');
       }
     }
 
@@ -3975,17 +3977,19 @@ class EditableTextState extends State<EditableText>
       final double? letterSpacingOverride = MediaQuery.maybeLetterSpacingOverrideOf(context);
       final double? wordSpacingOverride = MediaQuery.maybeWordSpacingOverrideOf(context);
       _textInputConnection!
-        ..setStyleWithMetrics(
-          fontFamily: _style.fontFamily,
-          fontSize: _style.fontSize,
-          fontWeight: _style.fontWeight,
-          textDirection: _textDirection,
-          textAlign: widget.textAlign,
-          letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
-          wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
-          // preferredLineHeight already includes lineHeightScaleFactor from
-          // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
-          lineHeight: renderEditable.preferredLineHeight,
+        ..updateStyle(
+          TextInputStyle(
+            fontFamily: _style.fontFamily,
+            fontSize: _style.fontSize,
+            fontWeight: _style.fontWeight,
+            textDirection: _textDirection,
+            textAlign: widget.textAlign,
+            letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
+            wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
+            // preferredLineHeight already includes lineHeightScaleFactor from
+            // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
+            lineHeight: renderEditable.preferredLineHeight,
+          ),
         )
         ..setEditingState(localValue)
         ..show();
@@ -4052,17 +4056,19 @@ class EditableTextState extends State<EditableText>
     final double? wordSpacingOverride = MediaQuery.maybeWordSpacingOverrideOf(context);
     newConnection
       ..show()
-      ..setStyleWithMetrics(
-        fontFamily: _style.fontFamily,
-        fontSize: _style.fontSize,
-        fontWeight: _style.fontWeight,
-        textDirection: _textDirection,
-        textAlign: widget.textAlign,
-        letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
-        wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
-        // preferredLineHeight already includes lineHeightScaleFactor from
-        // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
-        lineHeight: renderEditable.preferredLineHeight,
+      ..updateStyle(
+        TextInputStyle(
+          fontFamily: _style.fontFamily,
+          fontSize: _style.fontSize,
+          fontWeight: _style.fontWeight,
+          textDirection: _textDirection,
+          textAlign: widget.textAlign,
+          letterSpacing: letterSpacingOverride ?? _style.letterSpacing,
+          wordSpacing: wordSpacingOverride ?? _style.wordSpacing,
+          // preferredLineHeight already includes lineHeightScaleFactor from
+          // _OverridingTextStyleTextSpanUtils.applyTextSpacingOverrides.
+          lineHeight: renderEditable.preferredLineHeight,
+        ),
       )
       ..setEditingState(_value);
     _lastKnownRemoteTextEditingValue = _value;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3986,8 +3986,8 @@ class EditableTextState extends State<EditableText>
       _updateSizeAndTransform();
       _schedulePeriodicPostFrameCallbacks();
       _textInputConnection!
-        ..setEditingState(localValue)
         ..updateStyle(_getTextInputStyle())
+        ..setEditingState(localValue)
         ..show();
       if (_needsAutofill) {
         // Request autofill AFTER the size and the transform have been sent to

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3305,7 +3305,7 @@ class EditableTextState extends State<EditableText>
         if (!mounted || !_hasInputConnection) {
           return;
         }
-        _textInputConnection!.updateStyle(_getTextInputStyle());
+        _textInputConnection!.updateStyle(_getTextInputStyle(context));
       }, debugLabel: 'EditableText.updateStyle');
     }
 
@@ -3423,7 +3423,7 @@ class EditableTextState extends State<EditableText>
           if (!mounted || !_hasInputConnection) {
             return;
           }
-          _textInputConnection!.updateStyle(_getTextInputStyle());
+          _textInputConnection!.updateStyle(_getTextInputStyle(context));
         }, debugLabel: 'EditableText.updateStyle');
       }
     }
@@ -3447,7 +3447,7 @@ class EditableTextState extends State<EditableText>
     }
   }
 
-  TextInputStyle _getTextInputStyle() {
+  TextInputStyle _getTextInputStyle(BuildContext context) {
     final double? letterSpacingOverride = MediaQuery.maybeLetterSpacingOverrideOf(context);
     final double? wordSpacingOverride = MediaQuery.maybeWordSpacingOverrideOf(context);
 
@@ -3986,7 +3986,7 @@ class EditableTextState extends State<EditableText>
       _updateSizeAndTransform();
       _schedulePeriodicPostFrameCallbacks();
       _textInputConnection!
-        ..updateStyle(_getTextInputStyle())
+        ..updateStyle(_getTextInputStyle(context))
         ..setEditingState(localValue)
         ..show();
       if (_needsAutofill) {
@@ -4050,7 +4050,7 @@ class EditableTextState extends State<EditableText>
 
     newConnection
       ..show()
-      ..updateStyle(_getTextInputStyle())
+      ..updateStyle(_getTextInputStyle(context))
       ..setEditingState(_value);
     _lastKnownRemoteTextEditingValue = _value;
   }

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -1352,14 +1352,14 @@ void main() {
       expect(sentList[0][5], TextDirection.rtl.index); // direction
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setSelectionRects');
 
-      connection.setStyle(
+      connection.setStyleWithMetrics(
         fontFamily: null,
         fontSize: null,
         fontWeight: null,
         textDirection: TextDirection.ltr,
         textAlign: TextAlign.left,
       );
-      expectedMethodCalls.add('setStyle');
+      expectedMethodCalls.add('setStyleWithMetrics');
       expect(control.methodCalls, expectedMethodCalls);
       expect(fakeTextChannel.outgoingCalls.length, 9);
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setStyle');
@@ -1610,6 +1610,20 @@ class FakeTextInputControl with TextInputControl {
     required TextAlign textAlign,
   }) {
     methodCalls.add('setStyle');
+  }
+
+  @override
+  void setStyleWithMetrics({
+    required String? fontFamily,
+    required double? fontSize,
+    required FontWeight? fontWeight,
+    required TextDirection textDirection,
+    required TextAlign textAlign,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? lineHeight,
+  }) {
+    methodCalls.add('setStyleWithMetrics');
   }
 
   @override

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -1353,10 +1353,7 @@ void main() {
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setSelectionRects');
 
       connection.updateStyle(
-        const TextInputStyle(
-          textDirection: TextDirection.ltr,
-          textAlign: TextAlign.left,
-        ),
+        const TextInputStyle(textDirection: TextDirection.ltr, textAlign: TextAlign.left),
       );
       expectedMethodCalls.add('updateStyle');
       expect(control.methodCalls, expectedMethodCalls);

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -1352,14 +1352,13 @@ void main() {
       expect(sentList[0][5], TextDirection.rtl.index); // direction
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setSelectionRects');
 
-      connection.setStyleWithMetrics(
-        fontFamily: null,
-        fontSize: null,
-        fontWeight: null,
-        textDirection: TextDirection.ltr,
-        textAlign: TextAlign.left,
+      connection.updateStyle(
+        const TextInputStyle(
+          textDirection: TextDirection.ltr,
+          textAlign: TextAlign.left,
+        ),
       );
-      expectedMethodCalls.add('setStyleWithMetrics');
+      expectedMethodCalls.add('updateStyle');
       expect(control.methodCalls, expectedMethodCalls);
       expect(fakeTextChannel.outgoingCalls.length, 9);
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setStyle');
@@ -1613,17 +1612,8 @@ class FakeTextInputControl with TextInputControl {
   }
 
   @override
-  void setStyleWithMetrics({
-    required String? fontFamily,
-    required double? fontSize,
-    required FontWeight? fontWeight,
-    required TextDirection textDirection,
-    required TextAlign textAlign,
-    double? letterSpacing,
-    double? wordSpacing,
-    double? lineHeight,
-  }) {
-    methodCalls.add('setStyleWithMetrics');
+  void updateStyle(TextInputStyle style) {
+    methodCalls.add('updateStyle');
   }
 
   @override

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -1461,6 +1461,91 @@ void main() {
     expect(diagnosticsNodes.first.name, 'title');
     expect(diagnosticsNodes.first.value, title);
   });
+
+  group('TextInputStyle', () {
+    const style1 = TextInputStyle(
+      fontFamily: 'Roboto',
+      fontSize: 16.0,
+      fontWeight: FontWeight.bold,
+      textDirection: TextDirection.ltr,
+      textAlign: TextAlign.center,
+      letterSpacing: 1.2,
+      wordSpacing: 2.0,
+      lineHeight: 24.0,
+    );
+    const style2 = TextInputStyle(
+      fontFamily: 'Roboto',
+      fontSize: 16.0,
+      fontWeight: FontWeight.bold,
+      textDirection: TextDirection.ltr,
+      textAlign: TextAlign.center,
+      letterSpacing: 1.2,
+      wordSpacing: 2.0,
+      lineHeight: 24.0,
+    );
+    const style3 = TextInputStyle(
+      fontFamily: 'Other',
+      fontSize: 16.0,
+      fontWeight: FontWeight.bold,
+      textDirection: TextDirection.ltr,
+      textAlign: TextAlign.center,
+    );
+
+    test('equality operator works correctly', () {
+      expect(style1, equals(style2));
+      expect(style1.hashCode, equals(style2.hashCode));
+      expect(style1, isNot(equals(style3)));
+
+      expect(style1.fontFamily, equals(style2.fontFamily));
+      expect(style1.fontSize, equals(style2.fontSize));
+      expect(style1.fontWeight, equals(style2.fontWeight));
+      expect(style1.textDirection, equals(style2.textDirection));
+      expect(style1.textAlign, equals(style2.textAlign));
+      expect(style1.letterSpacing, equals(style2.letterSpacing));
+      expect(style1.wordSpacing, equals(style2.wordSpacing));
+      expect(style1.lineHeight, equals(style2.lineHeight));
+    });
+
+    test('hashCode works correctly', () {
+      expect(style1.hashCode, equals(style2.hashCode));
+
+      expect(style1.fontFamily.hashCode, equals(style2.fontFamily.hashCode));
+      expect(style1.fontSize.hashCode, equals(style2.fontSize.hashCode));
+      expect(style1.fontWeight.hashCode, equals(style2.fontWeight.hashCode));
+      expect(style1.textDirection.hashCode, equals(style2.textDirection.hashCode));
+      expect(style1.textAlign.hashCode, equals(style2.textAlign.hashCode));
+      expect(style1.letterSpacing.hashCode, equals(style2.letterSpacing.hashCode));
+      expect(style1.wordSpacing.hashCode, equals(style2.wordSpacing.hashCode));
+      expect(style1.lineHeight.hashCode, equals(style2.lineHeight.hashCode));
+    });
+
+    test('toJson produces expected map', () {
+      final Map<String, dynamic> json = style1.toJson();
+
+      expect(json['fontFamily'], 'Roboto');
+      expect(json['fontSize'], 16.0);
+      expect(json['fontWeightIndex'], FontWeight.bold.index);
+      expect(json['textAlignIndex'], TextAlign.center.index);
+      expect(json['textDirectionIndex'], TextDirection.ltr.index);
+      expect(json['letterSpacing'], 1.2);
+      expect(json['wordSpacing'], 2.0);
+      expect(json['lineHeight'], 24.0);
+    });
+
+    test('toJson handles null values', () {
+      const style = TextInputStyle(textDirection: TextDirection.ltr, textAlign: TextAlign.left);
+      final Map<String, dynamic> json = style.toJson();
+
+      expect(json['fontFamily'], isNull);
+      expect(json['fontSize'], isNull);
+      expect(json['fontWeightIndex'], isNull);
+      expect(json['letterSpacing'], isNull);
+      expect(json['wordSpacing'], isNull);
+      expect(json['lineHeight'], isNull);
+      expect(json['textAlignIndex'], TextAlign.left.index);
+      expect(json['textDirectionIndex'], TextDirection.ltr.index);
+    });
+  });
 }
 
 class FakeTextInputClient with TextInputClient {

--- a/packages/flutter/test/widgets/editable_text_styles_test.dart
+++ b/packages/flutter/test/widgets/editable_text_styles_test.dart
@@ -1,0 +1,285 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeTextInputControl with TextInputControl {
+  TextInputStyle? lastStyle;
+  final List<String> methodCalls = <String>[];
+
+  @override
+  void attach(TextInputClient client, TextInputConfiguration configuration) {
+    methodCalls.add('attach');
+  }
+
+  @override
+  void detach(TextInputClient client) {
+    methodCalls.add('detach');
+  }
+
+  @override
+  void setEditingState(TextEditingValue value) {}
+
+  @override
+  void updateConfig(TextInputConfiguration configuration) {}
+
+  @override
+  void show() {}
+
+  @override
+  void hide() {}
+
+  @override
+  void setComposingRect(Rect rect) {}
+
+  @override
+  void setCaretRect(Rect rect) {}
+
+  @override
+  void setEditableSizeAndTransform(Size editableBoxSize, Matrix4 transform) {}
+
+  @override
+  void setSelectionRects(List<SelectionRect> selectionRects) {}
+
+  @override
+  void setStyle({
+    required String? fontFamily,
+    required double? fontSize,
+    required FontWeight? fontWeight,
+    required TextDirection textDirection,
+    required TextAlign textAlign,
+  }) {}
+
+  @override
+  void updateStyle(TextInputStyle style) {
+    lastStyle = style;
+    methodCalls.add('updateStyle');
+  }
+
+  @override
+  void finishAutofillContext({bool shouldSave = true}) {}
+
+  @override
+  void requestAutofill() {}
+}
+
+void main() {
+  testWidgets('EditableText updates style when boldText changes', (WidgetTester tester) async {
+    final control = FakeTextInputControl();
+    TextInput.setInputControl(control);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(fontWeight: FontWeight.normal),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle?.fontWeight, FontWeight.normal);
+    control.lastStyle = null; // Reset
+
+    // Update boldText
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(boldText: true),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(fontWeight: FontWeight.normal),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle?.fontWeight, FontWeight.bold);
+
+    TextInput.restorePlatformInputControl();
+  });
+
+  testWidgets('EditableText updates style when letterSpacingOverride changes', (
+    WidgetTester tester,
+  ) async {
+    final control = FakeTextInputControl();
+    TextInput.setInputControl(control);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(letterSpacing: 1.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    expect(control.lastStyle?.letterSpacing, 1.0);
+    control.lastStyle = null;
+
+    // Update letterSpacingOverride
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(letterSpacingOverride: 5.0),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(letterSpacing: 1.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle?.letterSpacing, 5.0);
+
+    TextInput.restorePlatformInputControl();
+  });
+
+  testWidgets('EditableText updates style when wordSpacingOverride changes', (
+    WidgetTester tester,
+  ) async {
+    final control = FakeTextInputControl();
+    TextInput.setInputControl(control);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(wordSpacing: 2.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    expect(control.lastStyle?.wordSpacing, 2.0);
+    control.lastStyle = null;
+
+    // Update wordSpacingOverride
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(wordSpacingOverride: 10.0),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(wordSpacing: 2.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle?.wordSpacing, 10.0);
+
+    TextInput.restorePlatformInputControl();
+  });
+
+  testWidgets('EditableText updates style when lineHeightScaleFactorOverride changes', (
+    WidgetTester tester,
+  ) async {
+    final control = FakeTextInputControl();
+    TextInput.setInputControl(control);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(lineHeightScaleFactorOverride: 1.0),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(fontSize: 20.0, height: 1.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle!.lineHeight, 20.0);
+    control.lastStyle = null;
+
+    // Update lineHeightScaleFactorOverride to 2.0
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(lineHeightScaleFactorOverride: 2.0),
+          child: Material(
+            child: EditableText(
+              controller: TextEditingController(),
+              focusNode: FocusNode(),
+              style: const TextStyle(fontSize: 20.0, height: 1.0),
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(control.lastStyle, isNotNull);
+    expect(control.lastStyle!.lineHeight, 40.0);
+
+    TextInput.restorePlatformInputControl();
+  });
+}

--- a/packages/flutter/test/widgets/editable_text_styles_test.dart
+++ b/packages/flutter/test/widgets/editable_text_styles_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeTextInputControl with TextInputControl {
@@ -67,22 +67,35 @@ class FakeTextInputControl with TextInputControl {
 }
 
 void main() {
-  testWidgets('EditableText updates style when boldText changes', (WidgetTester tester) async {
-    final control = FakeTextInputControl();
-    TextInput.setInputControl(control);
+  late FakeTextInputControl control;
+  late TextEditingController controller;
+  late FocusNode focusNode;
 
+  setUp(() {
+    control = FakeTextInputControl();
+    TextInput.setInputControl(control);
+    controller = TextEditingController();
+    focusNode = FocusNode();
+  });
+
+  tearDown(() {
+    TextInput.restorePlatformInputControl();
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('EditableText updates style when boldText changes', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(fontWeight: FontWeight.normal),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(fontWeight: FontWeight.normal),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -97,17 +110,16 @@ void main() {
 
     // Update boldText
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(boldText: true),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(fontWeight: FontWeight.normal),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(boldText: true),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(fontWeight: FontWeight.normal),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -116,28 +128,22 @@ void main() {
 
     expect(control.lastStyle, isNotNull);
     expect(control.lastStyle?.fontWeight, FontWeight.bold);
-
-    TextInput.restorePlatformInputControl();
   });
 
   testWidgets('EditableText updates style when letterSpacingOverride changes', (
     WidgetTester tester,
   ) async {
-    final control = FakeTextInputControl();
-    TextInput.setInputControl(control);
-
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(letterSpacing: 1.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(letterSpacing: 1.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -151,17 +157,16 @@ void main() {
 
     // Update letterSpacingOverride
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(letterSpacingOverride: 5.0),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(letterSpacing: 1.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(letterSpacingOverride: 5.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(letterSpacing: 1.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -170,28 +175,22 @@ void main() {
 
     expect(control.lastStyle, isNotNull);
     expect(control.lastStyle?.letterSpacing, 5.0);
-
-    TextInput.restorePlatformInputControl();
   });
 
   testWidgets('EditableText updates style when wordSpacingOverride changes', (
     WidgetTester tester,
   ) async {
-    final control = FakeTextInputControl();
-    TextInput.setInputControl(control);
-
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(wordSpacing: 2.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(wordSpacing: 2.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -205,17 +204,16 @@ void main() {
 
     // Update wordSpacingOverride
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(wordSpacingOverride: 10.0),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(wordSpacing: 2.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(wordSpacingOverride: 10.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(wordSpacing: 2.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -224,28 +222,22 @@ void main() {
 
     expect(control.lastStyle, isNotNull);
     expect(control.lastStyle?.wordSpacing, 10.0);
-
-    TextInput.restorePlatformInputControl();
   });
 
   testWidgets('EditableText updates style when lineHeightScaleFactorOverride changes', (
     WidgetTester tester,
   ) async {
-    final control = FakeTextInputControl();
-    TextInput.setInputControl(control);
-
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(lineHeightScaleFactorOverride: 1.0),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(fontSize: 20.0, height: 1.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(lineHeightScaleFactorOverride: 1.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(fontSize: 20.0, height: 1.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -260,17 +252,16 @@ void main() {
 
     // Update lineHeightScaleFactorOverride to 2.0
     await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(lineHeightScaleFactorOverride: 2.0),
-          child: Material(
-            child: EditableText(
-              controller: TextEditingController(),
-              focusNode: FocusNode(),
-              style: const TextStyle(fontSize: 20.0, height: 1.0),
-              cursorColor: Colors.blue,
-              backgroundCursorColor: Colors.grey,
-            ),
+      MediaQuery(
+        data: const MediaQueryData(lineHeightScaleFactorOverride: 2.0),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(fontSize: 20.0, height: 1.0),
+            cursorColor: const Color(0xFF000000),
+            backgroundCursorColor: const Color(0xFF000000),
           ),
         ),
       ),
@@ -279,7 +270,5 @@ void main() {
 
     expect(control.lastStyle, isNotNull);
     expect(control.lastStyle!.lineHeight, 40.0);
-
-    TextInput.restorePlatformInputControl();
   });
 }

--- a/packages/flutter/test/widgets/editable_text_styles_test.dart
+++ b/packages/flutter/test/widgets/editable_text_styles_test.dart
@@ -106,9 +106,9 @@ void main() {
 
     expect(control.lastStyle, isNotNull);
     expect(control.lastStyle?.fontWeight, FontWeight.normal);
-    control.lastStyle = null; // Reset
+    control.lastStyle = null; // Reset.
 
-    // Update boldText
+    // Update boldText.
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(boldText: true),
@@ -155,7 +155,7 @@ void main() {
     expect(control.lastStyle?.letterSpacing, 1.0);
     control.lastStyle = null;
 
-    // Update letterSpacingOverride
+    // Update letterSpacingOverride.
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(letterSpacingOverride: 5.0),
@@ -202,7 +202,7 @@ void main() {
     expect(control.lastStyle?.wordSpacing, 2.0);
     control.lastStyle = null;
 
-    // Update wordSpacingOverride
+    // Update wordSpacingOverride.
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(wordSpacingOverride: 10.0),
@@ -250,7 +250,7 @@ void main() {
     expect(control.lastStyle!.lineHeight, 20.0);
     control.lastStyle = null;
 
-    // Update lineHeightScaleFactorOverride to 2.0
+    // Update lineHeightScaleFactorOverride to 2.0.
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(lineHeightScaleFactorOverride: 2.0),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5729,6 +5729,8 @@ void main() {
       fontSize: 20.0,
       fontFamily: 'Raleway',
       fontWeight: FontWeight.w700,
+      letterSpacing: 1.0,
+      wordSpacing: 2.0,
     );
     var currentTextStyle = textStyle1;
 
@@ -5790,8 +5792,8 @@ void main() {
           'fontWeightIndex': 6,
           'textAlignIndex': 4,
           'textDirectionIndex': 1,
-          'letterSpacing': null,
-          'wordSpacing': null,
+          'letterSpacing': 1.0,
+          'wordSpacing': 2.0,
           'lineHeight': 20.0,
         },
       ),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5664,6 +5664,9 @@ void main() {
           'fontWeightIndex': 5,
           'textAlignIndex': 4,
           'textDirectionIndex': 0,
+          'letterSpacing': null,
+          'wordSpacing': null,
+          'lineHeight': 20.0,
         },
       ),
     );
@@ -5706,6 +5709,9 @@ void main() {
           'fontWeightIndex': FontWeight.bold.index,
           'textAlignIndex': 4,
           'textDirectionIndex': 0,
+          'letterSpacing': null,
+          'wordSpacing': null,
+          'lineHeight': 20.0,
         },
       ),
     );
@@ -5784,6 +5790,9 @@ void main() {
           'fontWeightIndex': 6,
           'textAlignIndex': 4,
           'textDirectionIndex': 1,
+          'letterSpacing': null,
+          'wordSpacing': null,
+          'lineHeight': 20.0,
         },
       ),
     );


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/161592

The current implementation does not fully reflect [letter-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/letter-spacing), [word-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/word-spacing), and [line-height](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/line-height) in the DOM. 0bc99f8c4f70973a1877c88ca35804e9bc5fabcf
And the current implementation generates an DomHTMLTextAreaElement every time the `enabled`. Therefore, it reapplies the [scrollTop](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop) value that the Element had been holding internally. 726491298d2b1f17681cab421c7c9276dde19ee6

https://github.com/user-attachments/assets/6f575366-12a0-4246-b2ab-eb2a0e85cfa5

https://github.com/user-attachments/assets/ec660d4c-5166-450c-be38-77b90fcfce76

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MainApp());

class MainApp extends StatelessWidget {
  const MainApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(home: MainPage());
  }
}

class MainPage extends StatelessWidget {
  const MainPage({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Selection position')),
      body: SingleChildScrollView(
        padding: const .all(16),
        child: Column(
          children: [
            const Text('height=null'),
            TextField(maxLines: 5, style: TextStyle(height: null)),
            const Text('height=1.0'),
            TextField(maxLines: 5, style: TextStyle(height: 1.0)),
            const Text('height=2.0'),
            TextField(maxLines: 5, style: TextStyle(height: 2.0)),
          ],
        ),
      ),
    );
  }
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
