### PR TITLE
Add a null check for embedded view being added to accessibility tree

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1174,12 +1174,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         //
         // See the case above for how virtual displays are handled.
         if (!platformViewsAccessibilityDelegate.usesVirtualDisplay(child.platformViewId)) {
-          assert embeddedView != null;
-          // The embedded view is initially marked as not important at creation in the platform
-          // view controller, so we must explicitly mark it as important here.
-          embeddedView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
-          result.addChild(embeddedView);
-          continue;
+          if (embeddedView != null) {
+            // The embedded view is initially marked as not important at creation in the platform
+            // view controller, so we must explicitly mark it as important here.
+            embeddedView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+            result.addChild(embeddedView);
+            continue;
+          }
         }
       }
       result.addChild(rootAccessibilityView, child.id);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2114,6 +2114,46 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
+  public void itDoesNotCrashWhenEmbeddedViewIsNull() {
+    PlatformViewsAccessibilityDelegate accessibilityDelegate =
+        mock(PlatformViewsAccessibilityDelegate.class);
+    AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            /* rootAccessibilityView= */ null,
+            /* accessibilityChannel= */ null,
+            /* accessibilityManager= */ null,
+            /* contentResolver= */ null,
+            accessibilityViewEmbedder,
+            accessibilityDelegate);
+
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+
+    TestSemanticsNode platformView = new TestSemanticsNode();
+    platformView.id = 1;
+    platformView.platformViewId = 1;
+    root.addChild(platformView);
+
+    when(accessibilityDelegate.usesVirtualDisplay(1)).thenReturn(false);
+    when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(null);
+
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+
+    // This should not crash.
+    AccessibilityNodeInfo result = accessibilityBridge.createAccessibilityNodeInfo(0);
+
+    // Verify that we fell back to adding the child as a virtual node (standard semantics node)
+    // instead of trying to add the null embedded view.
+    boolean hasChild = false;
+    for (int i = 0; i < result.getChildCount(); i++) {
+        hasChild = true;
+    }
+    assertTrue("Should have added the virtual child node", hasChild);
+  }
+
+  @Test
   public void testItSetsDisableAnimationsFlagBasedOnTransitionAnimationScale() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
     ContentResolver mockContentResolver = mock(ContentResolver.class);

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2148,7 +2148,7 @@ public class AccessibilityBridgeTest {
     // instead of trying to add the null embedded view.
     boolean hasChild = false;
     for (int i = 0; i < result.getChildCount(); i++) {
-        hasChild = true;
+      hasChild = true;
     }
     assertTrue("Should have added the virtual child node", hasChild);
   }


### PR DESCRIPTION
Fixes 
https://github.com/flutter/flutter/issues/180381
https://github.com/flutter/flutter/issues/179922

which track a regression from https://github.com/flutter/flutter/pull/168939

Wraps in a null check, and if the embeddedView is null we fall back to adding the semantics node we are looking at in the loop as a child.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
