### PR TITLE
[CP][Stable][ios][pv] quick fix to enable and re-enable web view's gesture recognizer

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -573,6 +573,39 @@ static BOOL _preparedOnce = NO;
   return NO;
 }
 
+- (void)searchAndFixWebView:(UIView*)view {
+  if ([view isKindOfClass:[WKWebView class]]) {
+    return [self searchAndFixWebViewGestureRecognzier:view];
+  } else {
+    for (UIView* subview in view.subviews) {
+      [self searchAndFixWebView:subview];
+    }
+  }
+}
+
+- (void)searchAndFixWebViewGestureRecognzier:(UIView*)view {
+  for (UIGestureRecognizer* recognizer in view.gestureRecognizers) {
+    // This is to fix a bug on iOS 26 where web view link is not tappable.
+    // We reset the web view's WKTouchEventsGestureRecognizer in a bad state
+    // by disabling and re-enabling it.
+    // See: https://github.com/flutter/flutter/issues/175099.
+    // See also: https://github.com/flutter/engine/pull/56804 for an explanation of the
+    // bug on iOS 18.2, which is still valid on iOS 26.
+    // Warning: This is just a quick fix that patches the bug. For example,
+    // touches on a drawing website is still not completely blocked. A proper solution
+    // should rely on overriding the hitTest behavior.
+    // See: https://github.com/flutter/flutter/issues/179916.
+    if (recognizer.enabled &&
+        [NSStringFromClass([recognizer class]) hasSuffix:@"TouchEventsGestureRecognizer"]) {
+      recognizer.enabled = NO;
+      recognizer.enabled = YES;
+    }
+  }
+  for (UIView* subview in view.subviews) {
+    [self searchAndFixWebViewGestureRecognzier:subview];
+  }
+}
+
 - (void)blockGesture {
   switch (_blockingPolicy) {
     case FlutterPlatformViewGestureRecognizersBlockingPolicyEager:
@@ -588,9 +621,15 @@ static BOOL _preparedOnce = NO;
       // FlutterPlatformViewGestureRecognizersBlockingPolicyEager, but we should try it if a similar
       // issue arises for the other policy.
       if (@available(iOS 26.0, *)) {
-        // This workaround does not work on iOS 26.
-        // TODO(hellohuanlin): find a solution for iOS 26,
-        // https://github.com/flutter/flutter/issues/175099.
+        // This performs a nested DFS, with the outer one searching for any web view, and the inner
+        // one searching for a TouchEventsGestureRecognizer inside the web view. Once found, disable
+        // and immediately reenable it to reset its state.
+        // TODO(hellohuanlin): remove this flag after it is battle tested.
+        NSNumber* isWorkaroundDisabled =
+            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTDisableWebViewGestureReset"];
+        if (!isWorkaroundDisabled.boolValue) {
+          [self searchAndFixWebView:self.embeddedView];
+        }
       } else if (@available(iOS 18.2, *)) {
         // This workaround is designed for WKWebView only. The 1P web view plugin provides a
         // WKWebView itself as the platform view. However, some 3P plugins provide wrappers of


### PR DESCRIPTION
Stable CP PR: https://github.com/flutter/flutter/pull/180522
Beta CP PR: https://github.com/flutter/flutter/pull/179974
Original PR: https://github.com/flutter/flutter/pull/179908

The "cherry-pick template" linked in https://github.com/flutter/flutter/wiki/Flutter-Cherrypick-Process/e7b042dd481d4ac66477fb281b6e626e8dba8a4e seems to be broken, so I copied the template from previous CP. 

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/175099
https://github.com/flutter/flutter/issues/165787

### Impact Description:
WebViews (including ads) on iOS 26 are unclickable after being scrolled or after a Flutter menu is open and then closed. This is a serious regression that impacts revenue. This impacts all Flutter apps running on iOS 26 that use WebViews.

### Changelog Description:
[flutter/165787, flutter/175099] When WebViews are scrolled on iOS 26, they become unclickable.

### Workaround:
Is there a workaround for this issue?

None

### Risk:
What is the risk level of this cherry-pick?

  - [ ] Low
  - [x] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
Use sample project from https://github.com/flutter/flutter/issues/165787#issuecomment-3429452722. Touch and scroll on an ad, then try to click the ad. The ad will be unclickable.

https://github.com/flutter/flutter/issues/175099
https://github.com/flutter/flutter/issues/165787

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
