### PR TITLE
Unpin DDS

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -21,8 +21,6 @@
 const kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here. Please leave a comment explaining why.
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
-  'dds':
-      '5.0.3', // 5.0.4 contains bugs described in https://github.com/Dart-Code/Dart-Code/issues/4678.
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: 9.0.0
   archive: 3.6.1
   args: 2.7.0
-  dds: 5.0.3
+  dds: 5.1.0
   dwds: 26.2.3
   code_builder: 4.11.1
   collection: 1.19.1
@@ -127,4 +127,5 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: nsr4jq
+
+# PUBSPEC CHECKSUM: e4dvj0

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -128,4 +128,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: e4dvj0
+# PUBSPEC CHECKSUM: ot91td


### PR DESCRIPTION
Fly-by clean-up: My understanding from the [changelog](https://pub.dev/packages/dds/changelog) is that the change causing the bug in 5.0.4 has been reverted in 5.0.5. Therefore, the pin should be no longer necessary? Unpinning to find out...

> 5.0.5 
[DAP] The change in DDS 5.0.4 to individually add/remove breakpoints has been reverted and may be restored in a future version.
>
>5.0.4 
[DAP] Breakpoints are now added/removed individually instead of all being cleared and re-added during a setBreakpoints request. This improves performance and can avoid breakpoints flickering between unresolved/resolved when adding new breakpoints in the same file.