### PR TITLE
Add SK_SUPPORT_LEGACY_UNSPANNED_GRADIENTS to SkUserConfig.h

### DIFF
--- a/engine/src/flutter/skia/flutter_defines.gni
+++ b/engine/src/flutter/skia/flutter_defines.gni
@@ -13,6 +13,7 @@ flutter_defines = [
   "SK_DISABLE_LEGACY_PNG_WRITEBUFFER",
   "SK_DISABLE_LEGACY_IMAGE_READBUFFER",
   "SK_HIDE_PATH_EDIT_METHODS",
+  "SK_SUPPORT_LEGACY_UNSPANNED_GRADIENTS",
 
   # Fast low-precision software rendering isn't a priority for Flutter.
   "SK_DISABLE_LEGACY_SHADERCONTEXT",


### PR DESCRIPTION
Skia is planning to remove some deprecated gradient factory methods. Add a define to keep them until they are no longer used.