### PR TITLE
Bump deps of hooks,code_assets,native_toolchain_c

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_assets
-      sha256: ae0db647e668cbb295a3527f0938e4039e004c80099dce2f964102373f5ce0b5
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.10"
+    version: "1.0.0"
   collection:
     dependency: "direct main"
     description:
@@ -350,10 +350,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "5410b9f4f6c9f01e8ff0eb81c9801ea13a3c3d39f8f0b1613cda08e27eab3c18"
+      sha256: "5d309c86e7ce34cd8e37aa71cb30cb652d3829b900ab145e4d9da564b31d59f7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.5"
+    version: "1.0.0"
   html:
     dependency: "direct main"
     description:
@@ -510,10 +510,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_c
-      sha256: f8872ea6c7a50ce08db9ae280ca2b8efdd973157ce462826c82f3c3051d154ce
+      sha256: "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.2"
+    version: "0.17.4"
   nested:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   checked_yaml: 2.0.4
   cli_config: 0.2.0
   clock: 1.1.2
-  code_assets: 0.19.10
+  code_assets: 1.0.0
   collection: 1.19.1
   convert: 3.1.2
   coverage: 1.15.0
@@ -114,7 +114,7 @@ dependencies:
   google_mobile_ads: 5.1.0
   googleapis: 12.0.0
   googleapis_auth: 1.6.0
-  hooks: 0.20.5
+  hooks: 1.0.0
   html: 0.15.6
   http: 1.6.0
   http_multi_server: 3.2.2
@@ -133,7 +133,7 @@ dependencies:
   meta: 1.17.0
   metrics_center: 1.0.13
   mime: 2.0.0
-  native_toolchain_c: 0.17.2
+  native_toolchain_c: 0.17.4
   nested: 1.0.0
   node_preamble: 2.0.2
   package_config: 2.2.0
@@ -212,4 +212,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.3
-# PUBSPEC CHECKSUM: 27md0
+# PUBSPEC CHECKSUM: r0b6tb


### PR DESCRIPTION
It's unclear why these aren't getting picked up by the autoroller, see https://github.com/flutter/flutter/issues/180503.