### PR TITLE
Add `TestTextField` and migrate tests

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2056,16 +2056,21 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay>
   Widget build(BuildContext context) {
     final Rect handleRect = _getHandleRect(widget.type, widget.preferredLineHeight);
 
-    // Make sure the GestureDetector is big enough to be easily interactive.
-    final Rect interactiveRect = handleRect.expandToInclude(
-      Rect.fromCircle(center: handleRect.center, radius: kMinInteractiveDimension / 2),
-    );
-    final padding = RelativeRect.fromLTRB(
-      math.max((interactiveRect.width - handleRect.width) / 2, 0),
-      math.max((interactiveRect.height - handleRect.height) / 2, 0),
-      math.max((interactiveRect.width - handleRect.width) / 2, 0),
-      math.max((interactiveRect.height - handleRect.height) / 2, 0),
-    );
+    // Make sure the GestureDetector is big enough to be easily interactive if
+    // the handleRect is not empty.
+    final Rect interactiveRect = handleRect.isEmpty
+        ? handleRect
+        : handleRect.expandToInclude(
+            Rect.fromCircle(center: handleRect.center, radius: kMinInteractiveDimension / 2),
+          );
+    final RelativeRect padding = interactiveRect.isEmpty
+        ? RelativeRect.fill
+        : RelativeRect.fromLTRB(
+            math.max((interactiveRect.width - handleRect.width) / 2, 0),
+            math.max((interactiveRect.height - handleRect.height) / 2, 0),
+            math.max((interactiveRect.width - handleRect.width) / 2, 0),
+            math.max((interactiveRect.height - handleRect.height) / 2, 0),
+          );
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       widget.type,

--- a/packages/flutter/test/cupertino/text_field_cursor_test.dart
+++ b/packages/flutter/test/cupertino/text_field_cursor_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+@TestOn('!chrome')
+library;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Cursor animates', (WidgetTester tester) async {
+    await tester.pumpWidget(const CupertinoApp(home: CupertinoTextField()));
+
+    final Finder textFinder = find.byType(CupertinoTextField);
+    await tester.tap(textFinder);
+    await tester.pump();
+
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+
+    expect(renderEditable.cursorColor!.opacity, 1.0);
+
+    var walltimeMicrosecond = 0;
+    var lastVerifiedOpacity = 1.0;
+
+    Future<void> verifyKeyFrame({required double opacity, required int at}) async {
+      const delta = 1;
+      assert(at - delta > walltimeMicrosecond);
+      await tester.pump(Duration(microseconds: at - delta - walltimeMicrosecond));
+
+      // Instead of verifying the opacity at each key frame, this function
+      // verifies the opacity immediately *before* each key frame to avoid
+      // fp precision issues.
+      expect(
+        renderEditable.cursorColor!.opacity,
+        closeTo(lastVerifiedOpacity, 0.01),
+        reason: 'opacity at ${at - delta} microseconds',
+      );
+
+      walltimeMicrosecond = at - delta;
+      lastVerifiedOpacity = opacity;
+    }
+
+    await verifyKeyFrame(opacity: 1.0, at: 500000);
+    await verifyKeyFrame(opacity: 0.75, at: 537500);
+    await verifyKeyFrame(opacity: 0.5, at: 575000);
+    await verifyKeyFrame(opacity: 0.25, at: 612500);
+    await verifyKeyFrame(opacity: 0.0, at: 650000);
+    await verifyKeyFrame(opacity: 0.0, at: 850000);
+    await verifyKeyFrame(opacity: 0.25, at: 887500);
+    await verifyKeyFrame(opacity: 0.5, at: 925000);
+    await verifyKeyFrame(opacity: 0.75, at: 962500);
+    await verifyKeyFrame(opacity: 1.0, at: 1000000);
+  }, variant: TargetPlatformVariant.all());
+
+  testWidgets('Cursor radius is 2.0', (WidgetTester tester) async {
+    const Widget widget = CupertinoApp(home: CupertinoTextField(maxLines: 3));
+    await tester.pumpWidget(widget);
+
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+
+    expect(renderEditable.cursorRadius, const Radius.circular(2.0));
+  }, variant: TargetPlatformVariant.all());
+}

--- a/packages/flutter/test/material/text_field_cursor_test.dart
+++ b/packages/flutter/test/material/text_field_cursor_test.dart
@@ -1,0 +1,136 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+@TestOn('!chrome')
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Cursor animates on iOS',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Material(child: TextField())));
+
+      final Finder textFinder = find.byType(TextField);
+      await tester.tap(textFinder);
+      await tester.pump();
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final RenderEditable renderEditable = editableTextState.renderEditable;
+
+      expect(renderEditable.cursorColor!.opacity, 1.0);
+
+      var walltimeMicrosecond = 0;
+      var lastVerifiedOpacity = 1.0;
+
+      Future<void> verifyKeyFrame({required double opacity, required int at}) async {
+        const delta = 1;
+        assert(at - delta > walltimeMicrosecond);
+        await tester.pump(Duration(microseconds: at - delta - walltimeMicrosecond));
+
+        // Instead of verifying the opacity at each key frame, this function
+        // verifies the opacity immediately *before* each key frame to avoid
+        // fp precision issues.
+        expect(
+          renderEditable.cursorColor!.opacity,
+          closeTo(lastVerifiedOpacity, 0.01),
+          reason: 'opacity at ${at - delta} microseconds',
+        );
+
+        walltimeMicrosecond = at - delta;
+        lastVerifiedOpacity = opacity;
+      }
+
+      await verifyKeyFrame(opacity: 1.0, at: 500000);
+      await verifyKeyFrame(opacity: 0.75, at: 537500);
+      await verifyKeyFrame(opacity: 0.5, at: 575000);
+      await verifyKeyFrame(opacity: 0.25, at: 612500);
+      await verifyKeyFrame(opacity: 0.0, at: 650000);
+      await verifyKeyFrame(opacity: 0.0, at: 850000);
+      await verifyKeyFrame(opacity: 0.25, at: 887500);
+      await verifyKeyFrame(opacity: 0.5, at: 925000);
+      await verifyKeyFrame(opacity: 0.75, at: 962500);
+      await verifyKeyFrame(opacity: 1.0, at: 1000000);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
+  );
+
+  testWidgets(
+    'Cursor does not animate on non-iOS platforms',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Material(child: TextField(maxLines: 3))));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      // Wait for the current animation to finish. If the cursor never stops its
+      // blinking animation the test will timeout.
+      await tester.pumpAndSettle();
+
+      for (var i = 0; i < 40; i += 1) {
+        await tester.pump(const Duration(milliseconds: 100));
+        expect(tester.hasRunningAnimations, false);
+      }
+    },
+    variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.iOS}),
+  );
+
+  testWidgets('Cursor does not animate on Android', (WidgetTester tester) async {
+    final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
+    final Widget widget = MaterialApp(
+      home: Material(child: TextField(maxLines: 3, cursorColor: defaultCursorColor)),
+    );
+    await tester.pumpWidget(widget);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+
+    await tester.pump();
+    expect(renderEditable.cursorColor!.alpha, 255);
+    expect(renderEditable, paints..rect(color: defaultCursorColor));
+
+    // Android cursor goes from exactly on to exactly off on the 500ms dot.
+    await tester.pump(const Duration(milliseconds: 499));
+    expect(renderEditable.cursorColor!.alpha, 255);
+    expect(renderEditable, paints..rect(color: defaultCursorColor));
+
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(renderEditable.cursorColor!.alpha, 0);
+    // Don't try to draw the cursor.
+    expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(renderEditable.cursorColor!.alpha, 255);
+    expect(renderEditable, paints..rect(color: defaultCursorColor));
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(renderEditable.cursorColor!.alpha, 0);
+    expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
+  });
+
+  testWidgets(
+    'Cursor radius is 2.0 on Apple platforms',
+    (WidgetTester tester) async {
+      const Widget widget = MaterialApp(home: Material(child: TextField(maxLines: 3)));
+      await tester.pumpWidget(widget);
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+      final RenderEditable renderEditable = editableTextState.renderEditable;
+
+      expect(renderEditable.cursorRadius, const Radius.circular(2.0));
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+}

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -19113,6 +19113,36 @@ void main() {
 
     expect(controller.text, 'H');
   });
