### PR TITLE
Fix external texture support in embedder for Impeller

### DIFF
--- a/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/engine/src/flutter/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -140,11 +140,12 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTextureImpeller(
 
   impeller::TextureDescriptor desc;
   desc.size = impeller::ISize(texture->width, texture->height);
+  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
 
   impeller::ContextGLES& context =
       impeller::ContextGLES::Cast(*aiks_context->GetContext());
   impeller::HandleGLES handle = context.GetReactor()->CreateHandle(
-      impeller::HandleType::kTexture, texture->target);
+      impeller::HandleType::kTexture, texture->name);
   std::shared_ptr<impeller::TextureGLES> image =
       impeller::TextureGLES::WrapTexture(context.GetReactor(), desc, handle);
 


### PR DESCRIPTION
Set TextureDescriptor.format and use correct GL texture handle in ResolveTextureImpeller:
- Set desc.format to kR8G8B8A8UNormInt Without this, format defaults to kUnknown, which always fails TextureDescriptor::IsValid() check (format != kUnknown required)
- Use texture->name (GL texture ID) instead of texture->target texture->target is GL_TEXTURE_2D enum (3553), not the actual GL texture handle. This caused Impeller to wrap a non-existent texture.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
