### PR TITLE
[two_dimensional_scrollables] Fix tableview janks when first row/column pinned

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -8,8 +8,6 @@
 /// @docImport 'viewport.dart';
 library;
 
-import 'dart:math' as math;
-
 import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1383,11 +1383,11 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
 
   void _sortByYIndex() {
     _currentChildVicinities.sort((a, b) {
-      if (a.yIndex == b.yIndex) {
-        return a.xIndex.compareTo(b.xIndex);
-      } else {
-        return a.yIndex.compareTo(b.yIndex);
+      final int yComparison = a.yIndex.compareTo(b.yIndex);
+      if (yComparison != 0) {
+        return yComparison;
       }
+      return a.xIndex.compareTo(b.xIndex);
     });
   }
 

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1392,13 +1392,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   }
 
   void _sortByXIndex() {
-    _currentChildVicinities.sort((a, b) {
-      if (a.xIndex == b.xIndex) {
-        return a.yIndex.compareTo(b.yIndex);
-      } else {
-        return a.xIndex.compareTo(b.xIndex);
-      }
-    });
+    _currentChildVicinities.sort();
   }
 
   // Ensures all children have a layoutOffset, sets paintExtent & paintOffset,
@@ -1420,10 +1414,12 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         // through in the horizontal case below.
         // Minor
         _sortByYIndex();
+        break;
       case Axis.horizontal:
         // Column major traversal
         // Minor
         _sortByXIndex();