+
+  testWidgets('Cursor does not show when not focused', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/106512 .
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(child: TextField(focusNode: focusNode, autofocus: true)),
+      ),
+    );
+    assert(focusNode.hasFocus);
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+
+    focusNode.unfocus();
+    await tester.pump();
+
+    for (var i = 0; i < 10; i += 10) {
+      // Make sure it does not paint for a period of time.
+      expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
+      expect(tester.hasRunningAnimations, isFalse);
+      await tester.pump(const Duration(milliseconds: 29));
+    }
+
+    // Refocus and it should paint the caret.
+    focusNode.requestFocus();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(renderEditable, isNot(paintsExactlyCountTimes(#drawRect, 0)));
+  });
 }
 
 /// A Simple widget for testing the obscure text.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -19143,6 +19143,174 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     expect(renderEditable, isNot(paintsExactlyCountTimes(#drawRect, 0)));
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/175511.
+  testWidgets('Radio group does not intercept key events when no radio is focused', (
+    WidgetTester tester,
+  ) async {
+    final log = <String>[];
+    late final shortcuts = <ShortcutActivator, Intent>{
+      const SingleActivator(LogicalKeyboardKey.arrowLeft): VoidCallbackIntent(() => log.add('←')),
+      const SingleActivator(LogicalKeyboardKey.arrowRight): VoidCallbackIntent(() => log.add('→')),
+      const SingleActivator(LogicalKeyboardKey.arrowDown): VoidCallbackIntent(() => log.add('↓')),
+      const SingleActivator(LogicalKeyboardKey.arrowUp): VoidCallbackIntent(() => log.add('↑')),
+      const SingleActivator(LogicalKeyboardKey.space): VoidCallbackIntent(() => log.add('_')),
+    };
+
+    final firstRadioFocusNode = FocusNode();
+    addTearDown(firstRadioFocusNode.dispose);
+    final textFieldFocusNode = FocusNode();
+    addTearDown(textFieldFocusNode.dispose);
+    StateSetter setState;
+    int? groupValue;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Shortcuts(
+            shortcuts: shortcuts,
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter stateSetter) {
+                setState = stateSetter;
+                return RadioGroup<int>(
+                  groupValue: groupValue,
+                  onChanged: (int? newValue) {
+                    setState(() {
+                      groupValue = newValue;
+                    });
+                  },
+                  child: Column(
+                    children: <Widget>[
+                      Radio<int>(focusNode: firstRadioFocusNode, value: 0),
+                      const RadioListTile<int>(value: 1),
+                      const Radio<int>(value: 2),
+                      TextField(focusNode: textFieldFocusNode),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Focus on the first radio and toggle it.
+    firstRadioFocusNode.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(firstRadioFocusNode.hasFocus, isTrue);
+
+    // Toggle the second radio with shortcut.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(groupValue, 1);
+    // Log is empty because radio group handles shortcuts.
+    expect(log, isEmpty);
+
+    // Toggle the first radio with shortcut.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, isEmpty);
+
+    // Move focus to the text field.
+    // Now radio group will ignore shortcuts as there are no focused radios.
+    textFieldFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    // Verify that shortcuts are not intercepted by the radio group.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, <String>['←']);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, <String>['←', '→']);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, <String>['←', '→', '↓']);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, <String>['←', '→', '↓', '↑']);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, <String>['←', '→', '↓', '↑', '_']);
+
+    log.clear();
+    expect(log, isEmpty);
+
+    // Focus on the first radio.
+    firstRadioFocusNode.requestFocus();
+    await tester.pump();
+    expect(groupValue, 0);
+    expect(firstRadioFocusNode.hasFocus, isTrue);
+
+    // Verify that radio group handles shortcuts again.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(groupValue, 1);
+    expect(log, isEmpty);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(groupValue, 0);
+    expect(log, isEmpty);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/170521.
+  testWidgets(
+    'when supportsShowingSystemContextMenu is false, SystemContextMenu throws',
+    (WidgetTester tester) async {
+      final controller = TextEditingController(text: 'one two three');
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            final MediaQueryData mediaQueryData = MediaQuery.of(context);
+            return MediaQuery(
+              data: mediaQueryData.copyWith(supportsShowingSystemContextMenu: false),
+              child: MaterialApp(
+                home: Scaffold(
+                  body: Center(
+                    child: TextField(
+                      controller: controller,
+                      contextMenuBuilder:
+                          (BuildContext context, EditableTextState editableTextState) {
+                            return SystemContextMenu.editableText(
+                              editableTextState: editableTextState,
+                            );
+                          },
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      expect(find.byType(SystemContextMenu), findsNothing);
+
+      await tester.tap(find.byType(TextField));
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.showToolbar(), true);
+      await tester.pump();
+
+      expect(tester.takeException(), isAssertionError);
+    },
+    skip: kIsWeb, // [intended] SystemContextMenu is not supported on web.
+  );
 }
 
 /// A Simple widget for testing the obscure text.

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -2714,8 +2714,7 @@ void main() {
       const shortWindowSize = Size(
         1920.0,
         48.0,
-      ); //TODO(Renzo-Olivares): Should a test like this be in material,cupertino, and widgets? The shortWindowSize varies depending
-      // on the input field because of additional padding by decorators.
+      );
       tester.view.physicalSize = shortWindowSize;
       tester.view.devicePixelRatio = 1.0;
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -8,11 +8,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'list_tile_test_utils.dart';
-
-import 'multi_view_testing.dart';
 
 import 'editable_text_utils.dart';
+import 'list_tile_test_utils.dart';
+import 'multi_view_testing.dart';
 
 class User {
   const User({required this.email, required this.name});
@@ -2711,10 +2710,7 @@ void main() {
 
       // Shrink the screen further so that the options become smaller than
       // kMinInteractiveDimension and move to overlap the field.
-      const shortWindowSize = Size(
-        1920.0,
-        48.0,
-      );
+      const shortWindowSize = Size(1920.0, 48.0);
       tester.view.physicalSize = shortWindowSize;
       tester.view.devicePixelRatio = 1.0;
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -12,6 +12,8 @@ import 'list_tile_test_utils.dart';
 
 import 'multi_view_testing.dart';
 
+import 'editable_text_utils.dart';
+
 class User {
   const User({required this.email, required this.name});
 
@@ -74,7 +76,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return BasicTestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -293,7 +293,7 @@ void main() {
                       ) {
                         focusNode = fieldFocusNode;
                         textEditingController = fieldTextEditingController;
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -407,7 +407,7 @@ void main() {
                             FocusNode focusNode,
                             VoidCallback onSubmitted,
                           ) {
-                            return TextField(
+                            return TestTextField(
                               key: fieldKey,
                               focusNode: focusNode,
                               controller: textEditingController,
@@ -535,7 +535,7 @@ void main() {
                         FocusNode focusNode,
                         VoidCallback onSubmitted,
                       ) {
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -559,7 +559,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pump();
 
       expect(find.byKey(fieldKey), findsOneWidget);
@@ -599,7 +599,7 @@ void main() {
                         FocusNode focusNode,
                         VoidCallback onSubmitted,
                       ) {
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -623,7 +623,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pump();
 
       expect(find.byKey(fieldKey), findsOneWidget);
@@ -673,7 +673,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: fieldTextEditingController,
@@ -766,7 +766,7 @@ void main() {
                 ) {
                   textEditingController = fieldTextEditingController;
                   focusNode = fieldFocusNode;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: fieldTextEditingController,
@@ -853,7 +853,7 @@ void main() {
                   textEditingController = fieldTextEditingController;
                   focusNode = fieldFocusNode;
                   lastOnFieldSubmitted = onFieldSubmitted;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: fieldTextEditingController,
@@ -913,7 +913,7 @@ void main() {
                       FocusNode focusNode,
                       VoidCallback onFieldSubmitted,
                     ) {
-                      return TextField(controller: controller, focusNode: focusNode);
+                      return TestTextField(controller: controller, focusNode: focusNode);
                     },
                 optionsViewBuilder:
                     (
@@ -928,10 +928,10 @@ void main() {
           ),
         ),
       );
-      await tester.showKeyboard(find.byType(TextField));
+      await tester.showKeyboard(find.byType(TestTextField));
       await tester.pump();
       expect(
-        tester.getBottomLeft(find.byType(TextField)),
+        tester.getBottomLeft(find.byType(TestTextField)),
         offsetMoreOrLessEquals(tester.getTopLeft(find.text('a'))),
       );
     });
@@ -952,7 +952,7 @@ void main() {
                       FocusNode focusNode,
                       VoidCallback onFieldSubmitted,
                     ) {
-                      return TextField(controller: controller, focusNode: focusNode);
+                      return TestTextField(controller: controller, focusNode: focusNode);
                     },
                 optionsViewBuilder:
                     (
@@ -967,10 +967,10 @@ void main() {
           ),
         ),
       );
-      await tester.showKeyboard(find.byType(TextField));
+      await tester.showKeyboard(find.byType(TestTextField));
       await tester.pump();
       expect(
-        tester.getBottomLeft(find.byType(TextField)),
+        tester.getBottomLeft(find.byType(TestTextField)),
         offsetMoreOrLessEquals(tester.getTopLeft(find.text('a'))),
       );
     });
@@ -990,7 +990,7 @@ void main() {
                       FocusNode focusNode,
                       VoidCallback onFieldSubmitted,
                     ) {
-                      return TextField(controller: controller, focusNode: focusNode);
+                      return TestTextField(controller: controller, focusNode: focusNode);
                     },
                 optionsViewBuilder:
                     (
@@ -1005,10 +1005,10 @@ void main() {
           ),
         ),
       );
-      await tester.showKeyboard(find.byType(TextField));
+      await tester.showKeyboard(find.byType(TestTextField));
       await tester.pump();
       expect(
-        tester.getTopLeft(find.byType(TextField)),
+        tester.getTopLeft(find.byType(TestTextField)),
         offsetMoreOrLessEquals(tester.getBottomLeft(find.text('a'))),
       );
     });
@@ -1038,7 +1038,7 @@ void main() {
                           FocusNode focusNode,
                           VoidCallback onFieldSubmitted,
                         ) {
-                          return TextField(controller: controller, focusNode: focusNode);
+                          return TestTextField(controller: controller, focusNode: focusNode);
                         },
                     optionsViewBuilder:
                         (
@@ -1062,7 +1062,7 @@ void main() {
       );
 
       // Show the options. It should open downwards since there is more space.
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pump();
 
       expect(
@@ -1096,7 +1096,7 @@ void main() {
               body: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  TextField(controller: controller, focusNode: focusNode),
+                  TestTextField(controller: controller, focusNode: focusNode),
                   RawAutocomplete<String>(
                     key: autocompleteKey,
                     textEditingController: controller,
@@ -1118,7 +1118,7 @@ void main() {
             ),
           ),
         );
-        await tester.showKeyboard(find.byType(TextField));
+        await tester.showKeyboard(find.byType(TestTextField));
         await tester.pump();
         expect(
           tester.getBottomLeft(find.byKey(autocompleteKey)),
@@ -1154,13 +1154,13 @@ void main() {
                           return const Text('a');
                         },
                   ),
-                  TextField(controller: controller, focusNode: focusNode),
+                  TestTextField(controller: controller, focusNode: focusNode),
                 ],
               ),
             ),
           ),
         );
-        await tester.showKeyboard(find.byType(TextField));
+        await tester.showKeyboard(find.byType(TestTextField));
         await tester.pump();
         expect(
           tester.getTopLeft(find.byKey(autocompleteKey)),
@@ -1345,7 +1345,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: fieldTextEditingController,
@@ -1492,7 +1492,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -1570,7 +1570,7 @@ void main() {
               FocusNode fieldFocusNode,
               VoidCallback onFieldSubmitted,
             ) {
-              return TextField(focusNode: focusNode, controller: textEditingController);
+              return TestTextField(focusNode: focusNode, controller: textEditingController);
             },
       );
     }, throwsAssertionError);
@@ -1606,7 +1606,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -2241,7 +2241,7 @@ void main() {
                   FocusNode fieldFocusNode,
                   VoidCallback onFieldSubmitted,
                 ) {
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: fieldFocusNode,
                     controller: fieldTextEditingController,
@@ -2313,7 +2313,7 @@ void main() {
                           FocusNode focusNode,
                           VoidCallback onSubmitted,
                         ) {
-                          return TextField(
+                          return TestTextField(
                             key: fieldKey,
                             focusNode: focusNode,
                             controller: textEditingController,
@@ -2334,7 +2334,7 @@ void main() {
     final RenderBox fieldBox = tester.renderObject(find.byKey(fieldKey));
     expect(fieldBox.size.width, 100.0);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
 
     expect(find.byKey(fieldKey), findsOneWidget);
@@ -2385,7 +2385,7 @@ void main() {
                 setState = localStateSetter;
                 return SizedBox(
                   width: width,
-                  child: TextField(
+                  child: TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -2410,7 +2410,7 @@ void main() {
     final RenderBox fieldBox = tester.renderObject(find.byKey(fieldKey));
     expect(fieldBox.size.width, 100.0);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
 
     expect(find.byKey(fieldKey), findsOneWidget);
@@ -2484,7 +2484,7 @@ void main() {
                         FocusNode focusNode,
                         VoidCallback onSubmitted,
                       ) {
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -2514,7 +2514,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pumpAndSettle();
 
       expect(find.byKey(fieldKey), findsOneWidget);
@@ -2585,7 +2585,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pumpAndSettle();
 
       expect(find.byKey(fieldKey), findsOneWidget);
@@ -2658,7 +2658,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pumpAndSettle();
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsOneWidget);
@@ -2761,7 +2761,7 @@ void main() {
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pumpAndSettle();
       expect(find.byKey(fieldKey), findsOneWidget);
       expect(find.byKey(optionsKey), findsOneWidget);
@@ -2881,7 +2881,7 @@ void main() {
                         FocusNode focusNode,
                         VoidCallback onSubmitted,
                       ) {
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -2989,7 +2989,7 @@ void main() {
                         FocusNode focusNode,
                         VoidCallback onSubmitted,
                       ) {
-                        return TextField(
+                        return TestTextField(
                           key: fieldKey,
                           focusNode: focusNode,
                           controller: textEditingController,
@@ -3078,7 +3078,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -3158,7 +3158,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -3244,7 +3244,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -3327,7 +3327,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -3393,7 +3393,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return TextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,
@@ -3524,7 +3524,7 @@ void main() {
                       TextEditingController textEditingController,
                       FocusNode focusNode,
                       VoidCallback voidCallBack,
-                    ) => TextField(controller: textEditingController),
+                    ) => TestTextField(controller: textEditingController),
                 optionsViewBuilder:
                     (
                       BuildContext context,
@@ -3567,7 +3567,7 @@ void main() {
                     VoidCallback onFieldSubmitted,
                   ) {
                     focusNode = fieldFocusNode;
-                    return TextField(
+                    return TestTextField(
                       key: fieldKey,
                       focusNode: fieldFocusNode,
                       controller: fieldTextEditingController,

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -2711,7 +2711,11 @@ void main() {
 
       // Shrink the screen further so that the options become smaller than
       // kMinInteractiveDimension and move to overlap the field.
-      const shortWindowSize = Size(1920.0, 90.0);
+      const shortWindowSize = Size(
+        1920.0,
+        48.0,
+      ); //TODO(Renzo-Olivares): Should a test like this be in material,cupertino, and widgets? The shortWindowSize varies depending
+      // on the input field because of additional padding by decorators.
       tester.view.physicalSize = shortWindowSize;
       tester.view.devicePixelRatio = 1.0;
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -76,7 +76,7 @@ void main() {
                 ) {
                   focusNode = fieldFocusNode;
                   textEditingController = fieldTextEditingController;
-                  return BasicTestTextField(
+                  return TestTextField(
                     key: fieldKey,
                     focusNode: focusNode,
                     controller: textEditingController,

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart';
+
 final Matcher _matchesCommit = isMethodCall('TextInput.finishAutofillContext', arguments: true);
 final Matcher _matchesCancel = isMethodCall('TextInput.finishAutofillContext', arguments: false);
 
@@ -13,8 +15,8 @@ void main() {
     const outerKey = Key('outer');
     const innerKey = Key('inner');
 
-    const client1 = TextField(autofillHints: <String>['1']);
-    const client2 = TextField(autofillHints: <String>['2']);
+    const client1 = BasicTestTextField(autofillHints: <String>['1']);
+    const client2 = BasicTestTextField(autofillHints: <String>['2']);
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -26,7 +28,9 @@ void main() {
                 client1,
                 AutofillGroup(
                   key: innerKey,
-                  child: Column(children: <Widget>[client2, TextField(autofillHints: null)]),
+                  child: Column(
+                    children: <Widget>[client2, BasicTestTextField(autofillHints: null)],
+                  ),
                 ),
               ],
             ),
@@ -38,12 +42,16 @@ void main() {
     final AutofillGroupState innerState = tester.state<AutofillGroupState>(find.byKey(innerKey));
     final AutofillGroupState outerState = tester.state<AutofillGroupState>(find.byKey(outerKey));
 
-    final State<TextField> clientState1 = tester.state<State<TextField>>(find.byWidget(client1));
-    final State<TextField> clientState2 = tester.state<State<TextField>>(find.byWidget(client2));
+    final State<EditableText> clientState1 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client1), matching: find.byType(EditableText)),
+    );
+    final State<EditableText> clientState2 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client2), matching: find.byType(EditableText)),
+    );
 
-    expect(outerState.autofillClients.toList(), <State<TextField>>[clientState1]);
+    expect(outerState.autofillClients.toList(), <State<EditableText>>[clientState1]);
     // The second TextField in the AutofillGroup doesn't have autofill enabled.
-    expect(innerState.autofillClients.toList(), <State<TextField>>[clientState2]);
+    expect(innerState.autofillClients.toList(), <State<EditableText>>[clientState2]);
   });
 
   testWidgets('new clients can be added & removed to a scope', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -15,8 +15,8 @@ void main() {
     const outerKey = Key('outer');
     const innerKey = Key('inner');
 
-    const client1 = BasicTestTextField(autofillHints: <String>['1']);
-    const client2 = BasicTestTextField(autofillHints: <String>['2']);
+    const client1 = TestTextField(autofillHints: <String>['1']);
+    const client2 = TestTextField(autofillHints: <String>['2']);
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -29,7 +29,7 @@ void main() {
                 AutofillGroup(
                   key: innerKey,
                   child: Column(
-                    children: <Widget>[client2, BasicTestTextField(autofillHints: null)],
+                    children: <Widget>[client2, TestTextField(autofillHints: null)],
                   ),
                 ),
               ],

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../material/material_state_mixin_test.dart';
 import 'editable_text_utils.dart';
 
 final Matcher _matchesCommit = isMethodCall('TextInput.finishAutofillContext', arguments: true);

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../material/material_state_mixin_test.dart';
 import 'editable_text_utils.dart';
 
 final Matcher _matchesCommit = isMethodCall('TextInput.finishAutofillContext', arguments: true);
@@ -28,9 +29,7 @@ void main() {
                 client1,
                 AutofillGroup(
                   key: innerKey,
-                  child: Column(
-                    children: <Widget>[client2, TestTextField(autofillHints: null)],
-                  ),
+                  child: Column(children: <Widget>[client2, TestTextField(autofillHints: null)]),
                 ),
               ],
             ),
@@ -50,15 +49,15 @@ void main() {
     );
 
     expect(outerState.autofillClients.toList(), <State<EditableText>>[clientState1]);
-    // The second TextField in the AutofillGroup doesn't have autofill enabled.
+    // The second TestTextField in the AutofillGroup doesn't have autofill enabled.
     expect(innerState.autofillClients.toList(), <State<EditableText>>[clientState2]);
   });
 
   testWidgets('new clients can be added & removed to a scope', (WidgetTester tester) async {
     const scopeKey = Key('scope');
 
-    const client1 = TextField(autofillHints: <String>['1']);
-    var client2 = const TextField(autofillHints: null);
+    const client1 = TestTextField(autofillHints: <String>['1']);
+    var client2 = const TestTextField(autofillHints: null);
 
     late StateSetter setState;
 
@@ -80,14 +79,18 @@ void main() {
 
     final AutofillGroupState scopeState = tester.state<AutofillGroupState>(find.byKey(scopeKey));
 
-    final State<TextField> clientState1 = tester.state<State<TextField>>(find.byWidget(client1));
-    final State<TextField> clientState2 = tester.state<State<TextField>>(find.byWidget(client2));
+    final State<EditableText> clientState1 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client1), matching: find.byType(EditableText)),
+    );
+    final State<EditableText> clientState2 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client2), matching: find.byType(EditableText)),
+    );
 
-    expect(scopeState.autofillClients.toList(), <State<TextField>>[clientState1]);
+    expect(scopeState.autofillClients.toList(), <State<EditableText>>[clientState1]);
 
     // Add to scope.
     setState(() {
-      client2 = const TextField(autofillHints: <String>['2']);
+      client2 = const TestTextField(autofillHints: <String>['2']);
     });
 
     await tester.pump();
@@ -98,12 +101,12 @@ void main() {
 
     // Remove from scope again.
     setState(() {
-      client2 = const TextField(autofillHints: null);
+      client2 = const TestTextField(autofillHints: null);
     });
 
     await tester.pump();
 
-    expect(scopeState.autofillClients, <State<TextField>>[clientState1]);
+    expect(scopeState.autofillClients, <State<EditableText>>[clientState1]);
   });
 
   testWidgets('AutofillGroup has the right clients after reparenting', (WidgetTester tester) async {
@@ -111,8 +114,8 @@ void main() {
     const innerKey = Key('inner');
     final GlobalKey keyClient3 = GlobalKey();
 
-    const client1 = TextField(autofillHints: <String>['1']);
-    const client2 = TextField(autofillHints: <String>['2']);
+    const client1 = TestTextField(autofillHints: <String>['1']);
+    const client2 = TestTextField(autofillHints: <String>['2']);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -127,7 +130,7 @@ void main() {
                   child: Column(
                     children: <Widget>[
                       client2,
-                      TextField(key: keyClient3, autofillHints: const <String>['3']),
+                      TestTextField(key: keyClient3, autofillHints: const <String>['3']),
                     ],
                   ),
                 ),
@@ -141,9 +144,15 @@ void main() {
     final AutofillGroupState innerState = tester.state<AutofillGroupState>(find.byKey(innerKey));
     final AutofillGroupState outerState = tester.state<AutofillGroupState>(find.byKey(outerKey));
 
-    final State<TextField> clientState1 = tester.state<State<TextField>>(find.byWidget(client1));
-    final State<TextField> clientState2 = tester.state<State<TextField>>(find.byWidget(client2));
-    final State<TextField> clientState3 = tester.state<State<TextField>>(find.byKey(keyClient3));
+    final State<EditableText> clientState1 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client1), matching: find.byType(EditableText)),
+    );
+    final State<EditableText> clientState2 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byWidget(client2), matching: find.byType(EditableText)),
+    );
+    final State<EditableText> clientState3 = tester.state<State<EditableText>>(
+      find.descendant(of: find.byKey(keyClient3), matching: find.byType(EditableText)),
+    );
 
     await tester.pumpWidget(
       MaterialApp(
@@ -153,7 +162,7 @@ void main() {
             child: Column(
               children: <Widget>[
                 client1,
-                TextField(key: keyClient3, autofillHints: const <String>['3']),
+                TestTextField(key: keyClient3, autofillHints: const <String>['3']),
                 const AutofillGroup(
                   key: innerKey,
                   child: Column(children: <Widget>[client2]),
@@ -168,7 +177,7 @@ void main() {
     expect(outerState.autofillClients.length, 2);
     expect(outerState.autofillClients, contains(clientState1));
     expect(outerState.autofillClients, contains(clientState3));
-    expect(innerState.autofillClients, <State<TextField>>[clientState2]);
+    expect(innerState.autofillClients, <State<EditableText>>[clientState2]);
   });
 
   testWidgets('disposing AutofillGroups', (WidgetTester tester) async {
@@ -176,7 +185,7 @@ void main() {
     const group1 = Key('group1');
     const group2 = Key('group2');
     const group3 = Key('group3');
-    const placeholder = TextField(autofillHints: <String>[AutofillHints.name]);
+    const placeholder = TestTextField(autofillHints: <String>[AutofillHints.name]);
 
     var children = const <Widget>[
       AutofillGroup(

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -185,9 +185,9 @@ void main() {
   testWidgets(
     'Cursor animates on iOS',
     (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Material(child: BasicTestTextField())));
+      await tester.pumpWidget(const MaterialApp(home: Material(child: TestTextField())));
 
-      final Finder textFinder = find.byType(BasicTestTextField);
+      final Finder textFinder = find.byType(TestTextField);
       await tester.tap(textFinder);
       await tester.pump();
 
@@ -235,10 +235,10 @@ void main() {
     'Cursor does not animate on non-iOS platforms',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(home: Material(child: BasicTestTextField(maxLines: 3))),
+        const MaterialApp(home: Material(child: TestTextField(maxLines: 3))),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pump();
       // Wait for the current animation to finish. If the cursor never stops its
       // blinking animation the test will timeout.
@@ -444,11 +444,11 @@ void main() {
 
   testWidgets('Cursor does not show when showCursor set to false', (WidgetTester tester) async {
     const Widget widget = MaterialApp(
-      home: Material(child: BasicTestTextField(showCursor: false, maxLines: 3)),
+      home: Material(child: TestTextField(showCursor: false, maxLines: 3)),
     );
     await tester.pumpWidget(widget);
 
-    await tester.tap(find.byType(BasicTestTextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -291,10 +291,12 @@ void main() {
     (WidgetTester tester) async {
       EditableText.debugDeterministicCursor = true;
       final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-      const Widget widget = MaterialApp(home: Material(child: TextField(maxLines: 3)));
+      final Widget widget = MaterialApp(
+        home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
+      );
       await tester.pumpWidget(widget);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pump();
 
       final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
@@ -330,10 +332,12 @@ void main() {
   ) async {
     final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
     EditableText.debugDeterministicCursor = true;
-    const Widget widget = MaterialApp(home: Material(child: TextField(maxLines: 3)));
+    final Widget widget = MaterialApp(
+      home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
+    );
     await tester.pumpWidget(widget);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
@@ -496,7 +500,7 @@ void main() {
   testWidgets(
     'Cursor radius is 2.0',
     (WidgetTester tester) async {
-      const Widget widget = MaterialApp(home: Material(child: TextField(maxLines: 3)));
+      const Widget widget = MaterialApp(home: Material(child: TestTextField(maxLines: 3)));
       await tester.pumpWidget(widget);
 
       final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -185,9 +185,9 @@ void main() {
   testWidgets(
     'Cursor animates on iOS',
     (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Material(child: TextField())));
+      await tester.pumpWidget(const MaterialApp(home: Material(child: BasicTestTextField())));
 
-      final Finder textFinder = find.byType(TextField);
+      final Finder textFinder = find.byType(BasicTestTextField);
       await tester.tap(textFinder);
       await tester.pump();
 
@@ -234,9 +234,11 @@ void main() {
   testWidgets(
     'Cursor does not animate on non-iOS platforms',
     (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Material(child: TextField(maxLines: 3))));
+      await tester.pumpWidget(
+        const MaterialApp(home: Material(child: BasicTestTextField(maxLines: 3))),
+      );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       await tester.pump();
       // Wait for the current animation to finish. If the cursor never stops its
       // blinking animation the test will timeout.
@@ -442,11 +444,11 @@ void main() {
 
   testWidgets('Cursor does not show when showCursor set to false', (WidgetTester tester) async {
     const Widget widget = MaterialApp(
-      home: Material(child: TextField(showCursor: false, maxLines: 3)),
+      home: Material(child: BasicTestTextField(showCursor: false, maxLines: 3)),
     );
     await tester.pumpWidget(widget);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(BasicTestTextField));
     await tester.pump();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -234,9 +234,7 @@ void main() {
   testWidgets(
     'Cursor does not animate on non-iOS platforms',
     (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(home: Material(child: TestTextField(maxLines: 3))),
-      );
+      await tester.pumpWidget(const MaterialApp(home: Material(child: TestTextField(maxLines: 3))));
 
       await tester.tap(find.byType(TestTextField));
       await tester.pump();
@@ -469,7 +467,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/106512 .
     await tester.pumpWidget(
       MaterialApp(
-        home: Material(child: TextField(focusNode: focusNode, autofocus: true)),
+        home: Material(child: TestTextField(focusNode: focusNode, autofocus: true)),
       ),
     );
     assert(focusNode.hasFocus);

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -182,117 +182,90 @@ void main() {
     );
   });
 
-  testWidgets(
-    'Cursor animates on iOS',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Material(child: TestTextField())));
-
-      final Finder textFinder = find.byType(TestTextField);
-      await tester.tap(textFinder);
-      await tester.pump();
-
-      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-      final RenderEditable renderEditable = editableTextState.renderEditable;
-
-      expect(renderEditable.cursorColor!.opacity, 1.0);
-
-      var walltimeMicrosecond = 0;
-      var lastVerifiedOpacity = 1.0;
-
-      Future<void> verifyKeyFrame({required double opacity, required int at}) async {
-        const delta = 1;
-        assert(at - delta > walltimeMicrosecond);
-        await tester.pump(Duration(microseconds: at - delta - walltimeMicrosecond));
-
-        // Instead of verifying the opacity at each key frame, this function
-        // verifies the opacity immediately *before* each key frame to avoid
-        // fp precision issues.
-        expect(
-          renderEditable.cursorColor!.opacity,
-          closeTo(lastVerifiedOpacity, 0.01),
-          reason: 'opacity at ${at - delta} microseconds',
-        );
-
-        walltimeMicrosecond = at - delta;
-        lastVerifiedOpacity = opacity;
-      }
-
-      await verifyKeyFrame(opacity: 1.0, at: 500000);
-      await verifyKeyFrame(opacity: 0.75, at: 537500);
-      await verifyKeyFrame(opacity: 0.5, at: 575000);
-      await verifyKeyFrame(opacity: 0.25, at: 612500);
-      await verifyKeyFrame(opacity: 0.0, at: 650000);
-      await verifyKeyFrame(opacity: 0.0, at: 850000);
-      await verifyKeyFrame(opacity: 0.25, at: 887500);
-      await verifyKeyFrame(opacity: 0.5, at: 925000);
-      await verifyKeyFrame(opacity: 0.75, at: 962500);
-      await verifyKeyFrame(opacity: 1.0, at: 1000000);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS}),
-  );
-
-  testWidgets(
-    'Cursor does not animate on non-iOS platforms',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Material(child: TestTextField(maxLines: 3))));
-
-      await tester.tap(find.byType(TestTextField));
-      await tester.pump();
-      // Wait for the current animation to finish. If the cursor never stops its
-      // blinking animation the test will timeout.
-      await tester.pumpAndSettle();
-
-      for (var i = 0; i < 40; i += 1) {
-        await tester.pump(const Duration(milliseconds: 100));
-        expect(tester.hasRunningAnimations, false);
-      }
-    },
-    variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.iOS}),
-  );
-
-  testWidgets('Cursor does not animate on Android', (WidgetTester tester) async {
-    final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-    final Widget widget = MaterialApp(
-      home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
+  testWidgets('Cursor can animate', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Material(child: TestTextField(cursorOpacityAnimates: true))),
     );
-    await tester.pumpWidget(widget);
 
-    await tester.tap(find.byType(TestTextField));
+    final Finder textFinder = find.byType(TestTextField);
+    await tester.tap(textFinder);
     await tester.pump();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
     final RenderEditable renderEditable = editableTextState.renderEditable;
 
+    expect(renderEditable.cursorColor!.opacity, 1.0);
+
+    var walltimeMicrosecond = 0;
+    var lastVerifiedOpacity = 1.0;
+
+    Future<void> verifyKeyFrame({required double opacity, required int at}) async {
+      const delta = 1;
+      assert(at - delta > walltimeMicrosecond);
+      await tester.pump(Duration(microseconds: at - delta - walltimeMicrosecond));
+
+      // Instead of verifying the opacity at each key frame, this function
+      // verifies the opacity immediately *before* each key frame to avoid
+      // fp precision issues.
+      expect(
+        renderEditable.cursorColor!.opacity,
+        closeTo(lastVerifiedOpacity, 0.01),
+        reason: 'opacity at ${at - delta} microseconds',
+      );
+
+      walltimeMicrosecond = at - delta;
+      lastVerifiedOpacity = opacity;
+    }
+
+    await verifyKeyFrame(opacity: 1.0, at: 500000);
+    await verifyKeyFrame(opacity: 0.75, at: 537500);
+    await verifyKeyFrame(opacity: 0.5, at: 575000);
+    await verifyKeyFrame(opacity: 0.25, at: 612500);
+    await verifyKeyFrame(opacity: 0.0, at: 650000);
+    await verifyKeyFrame(opacity: 0.0, at: 850000);
+    await verifyKeyFrame(opacity: 0.25, at: 887500);
+    await verifyKeyFrame(opacity: 0.5, at: 925000);
+    await verifyKeyFrame(opacity: 0.75, at: 962500);
+    await verifyKeyFrame(opacity: 1.0, at: 1000000);
+  });
+
+  testWidgets('Cursor is static when cursorOpacityAnimates is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: TestTextField(
+            // cursorOpacityAnimates: false, default value.
+            maxLines: 3,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
+    // Wait for the current animation to finish. If the cursor never stops its
+    // blinking animation the test will timeout.
+    await tester.pumpAndSettle();
 
-    // Android cursor goes from exactly on to exactly off on the 500ms dot.
-    await tester.pump(const Duration(milliseconds: 499));
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    await tester.pump(const Duration(milliseconds: 1));
-    expect(renderEditable.cursorColor!.alpha, 0);
-    // Don't try to draw the cursor.
-    expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(renderEditable.cursorColor!.alpha, 0);
-    expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
+    for (var i = 0; i < 40; i += 1) {
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.hasRunningAnimations, false);
+    }
   });
 
   testWidgets(
-    'Cursor does not animates when debugDeterministicCursor is set',
+    'Cursor does not animate when EditableText.debugDeterministicCursor and cursorOpacityAnimates are true',
     (WidgetTester tester) async {
       EditableText.debugDeterministicCursor = true;
       final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
       final Widget widget = MaterialApp(
-        home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
+        home: Material(
+          child: TestTextField(
+            maxLines: 3,
+            cursorColor: defaultCursorColor,
+            cursorOpacityAnimates: true,
+          ),
+        ),
       );
       await tester.pumpWidget(widget);
 
@@ -307,62 +280,21 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
       expect(renderEditable.cursorColor!.alpha, 255);
-      expect(renderEditable, paints..rrect(color: defaultCursorColor));
+      expect(renderEditable, paints..rect(color: defaultCursorColor));
 
       // Cursor draw never changes.
       await tester.pump(const Duration(milliseconds: 200));
       expect(renderEditable.cursorColor!.alpha, 255);
-      expect(renderEditable, paints..rrect(color: defaultCursorColor));
+      expect(renderEditable, paints..rect(color: defaultCursorColor));
 
       // No more transient calls.
       await tester.pumpAndSettle();
       expect(renderEditable.cursorColor!.alpha, 255);
-      expect(renderEditable, paints..rrect(color: defaultCursorColor));
+      expect(renderEditable, paints..rect(color: defaultCursorColor));
 
       EditableText.debugDeterministicCursor = false;
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.iOS,
-      TargetPlatform.macOS,
-    }),
   );
-
-  testWidgets('Cursor does not animate on Android when debugDeterministicCursor is set', (
-    WidgetTester tester,
-  ) async {
-    final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-    EditableText.debugDeterministicCursor = true;
-    final Widget widget = MaterialApp(
-      home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
-    );
-    await tester.pumpWidget(widget);
-
-    await tester.tap(find.byType(TestTextField));
-    await tester.pump();
-
-    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-    final RenderEditable renderEditable = editableTextState.renderEditable;
-
-    await tester.pump();
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    // Cursor draw never changes.
-    await tester.pump(const Duration(milliseconds: 500));
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    // No more transient calls.
-    await tester.pumpAndSettle();
-    expect(renderEditable.cursorColor!.alpha, 255);
-    expect(renderEditable, paints..rect(color: defaultCursorColor));
-
-    EditableText.debugDeterministicCursor = false;
-  });
 
   testWidgets(
     'Cursor animation restarts when it is moved using keys on desktop',
@@ -496,23 +428,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     expect(renderEditable, isNot(paintsExactlyCountTimes(#drawRect, 0)));
   });
-
-  testWidgets(
-    'Cursor radius is 2.0',
-    (WidgetTester tester) async {
-      const Widget widget = MaterialApp(home: Material(child: TestTextField(maxLines: 3)));
-      await tester.pumpWidget(widget);
-
-      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
-      final RenderEditable renderEditable = editableTextState.renderEditable;
-
-      expect(renderEditable.cursorRadius, const Radius.circular(2.0));
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.iOS,
-      TargetPlatform.macOS,
-    }),
-  );
 
   testWidgets('Cursor gets placed correctly after going out of bounds', (
     WidgetTester tester,

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -252,10 +252,12 @@ void main() {
 
   testWidgets('Cursor does not animate on Android', (WidgetTester tester) async {
     final defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-    const Widget widget = MaterialApp(home: Material(child: TextField(maxLines: 3)));
+    final Widget widget = MaterialApp(
+      home: Material(child: TestTextField(maxLines: 3, cursorColor: defaultCursorColor)),
+    );
     await tester.pumpWidget(widget);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TestTextField));
     await tester.pump();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter/src/foundation/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart';
+
 class _TestSliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate {
   _TestSliverPersistentHeaderDelegate({
     required this.minExtent,
@@ -252,7 +254,7 @@ void main() {
                   Container(color: Colors.red),
                   ColoredBox(
                     color: Colors.green,
-                    child: TextField(controller: controller),
+                    child: TestTextField(controller: controller),
                   ),
                   Container(color: Colors.red),
                 ],

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -209,9 +209,9 @@ void main() {
       final groupIds = <String>['Group A', 'Group B', 'Group C'];
       final keys = List<GlobalKey>.generate(3, (_) => GlobalKey());
       final inputFields = <Widget>[
-        TextFormField(key: keys[0], groupId: groupIds[0]),
-        CupertinoTextField(key: keys[1], groupId: groupIds[1]),
-        TextField(key: keys[2], groupId: groupIds[2]),
+        BasicTestTextField(key: keys[0], groupId: groupIds[0]),
+        BasicTestTextField(key: keys[1], groupId: groupIds[1]),
+        BasicTestTextField(key: keys[2], groupId: groupIds[2]),
       ];
 
       await tester.pumpWidget(
@@ -242,9 +242,9 @@ void main() {
       (WidgetTester tester) async {
         final keys = List<GlobalKey>.generate(3, (_) => GlobalKey());
         final inputFields = <Widget>[
-          TextFormField(key: keys[0]),
-          CupertinoTextField(key: keys[1]),
-          TextField(key: keys[2]),
+          BasicTestTextField(key: keys[0]),
+          BasicTestTextField(key: keys[1]),
+          BasicTestTextField(key: keys[2]),
         ];
 
         await tester.pumpWidget(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17191,8 +17191,6 @@ void main() {
     await tester.showKeyboard(find.byType(EditableText, skipOffstage: false));
     await tester.pumpAndSettle();
     expect(find.byType(EditableText), findsOneWidget);
-    // TODO(Renzo-Olivares): Decide if the below calculation is worthwhile to verify
-    // or does simply verifying that EditableText is on screen suffice.
     // Verify scroll offset.
     final RenderSliverMainAxisGroup groupRenderer = tester.renderObject(
       find.byType(SliverMainAxisGroup),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17693,7 +17693,7 @@ void main() {
         cursorColor: cursorColor,
         backgroundCursorColor: const Color(0xFF424242), // grey.
         focusNode: focusNode,
-        selectionControls: basicTestTextSelectionHandleControls,
+        selectionControls: testTextSelectionHandleControls,
         contextMenuBuilder: (context, editableTextState) {
           return const SizedBox.shrink();
         },
@@ -17766,7 +17766,7 @@ void main() {
         cursorColor: cursorColor,
         backgroundCursorColor: const Color(0xFF424242), // grey.
         focusNode: focusNode,
-        selectionControls: basicTestTextSelectionHandleControls,
+        selectionControls: testTextSelectionHandleControls,
         contextMenuBuilder: (context, editableTextState) {
           return const SizedBox.shrink();
         },

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17693,7 +17693,7 @@ void main() {
         cursorColor: cursorColor,
         backgroundCursorColor: const Color(0xFF424242), // grey.
         focusNode: focusNode,
-        selectionControls: _fakeTextSelectionHandleControls,
+        selectionControls: basicTestTextSelectionHandleControls,
         contextMenuBuilder: (context, editableTextState) {
           return const SizedBox.shrink();
         },
@@ -17766,7 +17766,7 @@ void main() {
         cursorColor: cursorColor,
         backgroundCursorColor: const Color(0xFF424242), // grey.
         focusNode: focusNode,
-        selectionControls: _fakeTextSelectionHandleControls,
+        selectionControls: basicTestTextSelectionHandleControls,
         contextMenuBuilder: (context, editableTextState) {
           return const SizedBox.shrink();
         },
@@ -18279,28 +18279,3 @@ class FakeFlutterView extends TestFlutterView {
   @override
   final int viewId;
 }
-
-class _FakeTextSelectionHandleControls extends TextSelectionControls
-    with TextSelectionHandleControls {
-  @override
-  Widget buildHandle(
-    BuildContext context,
-    TextSelectionHandleType type,
-    double textLineHeight, [
-    VoidCallback? onTap,
-  ]) {
-    return const SizedBox.shrink();
-  }
-
-  @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
-    return Offset.zero;
-  }
-
-  @override
-  Size getHandleSize(double textLineHeight) {
-    return Size.zero;
-  }
-}
-
-final TextSelectionControls _fakeTextSelectionHandleControls = _FakeTextSelectionHandleControls();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -209,9 +209,9 @@ void main() {
       final groupIds = <String>['Group A', 'Group B', 'Group C'];
       final keys = List<GlobalKey>.generate(3, (_) => GlobalKey());
       final inputFields = <Widget>[
-        BasicTestTextField(key: keys[0], groupId: groupIds[0]),
-        BasicTestTextField(key: keys[1], groupId: groupIds[1]),
-        BasicTestTextField(key: keys[2], groupId: groupIds[2]),
+        TestTextField(key: keys[0], groupId: groupIds[0]),
+        TestTextField(key: keys[1], groupId: groupIds[1]),
+        TestTextField(key: keys[2], groupId: groupIds[2]),
       ];
 
       await tester.pumpWidget(
@@ -242,9 +242,9 @@ void main() {
       (WidgetTester tester) async {
         final keys = List<GlobalKey>.generate(3, (_) => GlobalKey());
         final inputFields = <Widget>[
-          BasicTestTextField(key: keys[0]),
-          BasicTestTextField(key: keys[1]),
-          BasicTestTextField(key: keys[2]),
+          TestTextField(key: keys[0]),
+          TestTextField(key: keys[1]),
+          TestTextField(key: keys[2]),
         ];
 
         await tester.pumpWidget(

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -181,7 +181,7 @@ class _TestTextFieldState extends State<TestTextField>
   FocusNode? _focusNode;
   FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
 
-  late _BasicTestTextFieldSelectionGestureDetectorBuilder _selectionGestureDetectorBuilder;
+  late _TestTextFieldSelectionGestureDetectorBuilder _selectionGestureDetectorBuilder;
 
   // API for TextSelectionGestureDetectorBuilderDelegate.
   @override
@@ -197,9 +197,7 @@ class _TestTextFieldState extends State<TestTextField>
   @override
   void initState() {
     super.initState();
-    _selectionGestureDetectorBuilder = _BasicTestTextFieldSelectionGestureDetectorBuilder(
-      state: this,
-    );
+    _selectionGestureDetectorBuilder = _TestTextFieldSelectionGestureDetectorBuilder(state: this);
   }
 
   @override
@@ -237,7 +235,7 @@ class _TestTextFieldState extends State<TestTextField>
         onChanged: widget.onChanged,
         readOnly: widget.readOnly,
         rendererIgnoresPointer: true, // for gestures.
-        selectionControls: basicTestTextSelectionHandleControls,
+        selectionControls: testTextSelectionHandleControls,
         showCursor: widget.showCursor,
         style: widget.style ?? const TextStyle(),
         controller: _effectiveController,
@@ -246,9 +244,8 @@ class _TestTextFieldState extends State<TestTextField>
   }
 }
 
-class _BasicTestTextFieldSelectionGestureDetectorBuilder
-    extends TextSelectionGestureDetectorBuilder {
-  _BasicTestTextFieldSelectionGestureDetectorBuilder({required _TestTextFieldState state})
+class _TestTextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDetectorBuilder {
+  _TestTextFieldSelectionGestureDetectorBuilder({required _TestTextFieldState state})
     : super(delegate: state);
 
   @override
@@ -260,7 +257,7 @@ class _BasicTestTextFieldSelectionGestureDetectorBuilder
   bool get onUserTapAlwaysCalled => false;
 }
 
-class BasicTestTextSelectionHandleControls extends TextSelectionControls
+class TestTextSelectionHandleControls extends TextSelectionControls
     with TextSelectionHandleControls {
   @override
   Widget buildHandle(
@@ -283,5 +280,4 @@ class BasicTestTextSelectionHandleControls extends TextSelectionControls
   }
 }
 
-final TextSelectionControls basicTestTextSelectionHandleControls =
-    BasicTestTextSelectionHandleControls();
+final TextSelectionControls testTextSelectionHandleControls = TestTextSelectionHandleControls();

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -148,12 +148,16 @@ class BasicTestTextField extends StatefulWidget {
     this.focusNode,
     this.style,
     this.autofocus = false,
+    this.contextMenuBuilder,
+    this.readOnly = false,
   });
 
   final bool autofocus;
   final TextEditingController? controller;
   final FocusNode? focusNode;
   final TextStyle? style;
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
+  final bool readOnly;
 
   @override
   State<BasicTestTextField> createState() => _BasicTestTextFieldState();
@@ -173,15 +177,46 @@ class _BasicTestTextFieldState extends State<BasicTestTextField> {
     super.dispose();
   }
 
+  static const Color _red = Color(0xFFF44336); // Colors.red.
+
   @override
   Widget build(BuildContext context) {
     return EditableText(
+      readOnly: widget.readOnly,
       autofocus: widget.autofocus,
       controller: _effectiveController,
       focusNode: _effectiveFocusNode,
       style: widget.style ?? const TextStyle(),
-      cursorColor: Colors.red,
-      backgroundCursorColor: Colors.red,
+      contextMenuBuilder: widget.contextMenuBuilder,
+      cursorColor: _red, // Colors.red
+      backgroundCursorColor: _red, // Colors.red
+      selectionControls: basicTestTextSelectionHandleControls,
     );
   }
 }
+
+class BasicTestTextSelectionHandleControls extends TextSelectionControls
+    with TextSelectionHandleControls {
+  @override
+  Widget buildHandle(
+    BuildContext context,
+    TextSelectionHandleType type,
+    double textLineHeight, [
+    VoidCallback? onTap,
+  ]) {
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    return Offset.zero;
+  }
+
+  @override
+  Size getHandleSize(double textLineHeight) {
+    return Size.zero;
+  }
+}
+
+final TextSelectionControls basicTestTextSelectionHandleControls =
+    BasicTestTextSelectionHandleControls();

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -140,3 +140,37 @@ class OverflowWidgetTextEditingController extends TextEditingController {
     );
   }
 }
+
+class BasicTestTextField extends StatefulWidget {
+  const BasicTestTextField({super.key, this.focusNode, this.style});
+
+  final FocusNode? focusNode;
+  final TextStyle? style;
+
+  @override
+  State<BasicTestTextField> createState() => _BasicTestTextFieldState();
+}
+
+class _BasicTestTextFieldState extends State<BasicTestTextField> {
+  final TextEditingController _controller = TextEditingController();
+  FocusNode? _focusNode;
+  FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
+
+  @override
+  void dispose() {
+    _focusNode?.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return EditableText(
+      controller: _controller,
+      focusNode: _effectiveFocusNode,
+      style: widget.style ?? const TextStyle(),
+      cursorColor: Colors.red,
+      backgroundCursorColor: Colors.red,
+    );
+  }
+}

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -143,11 +143,23 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 
 /// A minimal wrapper around [EditableText] for use in widget tests.
 ///
-/// This wrapper provides robust text selection gestures through
+/// This widget provides robust text selection gestures through
 /// [TextSelectionGestureDetector].
 ///
-/// This wrapper does not provide selection handles or context menus
-/// out of the box.
+/// This widget does not provide selection handles or text selection
+/// context menus out of the box.
+///
+/// This input field manages its own internal [TextEditingController]
+/// and [FocusNode] unless provided one. This field also provides defaults
+/// for required [EditableText] members [EditableText.cursorColor],
+/// [EditableText.backgroundCursorColor], and [EditableText.style].
+///
+/// This widget provides platform defaults based on observed native behavior:
+///
+///  * [EditableText.cursorOpacityAnimates] is set to true on iOS.
+///  * [EditableText.cursorRadius] is set to `Radius.circular(2.0)` on iOS and macOS.
+///  * [EditableText.backgroundCursorColor] is set to `Color(0xFF999999)` on iOS and macOS.
+///  * [TextSelectionGestureDetectorBuilderDelegate.forcePressEnabled] is set to true on iOS.
 class TestTextField extends StatefulWidget {
   const TestTextField({
     super.key,
@@ -223,6 +235,7 @@ class _TestTextFieldState extends State<TestTextField>
 
   @override
   Widget build(BuildContext context) {
+    // Platform defaults.
     final bool cursorOpacityAnimates = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => true,
       _ => false,
@@ -239,27 +252,29 @@ class _TestTextFieldState extends State<TestTextField>
       TargetPlatform.iOS => true,
       _ => false,
     };
+    // End of platform defaults.
     return _selectionGestureDetectorBuilder.buildGestureDetector(
       behavior: HitTestBehavior.translucent,
       child: EditableText(
         key: editableTextKey,
         autofillHints: widget.autofillHints,
         autofocus: widget.autofocus,
-        backgroundCursorColor: backgroundCursorColor ?? _red, // Colors.red
+        backgroundCursorColor:
+            backgroundCursorColor ?? _red, // Colors.red, required by editable text.
         contextMenuBuilder: widget.contextMenuBuilder,
-        cursorColor: widget.cursorColor ?? _red, // Colors.red
+        cursorColor: widget.cursorColor ?? _red, // Colors.red, required by editable text.
         cursorOpacityAnimates: cursorOpacityAnimates,
         cursorRadius: cursorRadius,
-        focusNode: _effectiveFocusNode,
+        focusNode: _effectiveFocusNode, // required by editable text.
         groupId: widget.groupId,
         maxLines: widget.maxLines,
         onChanged: widget.onChanged,
         readOnly: widget.readOnly,
-        rendererIgnoresPointer: true, // for gestures.
+        rendererIgnoresPointer: true, // gestures are provided by text selection gesture detector.
         selectionControls: testTextSelectionHandleControls,
         showCursor: widget.showCursor,
-        style: widget.style ?? const TextStyle(),
-        controller: _effectiveController,
+        style: widget.style ?? const TextStyle(), // required by editable text.
+        controller: _effectiveController, // required by editable text.
       ),
     );
   }

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -146,9 +146,13 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 /// This widget provides robust text selection gestures through
 /// [TextSelectionGestureDetector].
 ///
-/// This widget does not provide selection handles or text selection
-/// context menus out of the box. They can be added by providing
-/// [selectionControls] and [contextMenuBuilder].
+/// This widget does not provide text selection context menus out of the box.
+/// They can be added by providing [contextMenuBuilder].
+///
+/// This widget does not provide a concrete implementation of text selection handles
+/// out of the box, and instead uses [testTextSelectionHandleControls] as a default.
+/// A more robust implementation of text selection handles can be provided by
+/// setting [selectionControls].
 ///
 /// This input field manages its own internal [TextEditingController]
 /// and [FocusNode] unless provided one. This field also provides defaults
@@ -246,7 +250,7 @@ class _TestTextFieldState extends State<TestTextField>
         onChanged: widget.onChanged,
         readOnly: widget.readOnly,
         rendererIgnoresPointer: true, // gestures are provided by text selection gesture detector.
-        selectionControls: widget.selectionControls,
+        selectionControls: widget.selectionControls ?? testTextSelectionHandleControls,
         showCursor: widget.showCursor,
         style: widget.style ?? const TextStyle(), // required by editable text.
         controller: _effectiveController, // required by editable text.

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -173,12 +173,34 @@ class BasicTestTextField extends StatefulWidget {
   State<BasicTestTextField> createState() => _BasicTestTextFieldState();
 }
 
-class _BasicTestTextFieldState extends State<BasicTestTextField> {
+class _BasicTestTextFieldState extends State<BasicTestTextField>
+    implements TextSelectionGestureDetectorBuilderDelegate {
   TextEditingController? _controller;
   TextEditingController get _effectiveController =>
       widget.controller ?? (_controller ??= TextEditingController());
   FocusNode? _focusNode;
   FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
+
+  late _BasicTestTextFieldSelectionGestureDetectorBuilder _selectionGestureDetectorBuilder;
+
+  // API for TextSelectionGestureDetectorBuilderDelegate.
+  @override
+  late bool forcePressEnabled;
+
+  @override
+  final GlobalKey<EditableTextState> editableTextKey = GlobalKey<EditableTextState>();
+
+  @override
+  bool get selectionEnabled => true;
+  // End of API for TextSelectionGestureDetectorBuilderDelegate.
+
+  @override
+  void initState() {
+    super.initState();
+    _selectionGestureDetectorBuilder = _BasicTestTextFieldSelectionGestureDetectorBuilder(
+      state: this,
+    );
+  }
 
   @override
   void dispose() {
@@ -195,24 +217,47 @@ class _BasicTestTextFieldState extends State<BasicTestTextField> {
       TargetPlatform.iOS => true,
       _ => false,
     };
-    return EditableText(
-      autofillHints: widget.autofillHints,
-      maxLines: widget.maxLines,
-      onChanged: widget.onChanged,
-      readOnly: widget.readOnly,
-      autofocus: widget.autofocus,
-      controller: _effectiveController,
-      focusNode: _effectiveFocusNode,
-      style: widget.style ?? const TextStyle(),
-      contextMenuBuilder: widget.contextMenuBuilder,
-      cursorColor: _red, // Colors.red
-      backgroundCursorColor: _red, // Colors.red
-      selectionControls: basicTestTextSelectionHandleControls,
-      cursorOpacityAnimates: cursorOpacityAnimates,
-      showCursor: widget.showCursor,
-      groupId: widget.groupId,
+    forcePressEnabled = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS => true,
+      _ => false,
+    };
+    return _selectionGestureDetectorBuilder.buildGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      child: EditableText(
+        key: editableTextKey,
+        autofillHints: widget.autofillHints,
+        maxLines: widget.maxLines,
+        onChanged: widget.onChanged,
+        readOnly: widget.readOnly,
+        autofocus: widget.autofocus,
+        controller: _effectiveController,
+        focusNode: _effectiveFocusNode,
+        style: widget.style ?? const TextStyle(),
+        contextMenuBuilder: widget.contextMenuBuilder,
+        cursorColor: _red, // Colors.red
+        backgroundCursorColor: _red, // Colors.red
+        selectionControls: basicTestTextSelectionHandleControls,
+        cursorOpacityAnimates: cursorOpacityAnimates,
+        showCursor: widget.showCursor,
+        groupId: widget.groupId,
+        rendererIgnoresPointer: true, // for gestures.
+      ),
     );
   }
+}
+
+class _BasicTestTextFieldSelectionGestureDetectorBuilder
+    extends TextSelectionGestureDetectorBuilder {
+  _BasicTestTextFieldSelectionGestureDetectorBuilder({required _BasicTestTextFieldState state})
+    : super(delegate: state);
+
+  @override
+  void onUserTap() {
+    // BasicTestTextField does not have an onTap callback.
+  }
+
+  @override
+  bool get onUserTapAlwaysCalled => false;
 }
 
 class BasicTestTextSelectionHandleControls extends TextSelectionControls

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -142,8 +142,16 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 }
 
 class BasicTestTextField extends StatefulWidget {
-  const BasicTestTextField({super.key, this.focusNode, this.style});
+  const BasicTestTextField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.style,
+    this.autofocus = false,
+  });
 
+  final bool autofocus;
+  final TextEditingController? controller;
   final FocusNode? focusNode;
   final TextStyle? style;
 
@@ -152,21 +160,24 @@ class BasicTestTextField extends StatefulWidget {
 }
 
 class _BasicTestTextFieldState extends State<BasicTestTextField> {
-  final TextEditingController _controller = TextEditingController();
+  TextEditingController? _controller;
+  TextEditingController get _effectiveController =>
+      widget.controller ?? (_controller ??= TextEditingController());
   FocusNode? _focusNode;
   FocusNode get _effectiveFocusNode => widget.focusNode ?? (_focusNode ??= FocusNode());
 
   @override
   void dispose() {
     _focusNode?.dispose();
-    _controller.dispose();
+    _controller?.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return EditableText(
-      controller: _controller,
+      autofocus: widget.autofocus,
+      controller: _effectiveController,
       focusNode: _effectiveFocusNode,
       style: widget.style ?? const TextStyle(),
       cursorColor: Colors.red,

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -150,6 +150,11 @@ class BasicTestTextField extends StatefulWidget {
     this.autofocus = false,
     this.contextMenuBuilder,
     this.readOnly = false,
+    this.onChanged,
+    this.maxLines = 1,
+    this.showCursor,
+    this.autofillHints = const <String>[],
+    this.groupId = EditableText,
   });
 
   final bool autofocus;
@@ -158,6 +163,11 @@ class BasicTestTextField extends StatefulWidget {
   final TextStyle? style;
   final EditableTextContextMenuBuilder? contextMenuBuilder;
   final bool readOnly;
+  final ValueChanged<String>? onChanged;
+  final int? maxLines;
+  final bool? showCursor;
+  final Iterable<String>? autofillHints;
+  final Object groupId;
 
   @override
   State<BasicTestTextField> createState() => _BasicTestTextFieldState();
@@ -181,7 +191,14 @@ class _BasicTestTextFieldState extends State<BasicTestTextField> {
 
   @override
   Widget build(BuildContext context) {
+    final bool cursorOpacityAnimates = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS => true,
+      _ => false,
+    };
     return EditableText(
+      autofillHints: widget.autofillHints,
+      maxLines: widget.maxLines,
+      onChanged: widget.onChanged,
       readOnly: widget.readOnly,
       autofocus: widget.autofocus,
       controller: _effectiveController,
@@ -191,6 +208,9 @@ class _BasicTestTextFieldState extends State<BasicTestTextField> {
       cursorColor: _red, // Colors.red
       backgroundCursorColor: _red, // Colors.red
       selectionControls: basicTestTextSelectionHandleControls,
+      cursorOpacityAnimates: cursorOpacityAnimates,
+      showCursor: widget.showCursor,
+      groupId: widget.groupId,
     );
   }
 }

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -156,9 +156,6 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 ///
 /// This widget provides platform defaults based on observed native behavior:
 ///
-///  * [EditableText.cursorOpacityAnimates] is set to true on iOS.
-///  * [EditableText.cursorRadius] is set to `Radius.circular(2.0)` on iOS and macOS.
-///  * [EditableText.backgroundCursorColor] is set to `Color(0xFF999999)` on iOS and macOS.
 ///  * [TextSelectionGestureDetectorBuilderDelegate.forcePressEnabled] is set to true on iOS.
 class TestTextField extends StatefulWidget {
   const TestTextField({
@@ -167,6 +164,7 @@ class TestTextField extends StatefulWidget {
     this.autofocus = false,
     this.contextMenuBuilder,
     this.cursorColor,
+    this.cursorOpacityAnimates = false,
     this.focusNode,
     this.groupId = EditableText,
     this.maxLines = 1,
@@ -181,6 +179,7 @@ class TestTextField extends StatefulWidget {
   final bool autofocus;
   final EditableTextContextMenuBuilder? contextMenuBuilder;
   final Color? cursorColor;
+  final bool cursorOpacityAnimates;
   final FocusNode? focusNode;
   final Object groupId;
   final int? maxLines;
@@ -229,25 +228,10 @@ class _TestTextFieldState extends State<TestTextField>
   }
 
   static const Color _red = Color(0xFFF44336); // Colors.red.
-  static const Color _cupertinoInactiveGrey = Color(
-    0xFF999999,
-  ); // CupertinoColors.inactiveGrey.color
 
   @override
   Widget build(BuildContext context) {
     // Platform defaults.
-    final bool cursorOpacityAnimates = switch (defaultTargetPlatform) {
-      TargetPlatform.iOS => true,
-      _ => false,
-    };
-    final Radius? cursorRadius = switch (defaultTargetPlatform) {
-      TargetPlatform.iOS || TargetPlatform.macOS => const Radius.circular(2.0),
-      _ => null,
-    };
-    final Color? backgroundCursorColor = switch (defaultTargetPlatform) {
-      TargetPlatform.iOS || TargetPlatform.macOS => _cupertinoInactiveGrey,
-      _ => null,
-    };
     forcePressEnabled = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => true,
       _ => false,
@@ -259,12 +243,10 @@ class _TestTextFieldState extends State<TestTextField>
         key: editableTextKey,
         autofillHints: widget.autofillHints,
         autofocus: widget.autofocus,
-        backgroundCursorColor:
-            backgroundCursorColor ?? _red, // Colors.red, required by editable text.
+        backgroundCursorColor: _red, // Colors.red, required by editable text.
         contextMenuBuilder: widget.contextMenuBuilder,
         cursorColor: widget.cursorColor ?? _red, // Colors.red, required by editable text.
-        cursorOpacityAnimates: cursorOpacityAnimates,
-        cursorRadius: cursorRadius,
+        cursorOpacityAnimates: widget.cursorOpacityAnimates,
         focusNode: _effectiveFocusNode, // required by editable text.
         groupId: widget.groupId,
         maxLines: widget.maxLines,

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -154,6 +154,7 @@ class TestTextField extends StatefulWidget {
     this.autofillHints = const <String>[],
     this.autofocus = false,
     this.contextMenuBuilder,
+    this.cursorColor,
     this.focusNode,
     this.groupId = EditableText,
     this.maxLines = 1,
@@ -167,6 +168,7 @@ class TestTextField extends StatefulWidget {
   final Iterable<String>? autofillHints;
   final bool autofocus;
   final EditableTextContextMenuBuilder? contextMenuBuilder;
+  final Color? cursorColor;
   final FocusNode? focusNode;
   final Object groupId;
   final int? maxLines;
@@ -234,7 +236,7 @@ class _TestTextFieldState extends State<TestTextField>
         autofocus: widget.autofocus,
         backgroundCursorColor: _red, // Colors.red
         contextMenuBuilder: widget.contextMenuBuilder,
-        cursorColor: _red, // Colors.red
+        cursorColor: widget.cursorColor ?? _red, // Colors.red
         cursorOpacityAnimates: cursorOpacityAnimates,
         focusNode: _effectiveFocusNode,
         groupId: widget.groupId,

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -141,6 +141,13 @@ class OverflowWidgetTextEditingController extends TextEditingController {
   }
 }
 
+/// A minimal wrapper around [EditableText] for use in widget tests.
+///
+/// This wrapper provides robust text selection gestures through
+/// [TextSelectionGestureDetector].
+///
+/// This wrapper does not provide selection handles or context menus
+/// out of the box.
 class TestTextField extends StatefulWidget {
   const TestTextField({
     super.key,

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -217,12 +217,23 @@ class _TestTextFieldState extends State<TestTextField>
   }
 
   static const Color _red = Color(0xFFF44336); // Colors.red.
+  static const Color _cupertinoInactiveGrey = Color(
+    0xFF999999,
+  ); // CupertinoColors.inactiveGrey.color
 
   @override
   Widget build(BuildContext context) {
     final bool cursorOpacityAnimates = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => true,
       _ => false,
+    };
+    final Radius? cursorRadius = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => const Radius.circular(2.0),
+      _ => null,
+    };
+    final Color? backgroundCursorColor = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => _cupertinoInactiveGrey,
+      _ => null,
     };
     forcePressEnabled = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => true,
@@ -234,10 +245,11 @@ class _TestTextFieldState extends State<TestTextField>
         key: editableTextKey,
         autofillHints: widget.autofillHints,
         autofocus: widget.autofocus,
-        backgroundCursorColor: _red, // Colors.red
+        backgroundCursorColor: backgroundCursorColor ?? _red, // Colors.red
         contextMenuBuilder: widget.contextMenuBuilder,
         cursorColor: widget.cursorColor ?? _red, // Colors.red
         cursorOpacityAnimates: cursorOpacityAnimates,
+        cursorRadius: cursorRadius,
         focusNode: _effectiveFocusNode,
         groupId: widget.groupId,
         maxLines: widget.maxLines,

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -144,30 +144,30 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 class BasicTestTextField extends StatefulWidget {
   const BasicTestTextField({
     super.key,
-    this.controller,
-    this.focusNode,
-    this.style,
+    this.autofillHints = const <String>[],
     this.autofocus = false,
     this.contextMenuBuilder,
-    this.readOnly = false,
-    this.onChanged,
-    this.maxLines = 1,
-    this.showCursor,
-    this.autofillHints = const <String>[],
+    this.focusNode,
     this.groupId = EditableText,
+    this.maxLines = 1,
+    this.onChanged,
+    this.readOnly = false,
+    this.showCursor,
+    this.style,
+    this.controller,
   });
 
-  final bool autofocus;
-  final TextEditingController? controller;
-  final FocusNode? focusNode;
-  final TextStyle? style;
-  final EditableTextContextMenuBuilder? contextMenuBuilder;
-  final bool readOnly;
-  final ValueChanged<String>? onChanged;
-  final int? maxLines;
-  final bool? showCursor;
   final Iterable<String>? autofillHints;
+  final bool autofocus;
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
+  final FocusNode? focusNode;
   final Object groupId;
+  final int? maxLines;
+  final ValueChanged<String>? onChanged;
+  final bool readOnly;
+  final bool? showCursor;
+  final TextStyle? style;
+  final TextEditingController? controller;
 
   @override
   State<BasicTestTextField> createState() => _BasicTestTextFieldState();
@@ -226,21 +226,21 @@ class _BasicTestTextFieldState extends State<BasicTestTextField>
       child: EditableText(
         key: editableTextKey,
         autofillHints: widget.autofillHints,
+        autofocus: widget.autofocus,
+        backgroundCursorColor: _red, // Colors.red
+        contextMenuBuilder: widget.contextMenuBuilder,
+        cursorColor: _red, // Colors.red
+        cursorOpacityAnimates: cursorOpacityAnimates,
+        focusNode: _effectiveFocusNode,
+        groupId: widget.groupId,
         maxLines: widget.maxLines,
         onChanged: widget.onChanged,
         readOnly: widget.readOnly,
-        autofocus: widget.autofocus,
-        controller: _effectiveController,
-        focusNode: _effectiveFocusNode,
-        style: widget.style ?? const TextStyle(),
-        contextMenuBuilder: widget.contextMenuBuilder,
-        cursorColor: _red, // Colors.red
-        backgroundCursorColor: _red, // Colors.red
-        selectionControls: basicTestTextSelectionHandleControls,
-        cursorOpacityAnimates: cursorOpacityAnimates,
-        showCursor: widget.showCursor,
-        groupId: widget.groupId,
         rendererIgnoresPointer: true, // for gestures.
+        selectionControls: basicTestTextSelectionHandleControls,
+        showCursor: widget.showCursor,
+        style: widget.style ?? const TextStyle(),
+        controller: _effectiveController,
       ),
     );
   }

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -147,16 +147,13 @@ class OverflowWidgetTextEditingController extends TextEditingController {
 /// [TextSelectionGestureDetector].
 ///
 /// This widget does not provide selection handles or text selection
-/// context menus out of the box.
+/// context menus out of the box. They can be added by providing
+/// [selectionControls] and [contextMenuBuilder].
 ///
 /// This input field manages its own internal [TextEditingController]
 /// and [FocusNode] unless provided one. This field also provides defaults
 /// for required [EditableText] members [EditableText.cursorColor],
 /// [EditableText.backgroundCursorColor], and [EditableText.style].
-///
-/// This widget provides platform defaults based on observed native behavior:
-///
-///  * [TextSelectionGestureDetectorBuilderDelegate.forcePressEnabled] is set to true on iOS.
 class TestTextField extends StatefulWidget {
   const TestTextField({
     super.key,
@@ -170,6 +167,7 @@ class TestTextField extends StatefulWidget {
     this.maxLines = 1,
     this.onChanged,
     this.readOnly = false,
+    this.selectionControls,
     this.showCursor,
     this.style,
     this.controller,
@@ -185,6 +183,7 @@ class TestTextField extends StatefulWidget {
   final int? maxLines;
   final ValueChanged<String>? onChanged;
   final bool readOnly;
+  final TextSelectionControls? selectionControls;
   final bool? showCursor;
   final TextStyle? style;
   final TextEditingController? controller;
@@ -205,7 +204,7 @@ class _TestTextFieldState extends State<TestTextField>
 
   // API for TextSelectionGestureDetectorBuilderDelegate.
   @override
-  late bool forcePressEnabled;
+  bool get forcePressEnabled => false;
 
   @override
   final GlobalKey<EditableTextState> editableTextKey = GlobalKey<EditableTextState>();
@@ -227,16 +226,10 @@ class _TestTextFieldState extends State<TestTextField>
     super.dispose();
   }
 
-  static const Color _red = Color(0xFFF44336); // Colors.red.
+  static const Color _red = Color.fromARGB(0xFF, 0xFF, 0x00, 0x00);
 
   @override
   Widget build(BuildContext context) {
-    // Platform defaults.
-    forcePressEnabled = switch (defaultTargetPlatform) {
-      TargetPlatform.iOS => true,
-      _ => false,
-    };
-    // End of platform defaults.
     return _selectionGestureDetectorBuilder.buildGestureDetector(
       behavior: HitTestBehavior.translucent,
       child: EditableText(
@@ -253,7 +246,7 @@ class _TestTextFieldState extends State<TestTextField>
         onChanged: widget.onChanged,
         readOnly: widget.readOnly,
         rendererIgnoresPointer: true, // gestures are provided by text selection gesture detector.
-        selectionControls: testTextSelectionHandleControls,
+        selectionControls: widget.selectionControls,
         showCursor: widget.showCursor,
         style: widget.style ?? const TextStyle(), // required by editable text.
         controller: _effectiveController, // required by editable text.

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -141,8 +141,8 @@ class OverflowWidgetTextEditingController extends TextEditingController {
   }
 }
 
-class BasicTestTextField extends StatefulWidget {
-  const BasicTestTextField({
+class TestTextField extends StatefulWidget {
+  const TestTextField({
     super.key,
     this.autofillHints = const <String>[],
     this.autofocus = false,
@@ -170,10 +170,10 @@ class BasicTestTextField extends StatefulWidget {
   final TextEditingController? controller;
 
   @override
-  State<BasicTestTextField> createState() => _BasicTestTextFieldState();
+  State<TestTextField> createState() => _TestTextFieldState();
 }
 
-class _BasicTestTextFieldState extends State<BasicTestTextField>
+class _TestTextFieldState extends State<TestTextField>
     implements TextSelectionGestureDetectorBuilderDelegate {
   TextEditingController? _controller;
   TextEditingController get _effectiveController =>
@@ -248,7 +248,7 @@ class _BasicTestTextFieldState extends State<BasicTestTextField>
 
 class _BasicTestTextFieldSelectionGestureDetectorBuilder
     extends TextSelectionGestureDetectorBuilder {
-  _BasicTestTextFieldSelectionGestureDetectorBuilder({required _BasicTestTextFieldState state})
+  _BasicTestTextFieldSelectionGestureDetectorBuilder({required _TestTextFieldState state})
     : super(delegate: state);
 
   @override

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart';
+
 void main() {
   testWidgets('onSaved callback is called', (WidgetTester tester) async {
     final formKey = GlobalKey<FormState>();
@@ -62,7 +64,7 @@ void main() {
             child: Center(
               child: Material(
                 child: Form(
-                  child: TextField(
+                  child: BasicTestTextField(
                     onChanged: (String value) {
                       fieldValue = value;
                     },
@@ -80,7 +82,7 @@ void main() {
     expect(fieldValue, isNull);
 
     Future<void> checkText(String testValue) async {
-      await tester.enterText(find.byType(TextField), testValue);
+      await tester.enterText(find.byType(BasicTestTextField), testValue);
       // Pumping is unnecessary because callback happens regardless of frames.
       expect(fieldValue, equals(testValue));
     }

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -64,7 +64,7 @@ void main() {
             child: Center(
               child: Material(
                 child: Form(
-                  child: BasicTestTextField(
+                  child: TestTextField(
                     onChanged: (String value) {
                       fieldValue = value;
                     },
@@ -82,7 +82,7 @@ void main() {
     expect(fieldValue, isNull);
 
     Future<void> checkText(String testValue) async {
-      await tester.enterText(find.byType(BasicTestTextField), testValue);
+      await tester.enterText(find.byType(TestTextField), testValue);
       // Pumping is unnecessary because callback happens regardless of frames.
       expect(fieldValue, equals(testValue));
     }

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 
 void main() {
   testWidgets('Radio group control test', (WidgetTester tester) async {
@@ -245,7 +245,7 @@ void main() {
         home: Material(
           child: Column(
             children: <Widget>[
-              BasicTestTextField(focusNode: textFieldBefore),
+              TestTextField(focusNode: textFieldBefore),
               TestRadioGroup<int>(
                 child: Column(
                   children: <Widget>[
@@ -255,7 +255,7 @@ void main() {
                   ],
                 ),
               ),
-              BasicTestTextField(focusNode: textFieldAfter),
+              TestTextField(focusNode: textFieldAfter),
             ],
           ),
         ),
@@ -414,7 +414,7 @@ void main() {
                   Radio<int>(focusNode: firstRadioFocusNode, value: 0),
                   const RadioListTile<int>(value: 1),
                   const Radio<int>(value: 2),
-                  BasicTestTextField(focusNode: textFieldFocusNode),
+                  TestTextField(focusNode: textFieldFocusNode),
                 ],
               ),
             ),

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart' show BasicTestTextField;
+
 void main() {
   testWidgets('Radio group control test', (WidgetTester tester) async {
     final key0 = UniqueKey();
@@ -243,7 +245,7 @@ void main() {
         home: Material(
           child: Column(
             children: <Widget>[
-              TextField(focusNode: textFieldBefore),
+              BasicTestTextField(focusNode: textFieldBefore),
               TestRadioGroup<int>(
                 child: Column(
                   children: <Widget>[
@@ -253,7 +255,7 @@ void main() {
                   ],
                 ),
               ),
-              TextField(focusNode: textFieldAfter),
+              BasicTestTextField(focusNode: textFieldAfter),
             ],
           ),
         ),
@@ -412,7 +414,7 @@ void main() {
                   Radio<int>(focusNode: firstRadioFocusNode, value: 0),
                   const RadioListTile<int>(value: 1),
                   const Radio<int>(value: 2),
-                  TextField(focusNode: textFieldFocusNode),
+                  BasicTestTextField(focusNode: textFieldFocusNode),
                 ],
               ),
             ),

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 import 'semantics_tester.dart';
 
 final List<String> results = <String>[];
@@ -526,7 +526,7 @@ void main() {
               settings: settings,
               pageBuilder: (BuildContext context, Animation<double> input, Animation<double> out) {
                 return Focus(
-                  child: BasicTestTextField(
+                  child: TestTextField(
                     autofocus: true,
                     focusNode: focusNode,
                     controller: controller,
@@ -1997,12 +1997,12 @@ void main() {
         // Pushes one page.
         navigatorKey.currentState!.push<void>(
           MaterialPageRoute<void>(
-            builder: (BuildContext context) => const Material(child: BasicTestTextField()),
+            builder: (BuildContext context) => const Material(child: TestTextField()),
           ),
         );
         await tester.pumpAndSettle();
 
-        final Element textOnPageTwo = tester.element(find.byType(BasicTestTextField));
+        final Element textOnPageTwo = tester.element(find.byType(TestTextField));
         final FocusScopeNode focusNodeOnPageTwo = FocusScope.of(textOnPageTwo);
         // The focus should be on second page.
         expect(focusNodeOnPageOne.hasFocus, isFalse);
@@ -2832,7 +2832,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         navigatorKey: navigatorKey,
-        home: Scaffold(body: BasicTestTextField(focusNode: focusNode)),
+        home: Scaffold(body: TestTextField(focusNode: focusNode)),
       ),
     );
     focusNode.requestFocus();

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart' show BasicTestTextField;
 import 'semantics_tester.dart';
 
 final List<String> results = <String>[];
@@ -525,7 +526,11 @@ void main() {
               settings: settings,
               pageBuilder: (BuildContext context, Animation<double> input, Animation<double> out) {
                 return Focus(
-                  child: TextField(autofocus: true, focusNode: focusNode, controller: controller),
+                  child: BasicTestTextField(
+                    autofocus: true,
+                    focusNode: focusNode,
+                    controller: controller,
+                  ),
                 );
               },
             );
@@ -1992,12 +1997,12 @@ void main() {
         // Pushes one page.
         navigatorKey.currentState!.push<void>(
           MaterialPageRoute<void>(
-            builder: (BuildContext context) => const Material(child: TextField()),
+            builder: (BuildContext context) => const Material(child: BasicTestTextField()),
           ),
         );
         await tester.pumpAndSettle();
 
-        final Element textOnPageTwo = tester.element(find.byType(TextField));
+        final Element textOnPageTwo = tester.element(find.byType(BasicTestTextField));
         final FocusScopeNode focusNodeOnPageTwo = FocusScope.of(textOnPageTwo);
         // The focus should be on second page.
         expect(focusNodeOnPageOne.hasFocus, isFalse);
@@ -2827,7 +2832,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         navigatorKey: navigatorKey,
-        home: Scaffold(body: TextField(focusNode: focusNode)),
+        home: Scaffold(body: BasicTestTextField(focusNode: focusNode)),
       ),
     );
     focusNode.requestFocus();

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart';
 import 'states.dart';
 
 class ItemWidget extends StatefulWidget {
@@ -138,7 +139,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -148,8 +149,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -261,7 +262,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -271,8 +272,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -298,7 +299,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -308,8 +309,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -337,7 +338,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -347,8 +348,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -372,10 +373,10 @@ void main() {
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
           keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           children: focusNodes.map((FocusNode focusNode) {
-            return Container(
+            return Container( 
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -385,8 +386,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -414,7 +415,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -424,8 +425,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -452,7 +453,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -462,8 +463,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -490,7 +491,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -500,8 +501,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -528,7 +529,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -538,8 +539,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -564,7 +565,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -574,8 +575,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -601,7 +602,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -611,8 +612,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -637,7 +638,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -647,8 +648,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -675,7 +676,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -685,8 +686,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -712,7 +713,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -722,8 +723,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -750,7 +751,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -760,8 +761,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -787,7 +788,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -797,8 +798,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -824,7 +825,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -834,8 +835,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -861,7 +862,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: TextField(
+              child: BasicTestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -871,8 +872,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -972,7 +973,7 @@ void main() {
                 return Container(
                   height: 50,
                   color: Colors.green,
-                  child: TextField(
+                  child: BasicTestTextField(
                     focusNode: focusNode,
                     style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   ),
@@ -984,8 +985,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(TextField).first;
-    final TextField textField = tester.widget(finder);
+    final Finder finder = find.byType(BasicTestTextField).first;
+    final BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -1787,7 +1788,7 @@ void main() {
           drawer: Container(),
           body: Column(
             children: <Widget>[
-              const TextField(),
+              const BasicTestTextField(),
               Expanded(
                 child: ListView(
                   keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -1803,7 +1804,7 @@ void main() {
     );
 
     expect(tester.testTextInput.isVisible, isFalse);
-    final Finder finder = find.byType(TextField).first;
+    final Finder finder = find.byType(BasicTestTextField).first;
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 
@@ -1915,3 +1916,4 @@ void main() {
     expect(textValues, updatedTextValues);
   });
 }
+

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -373,7 +373,7 @@ void main() {
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
           keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           children: focusNodes.map((FocusNode focusNode) {
-            return Container( 
+            return Container(
               height: 50,
               color: Colors.green,
               child: BasicTestTextField(

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1916,4 +1916,3 @@ void main() {
     expect(textValues, updatedTextValues);
   });
 }
-

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -139,7 +139,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -149,8 +149,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -262,7 +262,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -272,8 +272,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -299,7 +299,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -309,8 +309,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -338,7 +338,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -348,8 +348,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -376,7 +376,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -386,8 +386,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -415,7 +415,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -425,8 +425,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -453,7 +453,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -463,8 +463,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -491,7 +491,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -501,8 +501,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -529,7 +529,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -539,8 +539,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -565,7 +565,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -575,8 +575,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -602,7 +602,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -612,8 +612,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -638,7 +638,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -648,8 +648,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -676,7 +676,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -686,8 +686,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -713,7 +713,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -723,8 +723,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -751,7 +751,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -761,8 +761,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -788,7 +788,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -798,8 +798,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -825,7 +825,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNode,
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -835,8 +835,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -862,7 +862,7 @@ void main() {
             return Container(
               height: 50,
               color: Colors.green,
-              child: BasicTestTextField(
+              child: TestTextField(
                 focusNode: focusNodes[index],
                 style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
               ),
@@ -872,8 +872,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -973,7 +973,7 @@ void main() {
                 return Container(
                   height: 50,
                   color: Colors.green,
-                  child: BasicTestTextField(
+                  child: TestTextField(
                     focusNode: focusNode,
                     style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   ),
@@ -985,8 +985,8 @@ void main() {
       ),
     );
 
-    final Finder finder = find.byType(BasicTestTextField).first;
-    final BasicTestTextField textField = tester.widget(finder);
+    final Finder finder = find.byType(TestTextField).first;
+    final TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -1788,7 +1788,7 @@ void main() {
           drawer: Container(),
           body: Column(
             children: <Widget>[
-              const BasicTestTextField(),
+              const TestTextField(),
               Expanded(
                 child: ListView(
                   keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -1804,7 +1804,7 @@ void main() {
     );
 
     expect(tester.testTextInput.isVisible, isFalse);
-    final Finder finder = find.byType(BasicTestTextField).first;
+    final Finder finder = find.byType(TestTextField).first;
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'clipboard_utils.dart';
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 import 'keyboard_utils.dart';
 import 'process_text_utils.dart';
 import 'semantics_tester.dart';
@@ -3633,7 +3633,7 @@ void main() {
                   children: <Widget>[
                     const Text('How are you?'),
                     const Text('Good, and you?'),
-                    BasicTestTextField(controller: controller, focusNode: textFieldFocus),
+                    TestTextField(controller: controller, focusNode: textFieldFocus),
                   ],
                 ),
               ),
@@ -3705,7 +3705,7 @@ void main() {
                   children: <Widget>[
                     const Text('How are you?'),
                     const Text('Good, and you?'),
-                    BasicTestTextField(controller: controller, focusNode: textFieldFocus),
+                    TestTextField(controller: controller, focusNode: textFieldFocus),
                   ],
                 ),
               ),

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'clipboard_utils.dart';
+import 'editable_text_utils.dart' show BasicTestTextField;
 import 'keyboard_utils.dart';
 import 'process_text_utils.dart';
 import 'semantics_tester.dart';
@@ -3632,7 +3633,7 @@ void main() {
                   children: <Widget>[
                     const Text('How are you?'),
                     const Text('Good, and you?'),
-                    TextField(controller: controller, focusNode: textFieldFocus),
+                    BasicTestTextField(controller: controller, focusNode: textFieldFocus),
                   ],
                 ),
               ),
@@ -3704,7 +3705,7 @@ void main() {
                   children: <Widget>[
                     const Text('How are you?'),
                     const Text('Good, and you?'),
-                    TextField(controller: controller, focusNode: textFieldFocus),
+                    BasicTestTextField(controller: controller, focusNode: textFieldFocus),
                   ],
                 ),
               ),

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'editable_text_utils.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -963,7 +964,7 @@ void main() {
             home: Material(
               child: Shortcuts.manager(
                 manager: testManager,
-                child: TextField(key: textFieldKey, autofocus: true),
+                child: BasicTestTextField(key: textFieldKey, autofocus: true),
               ),
             ),
           ),
@@ -1002,7 +1003,7 @@ void main() {
                     },
                   ),
                 },
-                child: TextField(key: textFieldKey, autofocus: true),
+                child: BasicTestTextField(key: textFieldKey, autofocus: true),
               ),
             ),
           ),
@@ -1044,7 +1045,7 @@ void main() {
                 },
                 child: Actions(
                   actions: <Type, Action<Intent>>{TestIntent: DoNothingAction(consumesKey: false)},
-                  child: TextField(key: textFieldKey, autofocus: true),
+                  child: BasicTestTextField(key: textFieldKey, autofocus: true),
                 ),
               ),
             ),
@@ -1089,7 +1090,7 @@ void main() {
                       LogicalKeySet(LogicalKeyboardKey.keyA):
                           const DoNothingAndStopPropagationIntent(),
                     },
-                    child: TextField(key: textFieldKey, autofocus: true),
+                    child: BasicTestTextField(key: textFieldKey, autofocus: true),
                   ),
                 ),
               ),
@@ -1843,7 +1844,7 @@ void main() {
                     SelectionChangedCause.keyboard,
                   ),
                 },
-                child: TextField(autofocus: true, controller: controller),
+                child: BasicTestTextField(autofocus: true, controller: controller),
               ),
             ),
           ),

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -964,7 +964,7 @@ void main() {
             home: Material(
               child: Shortcuts.manager(
                 manager: testManager,
-                child: BasicTestTextField(key: textFieldKey, autofocus: true),
+                child: TestTextField(key: textFieldKey, autofocus: true),
               ),
             ),
           ),
@@ -1003,7 +1003,7 @@ void main() {
                     },
                   ),
                 },
-                child: BasicTestTextField(key: textFieldKey, autofocus: true),
+                child: TestTextField(key: textFieldKey, autofocus: true),
               ),
             ),
           ),
@@ -1045,7 +1045,7 @@ void main() {
                 },
                 child: Actions(
                   actions: <Type, Action<Intent>>{TestIntent: DoNothingAction(consumesKey: false)},
-                  child: BasicTestTextField(key: textFieldKey, autofocus: true),
+                  child: TestTextField(key: textFieldKey, autofocus: true),
                 ),
               ),
             ),
@@ -1090,7 +1090,7 @@ void main() {
                       LogicalKeySet(LogicalKeyboardKey.keyA):
                           const DoNothingAndStopPropagationIntent(),
                     },
-                    child: BasicTestTextField(key: textFieldKey, autofocus: true),
+                    child: TestTextField(key: textFieldKey, autofocus: true),
                   ),
                 ),
               ),
@@ -1844,7 +1844,7 @@ void main() {
                     SelectionChangedCause.keyboard,
                   ),
                 },
-                child: BasicTestTextField(autofocus: true, controller: controller),
+                child: TestTextField(autofocus: true, controller: controller),
               ),
             ),
           ),

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 import 'semantics_tester.dart';
 
 class TestScrollPosition extends ScrollPositionWithSingleContext {
@@ -1055,7 +1055,7 @@ void main() {
               keyboardDismissBehavior: behavior,
               child: Column(
                 children: focusNodes.map((FocusNode focusNode) {
-                  return SizedBox(height: 50, child: BasicTestTextField(focusNode: focusNode));
+                  return SizedBox(height: 50, child: TestTextField(focusNode: focusNode));
                 }).toList(),
               ),
             ),
@@ -1067,8 +1067,8 @@ void main() {
     // ScrollViewKeyboardDismissBehavior.onDrag dismiss keyboard on drag
     await boilerplate(ScrollViewKeyboardDismissBehavior.onDrag);
 
-    Finder finder = find.byType(BasicTestTextField).first;
-    BasicTestTextField textField = tester.widget(finder);
+    Finder finder = find.byType(TestTextField).first;
+    TestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -1079,7 +1079,7 @@ void main() {
     // ScrollViewKeyboardDismissBehavior.manual does no dismiss the keyboard
     await boilerplate(ScrollViewKeyboardDismissBehavior.manual);
 
-    finder = find.byType(BasicTestTextField).first;
+    finder = find.byType(TestTextField).first;
     textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
@@ -1099,7 +1099,7 @@ void main() {
           drawer: Container(),
           body: Column(
             children: <Widget>[
-              const BasicTestTextField(),
+              const TestTextField(),
               Expanded(
                 child: SingleChildScrollView(
                   keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -1113,7 +1113,7 @@ void main() {
     );
 
     expect(tester.testTextInput.isVisible, isFalse);
-    final Finder finder = find.byType(BasicTestTextField).first;
+    final Finder finder = find.byType(TestTextField).first;
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
+import 'editable_text_utils.dart' show BasicTestTextField;
 import 'semantics_tester.dart';
 
 class TestScrollPosition extends ScrollPositionWithSingleContext {
@@ -1054,7 +1055,7 @@ void main() {
               keyboardDismissBehavior: behavior,
               child: Column(
                 children: focusNodes.map((FocusNode focusNode) {
-                  return SizedBox(height: 50, child: TextField(focusNode: focusNode));
+                  return SizedBox(height: 50, child: BasicTestTextField(focusNode: focusNode));
                 }).toList(),
               ),
             ),
@@ -1066,8 +1067,8 @@ void main() {
     // ScrollViewKeyboardDismissBehavior.onDrag dismiss keyboard on drag
     await boilerplate(ScrollViewKeyboardDismissBehavior.onDrag);
 
-    Finder finder = find.byType(TextField).first;
-    TextField textField = tester.widget(finder);
+    Finder finder = find.byType(BasicTestTextField).first;
+    BasicTestTextField textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
 
@@ -1078,7 +1079,7 @@ void main() {
     // ScrollViewKeyboardDismissBehavior.manual does no dismiss the keyboard
     await boilerplate(ScrollViewKeyboardDismissBehavior.manual);
 
-    finder = find.byType(TextField).first;
+    finder = find.byType(BasicTestTextField).first;
     textField = tester.widget(finder);
     await tester.showKeyboard(finder);
     expect(textField.focusNode!.hasFocus, isTrue);
@@ -1098,7 +1099,7 @@ void main() {
           drawer: Container(),
           body: Column(
             children: <Widget>[
-              const TextField(),
+              const BasicTestTextField(),
               Expanded(
                 child: SingleChildScrollView(
                   keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -1112,7 +1113,7 @@ void main() {
     );
 
     expect(tester.testTextInput.isVisible, isFalse);
-    final Finder finder = find.byType(TextField).first;
+    final Finder finder = find.byType(BasicTestTextField).first;
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -1161,7 +1161,7 @@ void main() {
 
       const selection = TextSelection(baseOffset: 0, extentOffset: 3);
       controller.selection = selection;
-      await tester.longPress(find.byType(TextField));
+      await tester.longPress(find.byType(BasicTestTextField));
       await tester.pumpAndSettle();
 
       expect(find.byType(SystemContextMenu), findsOneWidget);
@@ -1263,7 +1263,7 @@ void main() {
         ),
       );
 
-      await tester.longPress(find.byType(TextField).first);
+      await tester.longPress(find.byType(BasicTestTextField).first);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1296,7 +1296,7 @@ void main() {
 
       field1ActionCalled = false;
 
-      await tester.longPress(find.byType(TextField).last);
+      await tester.longPress(find.byType(BasicTestTextField).last);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -23,7 +23,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Center(
-              child: BasicTestTextField(
+              child: TestTextField(
                 controller: controller,
                 contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
                   return SystemContextMenu.editableText(editableTextState: editableTextState);
@@ -34,7 +34,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -73,7 +73,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Center(
-              child: BasicTestTextField(
+              child: TestTextField(
                 controller: controller,
                 contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
                   return SystemContextMenu.editableText(editableTextState: editableTextState);
@@ -84,7 +84,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -109,7 +109,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -128,7 +128,7 @@ void main() {
 
       expect(find.byType(SystemContextMenu), findsNothing);
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -187,7 +187,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -208,7 +208,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -272,7 +272,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -295,7 +295,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       expect(tester.takeException(), isNull);
@@ -355,7 +355,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -376,7 +376,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -438,7 +438,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -457,7 +457,7 @@ void main() {
 
       expect(targetRects, isEmpty);
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -493,7 +493,7 @@ void main() {
                     child: StatefulBuilder(
                       builder: (BuildContext context, StateSetter localSetState) {
                         setState = localSetState;
-                        return BasicTestTextField(
+                        return TestTextField(
                           controller: controller,
                           contextMenuBuilder:
                               (BuildContext context, EditableTextState editableTextState) {
@@ -512,7 +512,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -548,7 +548,7 @@ void main() {
                   body: Center(
                     child: Column(
                       children: <Widget>[
-                        BasicTestTextField(
+                        TestTextField(
                           key: field1Key,
                           controller: controller1,
                           contextMenuBuilder:
@@ -559,7 +559,7 @@ void main() {
                                 );
                               },
                         ),
-                        BasicTestTextField(
+                        TestTextField(
                           key: field2Key,
                           controller: controller2,
                           contextMenuBuilder:
@@ -752,7 +752,7 @@ void main() {
                   body: Builder(
                     builder: (BuildContext context) {
                       buildContext = context;
-                      return BasicTestTextField(
+                      return TestTextField(
                         controller: controller,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -793,7 +793,7 @@ void main() {
                   body: Builder(
                     builder: (BuildContext context) {
                       buildContext = context;
-                      return BasicTestTextField(
+                      return TestTextField(
                         controller: controller,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -831,7 +831,7 @@ void main() {
               return MediaQuery(
                 data: mediaQueryData.copyWith(supportsShowingSystemContextMenu: true),
                 child: MaterialApp(
-                  home: Scaffold(body: BasicTestTextField(readOnly: readOnly)),
+                  home: Scaffold(body: TestTextField(readOnly: readOnly)),
                 ),
               );
             },
@@ -864,7 +864,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -883,7 +883,7 @@ void main() {
 
       expect(find.byType(SystemContextMenu), findsNothing);
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -953,7 +953,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -971,7 +971,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -1046,7 +1046,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -1071,7 +1071,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -1138,7 +1138,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: BasicTestTextField(
+                    child: TestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -1156,12 +1156,12 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField));
+      await tester.tap(find.byType(TestTextField));
       await tester.pumpAndSettle();
 
       const selection = TextSelection(baseOffset: 0, extentOffset: 3);
       controller.selection = selection;
-      await tester.longPress(find.byType(BasicTestTextField));
+      await tester.longPress(find.byType(TestTextField));
       await tester.pumpAndSettle();
 
       expect(find.byType(SystemContextMenu), findsOneWidget);
@@ -1220,7 +1220,7 @@ void main() {
                 home: Scaffold(
                   body: Column(
                     children: <Widget>[
-                      BasicTestTextField(
+                      TestTextField(
                         controller: controller1,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -1237,7 +1237,7 @@ void main() {
                               );
                             },
                       ),
-                      BasicTestTextField(
+                      TestTextField(
                         controller: controller2,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -1263,7 +1263,7 @@ void main() {
         ),
       );
 
-      await tester.longPress(find.byType(BasicTestTextField).first);
+      await tester.longPress(find.byType(TestTextField).first);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1296,7 +1296,7 @@ void main() {
 
       field1ActionCalled = false;
 
-      await tester.longPress(find.byType(BasicTestTextField).last);
+      await tester.longPress(find.byType(TestTextField).last);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../system_context_menu_utils.dart';
+import 'editable_text_utils.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -22,7 +23,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Center(
-              child: TextField(
+              child: BasicTestTextField(
                 controller: controller,
                 contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
                   return SystemContextMenu.editableText(editableTextState: editableTextState);
@@ -33,7 +34,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -72,7 +73,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Center(
-              child: TextField(
+              child: BasicTestTextField(
                 controller: controller,
                 contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
                   return SystemContextMenu.editableText(editableTextState: editableTextState);
@@ -83,7 +84,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -108,7 +109,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -127,7 +128,7 @@ void main() {
 
       expect(find.byType(SystemContextMenu), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -186,7 +187,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -207,7 +208,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -271,7 +272,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -294,7 +295,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       expect(tester.takeException(), isNull);
@@ -354,7 +355,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -375,7 +376,7 @@ void main() {
       expect(find.byType(SystemContextMenu), findsNothing);
       expect(itemsReceived, hasLength(0));
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -437,7 +438,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -456,7 +457,7 @@ void main() {
 
       expect(targetRects, isEmpty);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -492,7 +493,7 @@ void main() {
                     child: StatefulBuilder(
                       builder: (BuildContext context, StateSetter localSetState) {
                         setState = localSetState;
-                        return TextField(
+                        return BasicTestTextField(
                           controller: controller,
                           contextMenuBuilder:
                               (BuildContext context, EditableTextState editableTextState) {
@@ -511,7 +512,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -547,7 +548,7 @@ void main() {
                   body: Center(
                     child: Column(
                       children: <Widget>[
-                        TextField(
+                        BasicTestTextField(
                           key: field1Key,
                           controller: controller1,
                           contextMenuBuilder:
@@ -558,7 +559,7 @@ void main() {
                                 );
                               },
                         ),
-                        TextField(
+                        BasicTestTextField(
                           key: field2Key,
                           controller: controller2,
                           contextMenuBuilder:
@@ -751,7 +752,7 @@ void main() {
                   body: Builder(
                     builder: (BuildContext context) {
                       buildContext = context;
-                      return TextField(
+                      return BasicTestTextField(
                         controller: controller,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -792,7 +793,7 @@ void main() {
                   body: Builder(
                     builder: (BuildContext context) {
                       buildContext = context;
-                      return TextField(
+                      return BasicTestTextField(
                         controller: controller,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -830,7 +831,7 @@ void main() {
               return MediaQuery(
                 data: mediaQueryData.copyWith(supportsShowingSystemContextMenu: true),
                 child: MaterialApp(
-                  home: Scaffold(body: TextField(readOnly: readOnly)),
+                  home: Scaffold(body: BasicTestTextField(readOnly: readOnly)),
                 ),
               );
             },
@@ -863,7 +864,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -882,7 +883,7 @@ void main() {
 
       expect(find.byType(SystemContextMenu), findsNothing);
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -952,7 +953,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -970,7 +971,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -1045,7 +1046,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -1070,7 +1071,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       expect(state.showToolbar(), true);
       await tester.pump();
@@ -1137,7 +1138,7 @@ void main() {
               child: MaterialApp(
                 home: Scaffold(
                   body: Center(
-                    child: TextField(
+                    child: BasicTestTextField(
                       controller: controller,
                       contextMenuBuilder:
                           (BuildContext context, EditableTextState editableTextState) {
@@ -1155,14 +1156,14 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(TextField));
+      await tester.tap(find.byType(BasicTestTextField));
       await tester.pumpAndSettle();
 
       const selection = TextSelection(baseOffset: 0, extentOffset: 3);
       controller.selection = selection;
-
-      await tester.longPress(find.byType(TextField));
-      await tester.pumpAndSettle();
+      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+      expect(state.showToolbar(), true);
+      await tester.pump();
 
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1220,7 +1221,7 @@ void main() {
                 home: Scaffold(
                   body: Column(
                     children: <Widget>[
-                      TextField(
+                      BasicTestTextField(
                         controller: controller1,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -1237,7 +1238,7 @@ void main() {
                               );
                             },
                       ),
-                      TextField(
+                      BasicTestTextField(
                         controller: controller2,
                         contextMenuBuilder:
                             (BuildContext context, EditableTextState editableTextState) {
@@ -1263,7 +1264,15 @@ void main() {
         ),
       );
 
-      await tester.longPress(find.byType(TextField).first);
+      await tester.tap(find.byType(BasicTestTextField).first);
+      await tester.pumpAndSettle();
+
+      const selection = TextSelection(baseOffset: 0, extentOffset: 3);
+      controller1.selection = selection;
+      final EditableTextState state1 = tester.state<EditableTextState>(
+        find.byType(EditableText).first,
+      );
+      expect(state1.showToolbar(), true);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1296,7 +1305,13 @@ void main() {
 
       field1ActionCalled = false;
 
-      await tester.longPress(find.byType(TextField).last);
+      await tester.tap(find.byType(BasicTestTextField).last);
+      await tester.pumpAndSettle();
+      controller2.selection = selection;
+      final EditableTextState state2 = tester.state<EditableTextState>(
+        find.byType(EditableText).last,
+      );
+      expect(state2.showToolbar(), true);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 

--- a/packages/flutter/test/widgets/system_context_menu_test.dart
+++ b/packages/flutter/test/widgets/system_context_menu_test.dart
@@ -1161,9 +1161,8 @@ void main() {
 
       const selection = TextSelection(baseOffset: 0, extentOffset: 3);
       controller.selection = selection;
-      final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-      expect(state.showToolbar(), true);
-      await tester.pump();
+      await tester.longPress(find.byType(TextField));
+      await tester.pumpAndSettle();
 
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1264,15 +1263,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byType(BasicTestTextField).first);
-      await tester.pumpAndSettle();
-
-      const selection = TextSelection(baseOffset: 0, extentOffset: 3);
-      controller1.selection = selection;
-      final EditableTextState state1 = tester.state<EditableTextState>(
-        find.byType(EditableText).first,
-      );
-      expect(state1.showToolbar(), true);
+      await tester.longPress(find.byType(TextField).first);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 
@@ -1305,13 +1296,7 @@ void main() {
 
       field1ActionCalled = false;
 
-      await tester.tap(find.byType(BasicTestTextField).last);
-      await tester.pumpAndSettle();
-      controller2.selection = selection;
-      final EditableTextState state2 = tester.state<EditableTextState>(
-        find.byType(EditableText).last,
-      );
-      expect(state2.showToolbar(), true);
+      await tester.longPress(find.byType(TextField).last);
       await tester.pump();
       expect(find.byType(SystemContextMenu), findsOneWidget);
 

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 import 'semantics_tester.dart';
 
 class TestStatefulWidget extends StatefulWidget {
@@ -1035,7 +1035,7 @@ void main() {
         home: Scaffold(
           body: Table(
             children: <TableRow>[
-              TableRow(children: <Widget>[BasicTestTextField(focusNode: focusNode)]),
+              TableRow(children: <Widget>[TestTextField(focusNode: focusNode)]),
             ],
           ),
         ),

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'editable_text_utils.dart' show BasicTestTextField;
 import 'semantics_tester.dart';
 
 class TestStatefulWidget extends StatefulWidget {
@@ -1034,7 +1035,7 @@ void main() {
         home: Scaffold(
           body: Table(
             children: <TableRow>[
-              TableRow(children: <Widget>[TextField(focusNode: focusNode)]),
+              TableRow(children: <Widget>[BasicTestTextField(focusNode: focusNode)]),
             ],
           ),
         ),

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -569,7 +569,7 @@ void main() {
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (_, int index) =>
-                        index == 0 ? const BasicTestTextField() : const SizedBox(height: 50),
+                        index == 0 ? const TestTextField() : const SizedBox(height: 50),
                     childCount: 200,
                     addAutomaticKeepAlives: false,
                   ),
@@ -583,7 +583,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       // Start a long press, don't release it, and don't completely reach kLongPressTimeout so the
       // gesture is not accepted and is cancelled when the recognizer is disposed.
-      await tester.startGesture(tester.getCenter(find.byType(BasicTestTextField)));
+      await tester.startGesture(tester.getCenter(find.byType(TestTextField)));
       await tester.pump(const Duration(milliseconds: 200));
       await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1237,7 +1237,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TextField(autofocus: true, controller: controller)),
+          home: Scaffold(body: TestTextField(autofocus: true, controller: controller)),
         ),
       );
 
@@ -1254,7 +1254,7 @@ void main() {
       expect(gestureDetector, findsOneWidget);
       // The GestureDetector's size should not exceed that of the TextField.
       final Rect hitRect = tester.getRect(gestureDetector);
-      final Rect textFieldRect = tester.getRect(find.byType(TextField));
+      final Rect textFieldRect = tester.getRect(find.byType(TestTextField));
 
       expect(hitRect.size.width, lessThanOrEqualTo(textFieldRect.size.width));
       expect(hitRect.size.height, lessThanOrEqualTo(textFieldRect.size.height));

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1237,7 +1237,13 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(body: TestTextField(autofocus: true, controller: controller)),
+          home: Scaffold(
+            body: TestTextField(
+              autofocus: true,
+              selectionControls: testTextSelectionHandleControls, // Needed for handles.
+              controller: controller,
+            ),
+          ),
         ),
       );
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -568,7 +568,8 @@ void main() {
               slivers: <Widget>[
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
-                    (_, int index) => index == 0 ? const TextField() : const SizedBox(height: 50),
+                    (_, int index) =>
+                        index == 0 ? const BasicTestTextField() : const SizedBox(height: 50),
                     childCount: 200,
                     addAutomaticKeepAlives: false,
                   ),
@@ -582,7 +583,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
       // Start a long press, don't release it, and don't completely reach kLongPressTimeout so the
       // gesture is not accepted and is cancelled when the recognizer is disposed.
-      await tester.startGesture(tester.getCenter(find.byType(TextField)));
+      await tester.startGesture(tester.getCenter(find.byType(BasicTestTextField)));
       await tester.pump(const Duration(milliseconds: 200));
       await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1237,13 +1237,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: TestTextField(
-              autofocus: true,
-              selectionControls: testTextSelectionHandleControls, // Needed for handles.
-              controller: controller,
-            ),
-          ),
+          home: Scaffold(body: TestTextField(autofocus: true, controller: controller)),
         ),
       );
 

--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/src/gestures/monodrag.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'editable_text_utils.dart' show BasicTestTextField;
 import 'two_dimensional_utils.dart';
 
 Widget? _testChildBuilder(BuildContext context, ChildVicinity vicinity) {
@@ -958,7 +959,7 @@ void main() {
             drawer: Container(),
             body: Column(
               children: <Widget>[
-                const TextField(),
+                const BasicTestTextField(),
                 Expanded(
                   child: SimpleBuilderTableView(
                     keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -978,7 +979,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.testTextInput.isVisible, isFalse);
-      final Finder finder = find.byType(TextField).first;
+      final Finder finder = find.byType(BasicTestTextField).first;
       await tester.tap(finder);
       expect(tester.testTextInput.isVisible, isTrue);
 

--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/src/gestures/monodrag.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'editable_text_utils.dart' show BasicTestTextField;
+import 'editable_text_utils.dart' show TestTextField;
 import 'two_dimensional_utils.dart';
 
 Widget? _testChildBuilder(BuildContext context, ChildVicinity vicinity) {
@@ -959,7 +959,7 @@ void main() {
             drawer: Container(),
             body: Column(
               children: <Widget>[
-                const BasicTestTextField(),
+                const TestTextField(),
                 Expanded(
                   child: SimpleBuilderTableView(
                     keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -979,7 +979,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.testTextInput.isVisible, isFalse);
-      final Finder finder = find.byType(BasicTestTextField).first;
+      final Finder finder = find.byType(TestTextField).first;
       await tester.tap(finder);
       expect(tester.testTextInput.isVisible, isTrue);
 


### PR DESCRIPTION
This PR introduces the convenience widget `TestTextField` in the framework widget tests. This new widget should be used in place of convenient `TextField` or `CupertinoTextField` usages in the widgets library tests.

part of: #177415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.