### PR TITLE
Add isFlexible Parameter to Flexible and Expanded for Conditional Flex Participation

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -28,7 +28,7 @@ import 'dart:ui'
         StringAttribute,
         TextDirection,
         Tristate;
-import 'dart:ui' as ui show SemanticsHitTestBehavior;
+import 'package:flutter/rendering.dart' show HitTestBehavior;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -1335,7 +1335,7 @@ class SemanticsData with Diagnosticable {
   final SemanticsValidationResult validationResult;
 
   /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
-  final ui.SemanticsHitTestBehavior hitTestBehavior;
+  final HitTestBehavior hitTestBehavior;
 
   /// {@macro flutter.semantics.SemanticsNode.inputType}
   final SemanticsInputType inputType;
@@ -2626,9 +2626,9 @@ class SemanticsProperties extends DiagnosticableTree {
   /// {@template flutter.semantics.SemanticsProperties.hitTestBehavior}
   /// Describes how the semantic node should behave during hit testing.
   ///
-  /// See [ui.SemanticsHitTestBehavior] for more details.
+  /// See [HitTestBehavior] for more details.
   /// {@endtemplate}
-  final ui.SemanticsHitTestBehavior? hitTestBehavior;
+  final HitTestBehavior? hitTestBehavior;
 
   /// {@template flutter.semantics.SemanticsProperties.inputType}
   /// The input type for of a editable widget.
@@ -3640,8 +3640,8 @@ class SemanticsNode with DiagnosticableTreeMixin {
   SemanticsValidationResult _validationResult = _kEmptyConfig.validationResult;
 
   /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
-  ui.SemanticsHitTestBehavior get hitTestBehavior => _hitTestBehavior;
-  ui.SemanticsHitTestBehavior _hitTestBehavior = ui.SemanticsHitTestBehavior.defer;
+  HitTestBehavior get hitTestBehavior => _hitTestBehavior;
+  HitTestBehavior _hitTestBehavior = HitTestBehavior.deferToChild;
 
   /// {@template flutter.semantics.SemanticsNode.inputType}
   /// The input type for of a editable node.
@@ -3780,7 +3780,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     SemanticsRole role = _role;
     Set<String>? controlsNodes = _controlsNodes;
     SemanticsValidationResult validationResult = _validationResult;
-    ui.SemanticsHitTestBehavior hitTestBehavior = _hitTestBehavior;
+    HitTestBehavior hitTestBehavior = _hitTestBehavior;
     SemanticsInputType inputType = _inputType;
     final Locale? locale = _locale;
     final customSemanticsActionIds = <int>{};
@@ -3847,7 +3847,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
         if (inputType == SemanticsInputType.none) {
           inputType = node._inputType;
         }
-        if (hitTestBehavior == ui.SemanticsHitTestBehavior.defer) {
+        if (hitTestBehavior == HitTestBehavior.deferToChild) {
           hitTestBehavior = node._hitTestBehavior;
         }
         if (tooltip == '') {
@@ -6547,9 +6547,9 @@ class SemanticsConfiguration {
   }
 
   /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
-  ui.SemanticsHitTestBehavior get hitTestBehavior => _hitTestBehavior;
-  ui.SemanticsHitTestBehavior _hitTestBehavior = ui.SemanticsHitTestBehavior.defer;
-  set hitTestBehavior(ui.SemanticsHitTestBehavior value) {
+  HitTestBehavior get hitTestBehavior => _hitTestBehavior;
+  HitTestBehavior _hitTestBehavior = HitTestBehavior.deferToChild;
+  set hitTestBehavior(HitTestBehavior value) {
     _hitTestBehavior = value;
     _hasBeenAnnotated = true;
   }
@@ -6681,8 +6681,8 @@ class SemanticsConfiguration {
     if (_hasExplicitRole && other._hasExplicitRole) {
       return false;
     }
-    if (_hitTestBehavior != ui.SemanticsHitTestBehavior.defer ||
-        other._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+    if (_hitTestBehavior != HitTestBehavior.deferToChild ||
+        other._hitTestBehavior != HitTestBehavior.deferToChild) {
       return false;
     }
     if (_minValue != null && other._minValue != null) {
@@ -6803,8 +6803,8 @@ class SemanticsConfiguration {
     _minValue ??= child._minValue;
     _maxValue ??= child._maxValue;
 
-    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer &&
-        child._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+    if (_hitTestBehavior == HitTestBehavior.deferToChild &&
+        child._hitTestBehavior != HitTestBehavior.deferToChild) {
       _hitTestBehavior = child._hitTestBehavior;
     }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6045,7 +6045,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
     super.key,
     this.flex = 1,
     this.fit = FlexFit.loose,
-    this.visible = true,
+    this.isFlexible = true,
     required super.child,
   });
 
@@ -6066,18 +6066,19 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   /// space (but is allowed to be smaller).
   final FlexFit fit;
 
-  /// Whether this flexible child participates in flex layout.
+  /// Whether this child participates in flex layout.
   ///
   /// If true, the child participates in flex layout according to [flex] and [fit].
-  /// If false, the child behaves as an inflexible child that determines its own size.
+  /// If false, the child becomes inflexible and takes its natural size without
+  /// expanding to fill available space.
   ///
   /// This can be useful for conditionally applying flex behavior based on screen
   /// size, device type, or other runtime conditions.
   ///
   /// {@tool dartpad}
-  /// This example shows how to use the [visible] parameter to conditionally
-  /// apply flex behavior. The flexible widget will only expand when [visible]
-  /// is true, otherwise it behaves like a regular child widget.
+  /// This example shows how to use the [isFlexible] parameter to conditionally
+  /// apply flex behavior. The flexible widget will only expand when [isFlexible]
+  /// is true, otherwise it takes its natural size.
   ///
   /// ```dart
   /// Row(
@@ -6087,7 +6088,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   ///
   ///     // This child will only expand on wide screens
   ///     Flexible(
-  ///       visible: MediaQuery.of(context).size.width > 600,
+  ///       isFlexible: MediaQuery.of(context).size.width > 600,
   ///       child: Container(height: 50, color: Colors.red),
   ///     ),
   ///
@@ -6099,7 +6100,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   /// )
   /// ```
   /// {@end-tool}
-  final bool visible;
+  final bool isFlexible;
 
   @override
   void applyParentData(RenderObject renderObject) {
@@ -6107,7 +6108,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
     final parentData = renderObject.parentData! as FlexParentData;
     var needsLayout = false;
 
-    final effectiveFlex = visible ? flex : 0;
+    final effectiveFlex = isFlexible ? flex : 0;
     if (parentData.flex != effectiveFlex) {
       parentData.flex = effectiveFlex;
       needsLayout = true;
@@ -6130,7 +6131,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(IntProperty('flex', flex));
-    properties.add(DiagnosticsProperty<bool>('visible', visible));
+    properties.add(DiagnosticsProperty<bool>('isFlexible', isFlexible));
   }
 }
 
@@ -6168,9 +6169,9 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// This example shows how to use the [visible] parameter with [Expanded] to
+/// This example shows how to use the [isFlexible] parameter with [Expanded] to
 /// conditionally expand children based on screen size or other conditions.
-/// When [visible] is false, the child behaves as a regular inflexible widget.
+/// When [isFlexible] is false, the child becomes inflexible and takes its natural size.
 ///
 /// ```dart
 /// class ResponsiveLayout extends StatelessWidget {
@@ -6191,7 +6192,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 ///
 ///         // Content area that only expands on wide screens
 ///         Expanded(
-///           visible: isWideScreen,
+///           isFlexible: isWideScreen,
 ///           child: Container(
 ///             height: 100,
 ///             color: Colors.green,
@@ -6223,7 +6224,7 @@ class Expanded extends Flexible {
   /// Creates a widget that expands a child of a [Row], [Column], or [Flex]
   /// so that the child fills the available space along the flex widget's
   /// main axis.
-  const Expanded({super.key, super.flex, super.visible, required super.child})
+  const Expanded({super.key, super.flex, super.isFlexible, required super.child})
     : super(fit: FlexFit.tight);
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6041,7 +6041,13 @@ class Column extends Flex {
 class Flexible extends ParentDataWidget<FlexParentData> {
   /// Creates a widget that controls how a child of a [Row], [Column], or [Flex]
   /// flexes.
-  const Flexible({super.key, this.flex = 1, this.fit = FlexFit.loose, required super.child});
+  const Flexible({
+    super.key,
+    this.flex = 1,
+    this.fit = FlexFit.loose,
+    this.visible = true,
+    required super.child,
+  });
 
   /// The flex factor to use for this child.
   ///
@@ -6060,14 +6066,50 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   /// space (but is allowed to be smaller).
   final FlexFit fit;
 
+  /// Whether this flexible child participates in flex layout.
+  ///
+  /// If true, the child participates in flex layout according to [flex] and [fit].
+  /// If false, the child behaves as an inflexible child that determines its own size.
+  ///
+  /// This can be useful for conditionally applying flex behavior based on screen
+  /// size, device type, or other runtime conditions.
+  ///
+  /// {@tool dartpad}
+  /// This example shows how to use the [visible] parameter to conditionally
+  /// apply flex behavior. The flexible widget will only expand when [visible]
+  /// is true, otherwise it behaves like a regular child widget.
+  ///
+  /// ```dart
+  /// Row(
+  ///   children: [
+  ///     // This child will always take its natural size
+  ///     Container(width: 100, height: 50, color: Colors.blue),
+  ///
+  ///     // This child will only expand on wide screens
+  ///     Flexible(
+  ///       visible: MediaQuery.of(context).size.width > 600,
+  ///       child: Container(height: 50, color: Colors.red),
+  ///     ),
+  ///
+  ///     // This child will always expand
+  ///     Flexible(
+  ///       child: Container(height: 50, color: Colors.green),
+  ///     ),
+  ///   ],
+  /// )
+  /// ```
+  /// {@end-tool}
+  final bool visible;
+
   @override
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is FlexParentData);
     final parentData = renderObject.parentData! as FlexParentData;
     var needsLayout = false;
 
-    if (parentData.flex != flex) {
-      parentData.flex = flex;
+    final effectiveFlex = visible ? flex : 0;
+    if (parentData.flex != effectiveFlex) {
+      parentData.flex = effectiveFlex;
       needsLayout = true;
     }
 
@@ -6088,6 +6130,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(IntProperty('flex', flex));
+    properties.add(DiagnosticsProperty<bool>('visible', visible));
   }
 }
 
@@ -6124,6 +6167,53 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 /// ** See code in examples/api/lib/widgets/basic/expanded.1.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows how to use the [visible] parameter with [Expanded] to
+/// conditionally expand children based on screen size or other conditions.
+/// When [visible] is false, the child behaves as a regular inflexible widget.
+///
+/// ```dart
+/// class ResponsiveLayout extends StatelessWidget {
+///   @override
+///   Widget build(BuildContext context) {
+///     final screenWidth = MediaQuery.of(context).size.width;
+///     final isWideScreen = screenWidth > 600;
+///
+///     return Row(
+///       children: [
+///         // Fixed width sidebar
+///         Container(
+///           width: 200,
+///           height: 100,
+///           color: Colors.blue,
+///           child: Center(child: Text('Sidebar')),
+///         ),
+///
+///         // Content area that only expands on wide screens
+///         Expanded(
+///           visible: isWideScreen,
+///           child: Container(
+///             height: 100,
+///             color: Colors.green,
+///             child: Center(child: Text('Content')),
+///           ),
+///         ),
+///
+///         // This always expands to fill remaining space
+///         Expanded(
+///           child: Container(
+///             height: 100,
+///             color: Colors.orange,
+///             child: Center(child: Text('Always Expanded')),
+///           ),
+///         ),
+///       ],
+///     );
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [Flexible], which does not force the child to fill the available space.
@@ -6133,7 +6223,8 @@ class Expanded extends Flexible {
   /// Creates a widget that expands a child of a [Row], [Column], or [Flex]
   /// so that the child fills the available space along the flex widget's
   /// main axis.
-  const Expanded({super.key, super.flex, required super.child}) : super(fit: FlexFit.tight);
+  const Expanded({super.key, super.flex, super.visible, required super.child})
+    : super(fit: FlexFit.tight);
 }
 
 /// A widget that displays its children in multiple horizontal or vertical runs.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6108,7 +6108,7 @@ class Flexible extends ParentDataWidget<FlexParentData> {
     final parentData = renderObject.parentData! as FlexParentData;
     var needsLayout = false;
 
-    final effectiveFlex = isFlexible ? flex : 0;
+    final int effectiveFlex = isFlexible ? flex : 0;
     if (parentData.flex != effectiveFlex) {
       parentData.flex = effectiveFlex;
       needsLayout = true;
@@ -6126,13 +6126,6 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 
   @override
   Type get debugTypicalAncestorWidgetClass => Flex;
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(IntProperty('flex', flex));
-    properties.add(DiagnosticsProperty<bool>('isFlexible', isFlexible));
-  }
 }
 
 /// A widget that expands a child of a [Row], [Column], or [Flex]

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6175,6 +6175,8 @@ class Flexible extends ParentDataWidget<FlexParentData> {
 ///
 /// ```dart
 /// class ResponsiveLayout extends StatelessWidget {
+///   const ResponsiveLayout({super.key});
+///
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     final screenWidth = MediaQuery.of(context).size.width;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -9,9 +9,7 @@
 library;
 
 import 'dart:math' as math;
-import 'dart:ui'
-    as ui
-    show Image, ImageFilter, SemanticsHitTestBehavior, SemanticsInputType, TextHeightBehavior;
+import 'dart:ui' as ui show Image, ImageFilter, SemanticsInputType, TextHeightBehavior;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -4105,7 +4103,7 @@ sealed class _SemanticsBase extends SingleChildRenderObjectWidget {
     required SemanticsRole? role,
     required Set<String>? controlsNodes,
     required SemanticsValidationResult validationResult,
-    required ui.SemanticsHitTestBehavior? hitTestBehavior,
+    required HitTestBehavior? hitTestBehavior,
     required ui.SemanticsInputType? inputType,
     required Locale? localeForSubtree,
     required String? minValue,


### PR DESCRIPTION
### Add isFlexible Parameter to Flexible and Expanded for Conditional Flex Participation
Resolves: #168365

This PR introduces an optional **bool isFlexible** parameter (defaulting to **true**) to **Flexible** and **Expanded**. When **isFlexible: false**, the widget completely removes its child from the flex layout — the child takes zero space and does not participate in flex distribution at all.
This provides a clean, declarative way to conditionally include or exclude a child from a **Row**, **Column**, or **Flex** layout without using ternary operators or wrapper widgets.

### Widgets Modified

**Flexible**
**Expanded** (which extends **Flexible**)

Behavior

**isFlexible: true** (default): Normal flex behavior.
**isFlexible: false**: The child is omitted from the layout entirely (equivalent to not including the widget at all in the flex children list). The child takes no space and does not receive any flex allocation.

Example Usage
Before (common responsive pattern):
```
isMobile
  ? Expanded(child: MyWidget())
  : const SizedBox.shrink()
```
After:
```
Expanded(
  isFlexible: isMobile,  // Only participates in layout on mobile
  child: MyWidget(),
)
```
```
Flexible(
  flex: 2,
  isFlexible: shouldBeFlexible,
  child: MyWidget(),
)
```
### Motivation

In responsive UIs, it's extremely common to show or hide parts of a **Row** or **Column** based on platform, screen size, orientation, or runtime state. The standard approach requires conditional widget construction (often with **SizedBox.shrink()** as a placeholder), which adds boilerplate, increases nesting, and can cause unnecessary rebuilds.

A **isFlexible** parameter allows developers to express intent directly on the widget itself, resulting in flatter, more readable, and more maintainable layout code.

### Impact

- Fully backward compatible (**isFlexible** defaults to **true**).
- Eliminates boilerplate in conditional flex layouts.
- Zero runtime overhead when **isFlexible: true**.
- When **isFlexible: false**, behaves exactly as if the widget were not present in the children list.
- Updated API documentation with **///** comments.
- Added tests verifying layout behavior for both **isFlexible: true** and **isFlexible: false**.

This pattern aligns with common UI conventions (e.g., **Visibility** widget) while being more efficient for flex-specific use cases.
