### PR TITLE
Unpin google_mobile_ads

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -25,7 +25,6 @@ const kManuallyPinnedDependencies = <String, String>{
       '5.0.3', // 5.0.4 contains bugs described in https://github.com/Dart-Code/Dart-Code/issues/4678.
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
-  'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
   'material_color_utilities': '0.13.0', // Keep pinned to latest until 1.0.0.
 };
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,10 +326,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_mobile_ads
-      sha256: e2d18992d30b2be77cb6976b931112fc3c4612feffb5eb7a8b036bd7a64934da
+      sha256: f35e040875bb54e8a3455bcffed3b4ac9e9263fbf7751b9fd1ae7f30793faee8
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "7.0.0"
   googleapis:
     dependency: "direct main"
     description:
@@ -1035,18 +1035,18 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: ec81f57aa1611f8ebecf1d2259da4ef052281cb5ad624131c93546c79ccc7736
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.13.0"
   webview_flutter_android:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: "47a8da40d02befda5b151a26dba71f47df471cddd91dfdb7802d0a87c5442558"
+      sha256: eeeb3fcd5f0ff9f8446c9f4bbc18a99b809e40297528a3395597d03aafb9f510
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.9"
+    version: "4.10.11"
   webview_flutter_platform_interface:
     dependency: "direct main"
     description:
@@ -1097,4 +1097,4 @@ packages:
     version: "2.2.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.35.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,7 +111,7 @@ dependencies:
   glob: 2.1.3
   google_fonts: 6.3.3
   google_identity_services_web: 0.3.3+1
-  google_mobile_ads: 5.1.0
+  google_mobile_ads: 7.0.0
   googleapis: 14.0.0
   googleapis_auth: 2.0.0
   hooks: 1.0.0
@@ -196,8 +196,8 @@ dependencies:
   web_socket_channel: 3.0.3
   webdriver: 3.1.0
   webkit_inspection_protocol: 1.2.1
-  webview_flutter: 4.9.0
-  webview_flutter_android: 3.16.9
+  webview_flutter: 4.13.0
+  webview_flutter_android: 4.10.11
   webview_flutter_platform_interface: 2.14.0
   webview_flutter_wkwebview: 3.23.5
   xdg_directories: 1.1.0
@@ -212,4 +212,5 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.3
-# PUBSPEC CHECKSUM: unhors
+
+# PUBSPEC CHECKSUM: vm9pfp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -213,4 +213,4 @@ dependencies:
   quiver: 3.2.2
   yaml_edit: 2.2.3
 
-# PUBSPEC CHECKSUM: vm9pfp
+# PUBSPEC CHECKSUM: ve87bf


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156912.

Fly-by clean-up: With the recent bump to Xcode I believe pinning `google_mobile_ads` is no longer necessary.

I verified locally with `flutter build ios --verbose` that the `dev/benchmarks/platform_views_layout` build successfully.

<details>
<summary>Build Log</summary>

```
$ flutter build ios 
Resolving dependencies in `/Users/goderbauer/dev/flutter`... 
Downloading packages... 
  _fe_analyzer_shared 89.0.0 (92.0.0 available)
  adaptive_breakpoints 0.1.7 (discontinued)
  analyzer 8.2.0 (9.0.0 available)
  archive 3.6.1 (4.0.7 available)
  device_info 2.0.3 (discontinued replaced by device_info_plus)
  ffigen 18.1.0 (20.1.1 available)
  gcloud 0.8.19 (0.9.0 available)
  googleapis 12.0.0 (15.0.0 available)
  googleapis_auth 1.6.0 (2.0.0 available)
  isolate 2.1.1 (discontinued)
  js 0.7.2 (discontinued)
  metrics_center 1.0.13 (1.0.14 available)
  pedantic 1.11.1 (discontinued replaced by lints)
  petitparser 6.1.0 (7.0.1 available)
  shelf_web_socket 2.0.1 (3.0.0 available)
  xml 6.5.0 (6.6.1 available)
Got dependencies in `/Users/goderbauer/dev/flutter`!
5 packages are discontinued.
11 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Building com.yourcompany.platformViewsLayout for device (ios-release)...
To ensure your app continues to launch on upcoming iOS versions, UIScene lifecycle support will soon be required. Please see https://flutter.dev/to/uiscene-migration for the migration guide.


Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Found saved certificate choice "Apple Development: Michael Goderbauer (WY4DWBNV57)". To clear, use "flutter config --clear-ios-signing-settings".
Developer identity "Apple Development: Michael Goderbauer (WY4DWBNV57)" selected for iOS code signing
Running pod install...                                           1,233ms
Running Xcode build...                                                  
Xcode build done.                                           32.5s
✓ Built build/ios/iphoneos/Runner.app (20.9MB)
```

</details>