### PR TITLE
Manually bump dependencies

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   #
   # For detailed instructions, refer to:
   # https://github.com/flutter/flutter/blob/main/docs/infra/Updating-dependencies-in-Flutter.md
-  analyzer: 8.2.0
+  analyzer: 9.0.0
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
@@ -36,7 +36,7 @@ dependencies:
   usage: 4.1.1
   webdriver: 3.1.0
   webkit_inspection_protocol: 1.2.1
-  xml: 6.5.0
+  xml: 6.6.1
   yaml: 3.1.3
   native_stack_traces: 0.6.1
   shelf: 1.4.2
@@ -44,7 +44,7 @@ dependencies:
   uuid: 4.5.2
   web_socket_channel: 3.0.3
   stream_channel: 2.1.4
-  shelf_web_socket: 2.0.1
+  shelf_web_socket: 3.0.0
   shelf_static: 1.1.3
   pub_semver: 2.2.0
   pool: 1.5.2
@@ -76,7 +76,7 @@ dependencies:
   dart_style: 3.1.3
 
   # The below dependencies are transitive and are here to pin them to a specific version.
-  _fe_analyzer_shared: 89.0.0
+  _fe_analyzer_shared: 92.0.0
   boolean_selector: 2.1.2
   browser_launcher: 1.1.3
   built_collection: 5.1.1
@@ -94,9 +94,9 @@ dependencies:
   glob: 2.1.3
   http_parser: 4.1.2
   io: 1.0.5
-  json_rpc_2: 3.0.3
+  json_rpc_2: 4.0.0
   matcher: 0.12.18
-  petitparser: 6.1.0
+  petitparser: 7.0.1
   platform: 3.1.6
   shelf_packages_handler: 3.0.2
   shelf_proxy: 1.0.4
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: qjqion
+# PUBSPEC CHECKSUM: nsr4jq

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/pubspec.yaml
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   dtd: 4.0.0
   flutter_lints: 6.0.0
   google_fonts: 6.3.3
-  json_rpc_2: 3.0.3
+  json_rpc_2: 4.0.0
   path: 1.9.1
   stack_trace: 1.12.1
   url_launcher: 6.3.2
@@ -68,4 +68,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-# PUBSPEC CHECKSUM: 437hbt
+# PUBSPEC CHECKSUM: bl1ls3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: _fe_analyzer_shared
-      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "89.0.0"
+    version: "92.0.0"
   adaptive_breakpoints:
     dependency: "direct main"
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "9.0.0"
   animations:
     dependency: "direct main"
     description:
@@ -334,18 +334,18 @@ packages:
     dependency: "direct main"
     description:
       name: googleapis
-      sha256: "8a8c311723162af077ca73f94b823b97ff68770d966e29614d20baca9fdb490a"
+      sha256: "5c9e0f25be1dec13d8d2158263141104c51b5ba83487537c17a2330581e505ee"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "14.0.0"
   googleapis_auth:
     dependency: "direct main"
     description:
       name: googleapis_auth
-      sha256: befd71383a955535060acde8792e7efc11d2fccd03dd1d3ec434e85b68775938
+      sha256: b81fe352cc4a330b3710d2b7ad258d9bcef6f909bb759b306bf42973a7d046db
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   hooks:
     dependency: "direct main"
     description:
@@ -494,10 +494,10 @@ packages:
     dependency: "direct main"
     description:
       name: metrics_center
-      sha256: "0379309f4b36ea6b2af042fb8cfd045e611a929758b18b7382a066d65d1e6bbb"
+      sha256: "375809eaa274fbc0b649c74d5eebd1fecdc3c5026249e5d9b2a7b7dd6edca5bc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.13"
+    version: "1.0.14"
   mime:
     dependency: "direct main"
     description:
@@ -606,10 +606,10 @@ packages:
     dependency: "direct main"
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.1"
   platform:
     dependency: "direct main"
     description:
@@ -734,10 +734,10 @@ packages:
     dependency: "direct main"
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   shrine_images:
     dependency: "direct main"
     description:
@@ -1075,10 +1075,10 @@ packages:
     dependency: "direct main"
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,9 +78,9 @@ workspace:
 
 dependencies:
   _discoveryapis_commons: 1.0.7
-  _fe_analyzer_shared: 89.0.0
+  _fe_analyzer_shared: 92.0.0
   adaptive_breakpoints: 0.1.7
-  analyzer: 8.2.0
+  analyzer: 9.0.0
   animations: 2.1.1
   archive: 3.6.1
   args: 2.7.0
@@ -112,8 +112,8 @@ dependencies:
   google_fonts: 6.3.3
   google_identity_services_web: 0.3.3+1
   google_mobile_ads: 5.1.0
-  googleapis: 12.0.0
-  googleapis_auth: 1.6.0
+  googleapis: 14.0.0
+  googleapis_auth: 2.0.0
   hooks: 1.0.0
   html: 0.15.6
   http: 1.6.0
@@ -131,7 +131,7 @@ dependencies:
   matcher: 0.12.18
   material_color_utilities: 0.13.0
   meta: 1.17.0
-  metrics_center: 1.0.13
+  metrics_center: 1.0.14
   mime: 2.0.0
   native_toolchain_c: 0.17.4
   nested: 1.0.0
@@ -144,7 +144,7 @@ dependencies:
   path_provider_linux: 2.2.1
   path_provider_platform_interface: 2.1.2
   path_provider_windows: 2.3.0
-  petitparser: 6.1.0
+  petitparser: 7.0.1
   platform: 3.1.6
   plugin_platform_interface: 2.1.8
   pool: 1.5.2
@@ -159,7 +159,7 @@ dependencies:
   shelf: 1.4.2
   shelf_packages_handler: 3.0.2
   shelf_static: 1.1.3
-  shelf_web_socket: 2.0.1
+  shelf_web_socket: 3.0.0
   shrine_images: 2.0.2
   source_map_stack_trace: 2.1.2
   source_maps: 0.10.13
@@ -201,7 +201,7 @@ dependencies:
   webview_flutter_platform_interface: 2.14.0
   webview_flutter_wkwebview: 3.23.5
   xdg_directories: 1.1.0
-  xml: 6.5.0
+  xml: 6.6.1
   yaml: 3.1.3
   cli_util: 0.4.2
   dart_style: 3.1.3
@@ -212,4 +212,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.3
-# PUBSPEC CHECKSUM: r0b6tb
+# PUBSPEC CHECKSUM: unhors


### PR DESCRIPTION
Fly-by clean-up: It's unclear why these aren't getting picked up by the autoroller, see https://github.com/flutter/flutter/issues/180503.