+        break;
     }
     for (final ChildVicinity vicinity in _currentChildVicinities) {
       previousChild = _completeChildParentData(

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1420,10 +1420,8 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         _sortByXIndex();
     }
     for (final ChildVicinity vicinity in _currentChildVicinities) {
-      previousChild = _completeChildParentData(
-        vicinity,
-        previousChild: previousChild,
-      ) ?? previousChild;
+      previousChild =
+          _completeChildParentData(vicinity, previousChild: previousChild) ?? previousChild;
     }
     _lastChild = previousChild;
     if (_lastChild != null) {

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1414,12 +1414,10 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         // through in the horizontal case below.
         // Minor
         _sortByYIndex();
-        break;
       case Axis.horizontal:
         // Column major traversal
         // Minor
         _sortByXIndex();
-        break;
     }
     for (final ChildVicinity vicinity in _currentChildVicinities) {
       previousChild = _completeChildParentData(

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -803,6 +803,8 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   bool _hasVisualOverflow = false;
   final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();
 
+  final List<ChildVicinity> _currentChildVicinities = <ChildVicinity>[];
+
   @override
   bool get isRepaintBoundary => true;
 
@@ -1379,6 +1381,26 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     }
   }
 
+  void _sortByYIndex() {
+    _currentChildVicinities.sort((a, b) {
+      if (a.yIndex == b.yIndex) {
+        return a.xIndex.compareTo(b.xIndex);
+      } else {
+        return a.yIndex.compareTo(b.yIndex);
+      }
+    });
+  }
+
+  void _sortByXIndex() {
+    _currentChildVicinities.sort((a, b) {
+      if (a.xIndex == b.xIndex) {
+        return a.yIndex.compareTo(b.yIndex);
+      } else {
+        return a.xIndex.compareTo(b.xIndex);
+      }
+    });
+  }
+
   // Ensures all children have a layoutOffset, sets paintExtent & paintOffset,
   // and arranges children in paint order.
   void _reifyChildren() {
@@ -1397,25 +1419,17 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         // typical default for matrices, which is why the inverse follows
         // through in the horizontal case below.
         // Minor
-        for (int minorIndex = _leadingYIndex!; minorIndex <= _trailingYIndex!; minorIndex++) {
-          // Major
-          for (int majorIndex = _leadingXIndex!; majorIndex <= _trailingXIndex!; majorIndex++) {
-            final vicinity = ChildVicinity(xIndex: majorIndex, yIndex: minorIndex);
-            previousChild =
-                _completeChildParentData(vicinity, previousChild: previousChild) ?? previousChild;
-          }
-        }
+        _sortByYIndex();
       case Axis.horizontal:
         // Column major traversal
         // Minor
-        for (int minorIndex = _leadingXIndex!; minorIndex <= _trailingXIndex!; minorIndex++) {
-          // Major
-          for (int majorIndex = _leadingYIndex!; majorIndex <= _trailingYIndex!; majorIndex++) {
-            final vicinity = ChildVicinity(xIndex: minorIndex, yIndex: majorIndex);
-            previousChild =
-                _completeChildParentData(vicinity, previousChild: previousChild) ?? previousChild;
-          }
-        }
+        _sortByXIndex();
+    }
+    for (final ChildVicinity vicinity in _currentChildVicinities) {
+      previousChild = _completeChildParentData(
+        vicinity,
+        previousChild: previousChild,
+      ) ?? previousChild;
     }
     _lastChild = previousChild;
     if (_lastChild != null) {
@@ -1426,6 +1440,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     _trailingXIndex = null;
     _leadingYIndex = null;
     _trailingYIndex = null;
+    _currentChildVicinities.clear();
   }
 
   RenderBox? _completeChildParentData(ChildVicinity vicinity, {RenderBox? previousChild}) {
@@ -1539,6 +1554,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     final RenderBox child = _children[vicinity]!;
     _activeChildrenForLayoutPass[vicinity] = child;
     parentDataOf(child).vicinity = vicinity;
+    _currentChildVicinities.add(vicinity);
     return child;
   }
 

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -811,15 +811,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   @override
   bool get sizedByParent => true;
 
-  // Keeps track of the upper and lower bounds of ChildVicinity indices when
-  // subclasses call buildOrObtainChildFor during layoutChildSequence. These
-  // values are used to sort children in accordance with the mainAxis for
-  // paint order.
-  int? _leadingXIndex;
-  int? _trailingXIndex;
-  int? _leadingYIndex;
-  int? _trailingYIndex;
-
   /// The first child of the viewport according to the traversal order of the
   /// [mainAxis].
   ///
@@ -1398,10 +1389,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   // Ensures all children have a layoutOffset, sets paintExtent & paintOffset,
   // and arranges children in paint order.
   void _reifyChildren() {
-    assert(_leadingXIndex != null);
-    assert(_trailingXIndex != null);
-    assert(_leadingYIndex != null);
-    assert(_trailingYIndex != null);
     assert(_firstChild == null);
     assert(_lastChild == null);
     RenderBox? previousChild;
@@ -1428,10 +1415,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       parentDataOf(_lastChild!)._nextSibling = null;
     }
     // Reset for next layout pass.
-    _leadingXIndex = null;
-    _trailingXIndex = null;
-    _leadingYIndex = null;
-    _trailingYIndex = null;
     _currentChildVicinities.clear();
   }
 
@@ -1505,28 +1488,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     assert(vicinity != ChildVicinity.invalid);
     // This should only be called during layout.
     assert(debugDoingThisLayout);
