### PR TITLE
Remove material import from `opacity_test.dart`

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -245,7 +245,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/simple_semantics_test.dart',
     'packages/flutter/test/widgets/image_filter_test.dart',
     'packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart',
-    'packages/flutter/test/widgets/opacity_test.dart',
     'packages/flutter/test/widgets/baseline_test.dart',
     'packages/flutter/test/widgets/selection_container_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -9,13 +9,17 @@ library;
 
 import 'dart:ui' as ui;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
 
 void main() {
+  const blue = Color(0xFF2196F3);
+  const red = Color(0xFFF44336);
+  const gray = Color(0xFFFEF7FF);
+
   testWidgets('Opacity', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
 
@@ -151,22 +155,21 @@ void main() {
 
   testWidgets('offset is correctly handled in Opacity', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SingleChildScrollView(
-            child: RepaintBoundary(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: List<Widget>.generate(10, (int index) {
-                  return Opacity(
-                    opacity: 0.5,
-                    child: Padding(
-                      padding: const EdgeInsets.all(5.0),
-                      child: Container(color: Colors.blue, height: 50),
-                    ),
-                  );
-                }),
-              ),
+      SingleChildScrollView(
+        child: RepaintBoundary(
+          child: ColoredBox(
+            color: gray,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: List<Widget>.generate(10, (int index) {
+                return Opacity(
+                  opacity: 0.5,
+                  child: Padding(
+                    padding: const EdgeInsets.all(5.0),
+                    child: Container(color: blue, height: 50),
+                  ),
+                );
+              }),
             ),
           ),
         ),
@@ -203,10 +206,7 @@ void main() {
               Positioned(
                 top: 40,
                 left: 140,
-                child: Opacity(
-                  opacity: .5,
-                  child: Container(height: 100, width: 100, color: Colors.red),
-                ),
+                child: Opacity(opacity: .5, child: Container(height: 100, width: 100, color: red)),
               ),
             ],
           ),


### PR DESCRIPTION
Towards #177415

Replaces the convenient `MaterialApp` and `Scaffold` for a `ColoredBox`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