-    if (_leadingXIndex == null ||
-        _trailingXIndex == null ||
-        _leadingXIndex == null ||
-        _trailingYIndex == null) {
-      // First child of this layout pass. Set leading and trailing trackers.
-      _leadingXIndex = vicinity.xIndex;
-      _trailingXIndex = vicinity.xIndex;
-      _leadingYIndex = vicinity.yIndex;
-      _trailingYIndex = vicinity.yIndex;
-    } else {
-      // If any of these are still null, we missed a child.
-      assert(_leadingXIndex != null);
-      assert(_trailingXIndex != null);
-      assert(_leadingYIndex != null);
-      assert(_trailingYIndex != null);
-
-      // Update as we go.
-      _leadingXIndex = math.min(vicinity.xIndex, _leadingXIndex!);
-      _trailingXIndex = math.max(vicinity.xIndex, _trailingXIndex!);
-      _leadingYIndex = math.min(vicinity.yIndex, _leadingYIndex!);
-      _trailingYIndex = math.max(vicinity.yIndex, _trailingYIndex!);
-    }
     if (_needsDelegateRebuild ||
         (!_children.containsKey(vicinity) && !_keepAliveBucket.containsKey(vicinity))) {
       invokeLayoutCallback<BoxConstraints>((BoxConstraints _) {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2963,8 +2963,6 @@ void main() {
       expect(tester.state(find.byKey(const ValueKey<int>(2))), stateBeforeReordering);
     }, variant: TargetPlatformVariant.all());
 
-
-
     testWidgets('Child sorting and layout logic remain consistent', (WidgetTester tester) async {
       // Verify that sorting rules are unchanged after removing nested loops:
       // - Main axis vertical → Row-major order (y-index first, then x-index)

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2962,6 +2962,111 @@ void main() {
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
       expect(tester.state(find.byKey(const ValueKey<int>(2))), stateBeforeReordering);
     }, variant: TargetPlatformVariant.all());
+
+
+
+    testWidgets('Child sorting and layout logic remain consistent', (WidgetTester tester) async {
+      // Verify that sorting rules are unchanged after removing nested loops:
+      // - Main axis vertical → Row-major order (y-index first, then x-index)
+      // - Main axis horizontal → Column-major order (x-index first, then y-index)
+      final childKeys = <ChildVicinity, UniqueKey>{};
+
+      // Configure grid dimensions: create a dense grid of child widgets to simulate the original nested loop scenario
+      const maxXCount = 5; // Total number of columns (x-axis)
+      const maxYCount = 10; // Total number of rows (y-axis)
+
+      // Create delegate to build child widgets with fixed size (200x200)
+      final delegate = TwoDimensionalChildBuilderDelegate(
+        maxXIndex: maxXCount - 1,
+        maxYIndex: maxYCount - 1,
+        builder: (BuildContext context, ChildVicinity vicinity) {
+          childKeys[vicinity] = childKeys[vicinity] ?? UniqueKey();
+          return SizedBox.square(
+            key: childKeys[vicinity],
+            dimension: 200,
+          );
+        },
+      );
+
+      // Set viewport size to fit all children exactly (no overflow, no partial visibility)
+      tester.view.physicalSize = Size(
+        200 * maxXCount.toDouble(),
+        200 * maxYCount.toDouble(),
+      );
+      tester.view.devicePixelRatio = 1.0;
+      // Clean up resources after test: dispose delegate and reset viewport settings
+      addTearDown(() {
+        delegate.dispose();
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      // 1. Test with main axis set to vertical (default behavior)
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
+      await tester.pumpAndSettle();
+      RenderTwoDimensionalViewport viewport = getViewport(tester, childKeys.values.first);
+      final verticalOrder = <ChildVicinity>[];
+      RenderBox? child = viewport.firstChild;
+
+      // Traverse all children in the viewport's paint order
+      while (child != null) {
+        final ParentData? parentData = child.parentData;
+        if (parentData is TwoDimensionalViewportParentData) {
+          verticalOrder.add(parentData.vicinity);
+        }
+        child = viewport.childAfter(child);
+      }
+
+      // Verify row-major order for vertical main axis
+      for (var y = 0; y < maxYCount; y++) {
+        for (var x = 0; x < maxXCount; x++) {
+          final expectedVicinity = ChildVicinity(xIndex: x, yIndex: y);
+          final int expectedListIndex = y * maxXCount + x;
+          expect(
+            verticalOrder[expectedListIndex],
+            expectedVicinity,
+            reason: 'Vertical main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
+                'got ${verticalOrder[expectedListIndex]}',
+          );
+        }
+      }
+
+      // 2. Test with main axis set to horizontal
+      await tester.pumpWidget(
+        simpleBuilderTest(
+          delegate: delegate,
+          mainAxis: Axis.horizontal,
+        ),
+      );
+      await tester.pumpAndSettle();
+      viewport = getViewport(tester, childKeys.values.first);
+      final horizontalOrder = <ChildVicinity>[];
+      child = viewport.firstChild;
+
+      // Traverse all children in the viewport's paint order
+      while (child != null) {
+        final ParentData? parentData = child.parentData;
+        if (parentData is TwoDimensionalViewportParentData) {
+          horizontalOrder.add(parentData.vicinity);
+        }
+        child = viewport.childAfter(child);
+      }
+
+      // Verify column-major order for horizontal main axis
+      for (var x = 0; x < maxXCount; x++) {
+        for (var y = 0; y < maxYCount; y++) {
+          final expectedVicinity = ChildVicinity(xIndex: x, yIndex: y);
+          // Calculate expected index in the horizontalOrder list (column * rows + row)
+          final int expectedListIndex = x * maxYCount + y;
+          expect(
+            horizontalOrder[expectedListIndex],
+            expectedVicinity,
+            reason: 'Horizontal main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
+                'got ${horizontalOrder[expectedListIndex]}',
+          );
+        }
+      }
+    }, variant: TargetPlatformVariant.all());
   });
 }
 

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2979,18 +2979,12 @@ void main() {
         maxYIndex: maxYCount - 1,
         builder: (BuildContext context, ChildVicinity vicinity) {
           childKeys[vicinity] = childKeys[vicinity] ?? UniqueKey();
-          return SizedBox.square(
-            key: childKeys[vicinity],
-            dimension: 200,
-          );
+          return SizedBox.square(key: childKeys[vicinity], dimension: 200);
         },
       );
 
       // Set viewport size to fit all children exactly (no overflow, no partial visibility)
-      tester.view.physicalSize = Size(
-        200 * maxXCount.toDouble(),
-        200 * maxYCount.toDouble(),
-      );
+      tester.view.physicalSize = Size(200 * maxXCount.toDouble(), 200 * maxYCount.toDouble());
       tester.view.devicePixelRatio = 1.0;
       // Clean up resources after test: dispose delegate and reset viewport settings
       addTearDown(() {
@@ -3023,19 +3017,15 @@ void main() {
           expect(
             verticalOrder[expectedListIndex],
             expectedVicinity,
-            reason: 'Vertical main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
+            reason:
+                'Vertical main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
                 'got ${verticalOrder[expectedListIndex]}',
           );
         }
       }
 
       // 2. Test with main axis set to horizontal
-      await tester.pumpWidget(
-        simpleBuilderTest(
-          delegate: delegate,
-          mainAxis: Axis.horizontal,
-        ),
-      );
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate, mainAxis: Axis.horizontal));
       await tester.pumpAndSettle();
       viewport = getViewport(tester, childKeys.values.first);
       final horizontalOrder = <ChildVicinity>[];
@@ -3059,7 +3049,8 @@ void main() {
           expect(
             horizontalOrder[expectedListIndex],
             expectedVicinity,
-            reason: 'Horizontal main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
+            reason:
+                'Horizontal main axis: Expected vicinity $expectedVicinity at index $expectedListIndex, '
                 'got ${horizontalOrder[expectedListIndex]}',
           );
         }

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2965,15 +2965,15 @@ void main() {
 
     testWidgets('Child sorting and layout logic remain consistent', (WidgetTester tester) async {
       // Verify that sorting rules are unchanged after removing nested loops:
-      // - Main axis vertical → Row-major order (y-index first, then x-index)
-      // - Main axis horizontal → Column-major order (x-index first, then y-index)
+      // - Main axis vertical → Row-major order (y-index first, then x-index).
+      // - Main axis horizontal → Column-major order (x-index first, then y-index).
       final childKeys = <ChildVicinity, UniqueKey>{};
 
-      // Configure grid dimensions: create a dense grid of child widgets to simulate the original nested loop scenario
-      const maxXCount = 5; // Total number of columns (x-axis)
-      const maxYCount = 10; // Total number of rows (y-axis)
+      // Configure grid dimensions: create a dense grid of child widgets to simulate the original nested loop scenario.
+      const maxXCount = 5; // Total number of columns (x-axis).
+      const maxYCount = 10; // Total number of rows (y-axis).
 
-      // Create delegate to build child widgets with fixed size (200x200)
+      // Create delegate to build child widgets with fixed size (200x200).
       final delegate = TwoDimensionalChildBuilderDelegate(
         maxXIndex: maxXCount - 1,
         maxYIndex: maxYCount - 1,
@@ -2983,24 +2983,24 @@ void main() {
         },
       );
 
-      // Set viewport size to fit all children exactly (no overflow, no partial visibility)
+      // Set viewport size to fit all children exactly (no overflow, no partial visibility).
       tester.view.physicalSize = Size(200 * maxXCount.toDouble(), 200 * maxYCount.toDouble());
       tester.view.devicePixelRatio = 1.0;
-      // Clean up resources after test: dispose delegate and reset viewport settings
+      // Clean up resources after test: dispose delegate and reset viewport settings.
       addTearDown(() {
         delegate.dispose();
         tester.view.resetPhysicalSize();
         tester.view.resetDevicePixelRatio();
       });
 
-      // 1. Test with main axis set to vertical (default behavior)
+      // 1. Test with main axis set to vertical (default behavior).
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
       await tester.pumpAndSettle();
       RenderTwoDimensionalViewport viewport = getViewport(tester, childKeys.values.first);
       final verticalOrder = <ChildVicinity>[];
       RenderBox? child = viewport.firstChild;
 
-      // Traverse all children in the viewport's paint order
+      // Traverse all children in the viewport's paint order.
       while (child != null) {
         final ParentData? parentData = child.parentData;
         if (parentData is TwoDimensionalViewportParentData) {
@@ -3009,7 +3009,7 @@ void main() {
         child = viewport.childAfter(child);
       }
 
-      // Verify row-major order for vertical main axis
+      // Verify row-major order for vertical main axis.
       for (var y = 0; y < maxYCount; y++) {
         for (var x = 0; x < maxXCount; x++) {
           final expectedVicinity = ChildVicinity(xIndex: x, yIndex: y);
@@ -3024,14 +3024,14 @@ void main() {
         }
       }
 
-      // 2. Test with main axis set to horizontal
+      // 2. Test with main axis set to horizontal.
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate, mainAxis: Axis.horizontal));
       await tester.pumpAndSettle();
       viewport = getViewport(tester, childKeys.values.first);
       final horizontalOrder = <ChildVicinity>[];
       child = viewport.firstChild;
 
-      // Traverse all children in the viewport's paint order
+      // Traverse all children in the viewport's paint order.
       while (child != null) {
         final ParentData? parentData = child.parentData;
         if (parentData is TwoDimensionalViewportParentData) {
@@ -3040,7 +3040,7 @@ void main() {
         child = viewport.childAfter(child);
       }
 
-      // Verify column-major order for horizontal main axis
+      // Verify column-major order for horizontal main axis.
       for (var x = 0; x < maxXCount; x++) {
         for (var y = 0; y < maxYCount; y++) {
           final expectedVicinity = ChildVicinity(xIndex: x, yIndex: y);


### PR DESCRIPTION
### Description
This PR addresses a critical performance issue where the TableView component experiences severe lag when scrolling to row 15,000 with both the first row and first column pinned.

### Root Cause
The _reifyChildren method in RenderTwoDimensionalViewport was consuming excessive CPU resources due to inefficient iteration logic:
It used nested for-loops starting from index 0, iterating through all rows (0 ~ 15K) even when only 4 rows/columns were visible on screen
The pinned first row/column caused unnecessary full-range iteration instead of limiting to the visible viewport

### Solution
Optimized the iteration logic in _reifyChildren:
Store only viewport-visible children in _currentChildVicinities
Restrict ParentData calculations in _reifyChildren to only the children within _currentChildVicinities
Eliminated full-range (0 ~ 15K) iterations and focused only on visible elements

### Fixes:https://github.com/flutter/flutter/issues/138271
Important Note: This fix exclusively resolves the jank associated with pinned rows and columns; the jank in non-pinned scenarios stems from a different root cause and is not included in this commit.

### Video performance comparison
before：
https://github.com/user-attachments/assets/b0892dd5-858b-44a6-8f26-37803ce50452

after：
https://github.com/user-attachments/assets/7a6cddf2-04bf-465d-9997-3fdcab5692f7

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


