### PR TITLE
feat: Add --reporter=summary option to flutter test

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -100,6 +100,7 @@ export 'dart:io'
         Stdin,
         StdinException,
         Stdout,
+        StdoutException,
         WebSocket,
         WebSocketException,
         WebSocketTransformer,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -244,7 +244,15 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         abbr: 'r',
         help:
             'Set how to print test results. If unset, value will default to either compact or expanded.',
-        allowed: <String>['compact', 'expanded', 'failures-only', 'github', 'json', 'silent', 'summary'],
+        allowed: <String>[
+          'compact',
+          'expanded',
+          'failures-only',
+          'github',
+          'json',
+          'silent',
+          'summary',
+        ],
         allowedHelp: <String, String>{
           'compact': 'A single line, updated continuously (the default).',
           'expanded':

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -244,7 +244,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         abbr: 'r',
         help:
             'Set how to print test results. If unset, value will default to either compact or expanded.',
-        allowed: <String>['compact', 'expanded', 'failures-only', 'github', 'json', 'silent'],
+        allowed: <String>['compact', 'expanded', 'failures-only', 'github', 'json', 'silent', 'summary'],
         allowedHelp: <String, String>{
           'compact': 'A single line, updated continuously (the default).',
           'expanded':
@@ -255,6 +255,8 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           'json': 'A machine-readable format. See: https://dart.dev/go/test-docs/json_reporter.md',
           'silent':
               'A reporter with no output. May be useful when only the exit code is meaningful.',
+          'summary':
+              'Like compact, but prints a list of all failed tests at the end for easy identification.',
         },
       )
       ..addOption(

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -157,6 +157,7 @@ interface class FlutterTestRunner {
         final summaryReporter = SummaryReporter(
           supportsColor: globals.terminal.supportsColor,
           stdout: globals.stdio.stdout,
+          logger: globals.logger,
         );
         await testWrapper.mainWithOutputCapture(testArgs, onOutputLine: summaryReporter.handleLine);
       } else {
@@ -205,6 +206,7 @@ interface class FlutterTestRunner {
         final summaryReporter = SummaryReporter(
           supportsColor: globals.terminal.supportsColor,
           stdout: globals.stdio.stdout,
+          logger: globals.logger,
         );
         await testWrapper.mainWithOutputCapture(testArgs, onOutputLine: summaryReporter.handleLine);
       } else {

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -79,7 +79,8 @@ interface class FlutterTestRunner {
     final testArgs = <String>[
       if (!globals.terminal.supportsColor) '--no-color',
       if (debuggingOptions.startPaused) '--pause-after-load',
-      if (machine || useSummaryReporter) ...<String>['-r', 'json'] else if (reporter != null) ...<String>['-r', reporter],
+      if (machine || useSummaryReporter) ...<String>['-r', 'json'] else if (reporter !=
+          null) ...<String>['-r', reporter],
       if (fileReporter != null) '--file-reporter=$fileReporter',
       if (timeout != null) ...<String>['--timeout', timeout],
       if (ignoreTimeouts) '--ignore-timeouts',
@@ -157,10 +158,7 @@ interface class FlutterTestRunner {
           supportsColor: globals.terminal.supportsColor,
           stdout: globals.stdio.stdout,
         );
-        await testWrapper.mainWithOutputCapture(
-          testArgs,
-          onOutputLine: summaryReporter.handleLine,
-        );
+        await testWrapper.mainWithOutputCapture(testArgs, onOutputLine: summaryReporter.handleLine);
       } else {
         await testWrapper.main(testArgs);
       }
@@ -208,10 +206,7 @@ interface class FlutterTestRunner {
           supportsColor: globals.terminal.supportsColor,
           stdout: globals.stdio.stdout,
         );
-        await testWrapper.mainWithOutputCapture(
-          testArgs,
-          onOutputLine: summaryReporter.handleLine,
-        );
+        await testWrapper.mainWithOutputCapture(testArgs, onOutputLine: summaryReporter.handleLine);
       } else {
         await testWrapper.main(testArgs);
       }
@@ -693,7 +688,10 @@ class SpawnPlugin extends PlatformPlugin {
     // Compute the command-line arguments for package:test.
     final packageTestArgs = <String>[
       if (!globals.terminal.supportsColor) '--no-color',
-      if (machine) ...<String>['-r', 'json'] else if (effectiveReporter != null) ...<String>['-r', effectiveReporter],
+      if (machine) ...<String>['-r', 'json'] else if (effectiveReporter != null) ...<String>[
+        '-r',
+        effectiveReporter,
+      ],
       if (fileReporter != null) '--file-reporter=$fileReporter',
       if (timeout != null) ...<String>['--timeout', timeout],
       if (ignoreTimeouts) '--ignore-timeouts',

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -45,8 +45,8 @@ class SummaryReporter {
     }
 
     try {
-      final dynamic event = json.decode(line);
-      if (event is! Map<String, dynamic>) {
+      final Object? event = json.decode(line);
+      if (event is! Map<String, Object?>) {
         _printLine(line);
         return;
       }
@@ -56,7 +56,7 @@ class SummaryReporter {
     }
   }
 
-  void _handleEvent(Map<String, dynamic> event) {
+  void _handleEvent(Map<String, Object?> event) {
     final type = event['type'] as String?;
 
     switch (type) {
@@ -77,9 +77,9 @@ class SummaryReporter {
     }
   }
 
-  void _handleSuite(Map<String, dynamic> event) {
-    final dynamic suite = event['suite'];
-    if (suite is! Map<String, dynamic>) {
+  void _handleSuite(Map<String, Object?> event) {
+    final Object? suite = event['suite'];
+    if (suite is! Map<String, Object?>) {
       return;
     }
 
@@ -91,9 +91,9 @@ class SummaryReporter {
     }
   }
 
-  void _handleTestStart(Map<String, dynamic> event) {
-    final dynamic test = event['test'];
-    if (test is! Map<String, dynamic>) {
+  void _handleTestStart(Map<String, Object?> event) {
+    final Object? test = event['test'];
+    if (test is! Map<String, Object?>) {
       return;
     }
 
@@ -108,7 +108,7 @@ class SummaryReporter {
     }
   }
 
-  void _handleTestDone(Map<String, dynamic> event) {
+  void _handleTestDone(Map<String, Object?> event) {
     final testId = event['testID'] as int?;
     final result = event['result'] as String?;
     final bool skipped = event['skipped'] as bool? ?? false;
@@ -141,7 +141,7 @@ class SummaryReporter {
     _printProgress();
   }
 
-  void _handleError(Map<String, dynamic> event) {
+  void _handleError(Map<String, Object?> event) {
     final error = event['error'] as String?;
     final stackTrace = event['stackTrace'] as String?;
 
@@ -158,7 +158,7 @@ class SummaryReporter {
     }
   }
 
-  void _handlePrint(Map<String, dynamic> event) {
+  void _handlePrint(Map<String, Object?> event) {
     final message = event['message'] as String?;
     if (message != null) {
       if (_lastLineWasProgress) {
@@ -169,7 +169,7 @@ class SummaryReporter {
     }
   }
 
-  void _handleDone(Map<String, dynamic> event) {
+  void _handleDone(Map<String, Object?> event) {
     _stopwatch.stop();
 
     final bool success = event['success'] as bool? ?? false;

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -169,32 +169,18 @@ class SummaryReporter {
   }
 
   void _printProgress() {
-    final buffer = StringBuffer();
-    final Duration elapsed = _stopwatch.elapsed;
-    final String minutes = elapsed.inMinutes.toString().padLeft(2, '0');
-    final String seconds = (elapsed.inSeconds % 60).toString().padLeft(2, '0');
-
-    buffer.write('$minutes:$seconds ');
-    buffer.write('$_green+$_passed$_reset');
-
-    if (_skipped > 0) {
-      buffer.write(' $_yellow~$_skipped$_reset');
-    }
-
-    if (_failed > 0) {
-      buffer.write(' $_red-$_failed$_reset');
-    }
-
-    buffer.write(': ');
-    buffer.write(_currentTestName);
-
-    final line = buffer.toString();
+    final line = '${_buildStatusPrefix()}: $_currentTestName';
     final String paddedLine = line.padRight(_terminalWidth);
     stdout.write('\r$paddedLine');
     _lastLineWasProgress = true;
   }
 
   void _printFinalStatus(String message, {bool isFailure = false}) {
+    final suffix = isFailure ? '$_red$message$_reset' : message;
+    _printLine('${_buildStatusPrefix()}: $suffix');
+  }
+
+  String _buildStatusPrefix() {
     final buffer = StringBuffer();
     final Duration elapsed = _stopwatch.elapsed;
     final String minutes = elapsed.inMinutes.toString().padLeft(2, '0');
@@ -211,15 +197,7 @@ class SummaryReporter {
       buffer.write(' $_red-$_failed$_reset');
     }
 
-    buffer.write(': ');
-
-    if (isFailure) {
-      buffer.write('$_red$message$_reset');
-    } else {
-      buffer.write(message);
-    }
-
-    _printLine(buffer.toString());
+    return buffer.toString();
   }
 
   void _printFailureSummary() {

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
-
+import '../base/io.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 
@@ -20,7 +19,7 @@ class SummaryReporter {
   SummaryReporter({required this.supportsColor, required this.stdout});
 
   final bool supportsColor;
-  final io.Stdout stdout;
+  final Stdout stdout;
 
   final Map<int, _TestInfo> _tests = <int, _TestInfo>{};
   final Map<int, String> _suites = <int, String>{};
@@ -263,7 +262,7 @@ class SummaryReporter {
   int get _terminalWidth {
     try {
       return stdout.terminalColumns;
-    } on io.StdoutException {
+    } on StdoutException {
       return 80;
     }
   }

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import '../base/io.dart';
+import '../base/logger.dart';
 import '../convert.dart';
-import '../globals.dart' as globals;
 
 /// A test reporter that displays compact progress and prints a summary of
 /// failed tests at the end.
@@ -16,10 +16,15 @@ import '../globals.dart' as globals;
 /// Usage:
 ///   flutter test --reporter=summary
 class SummaryReporter {
-  SummaryReporter({required this.supportsColor, required this.stdout});
+  SummaryReporter({
+    required this.supportsColor,
+    required this.stdout,
+    required Logger logger,
+  }) : _logger = logger;
 
   final bool supportsColor;
   final Stdout stdout;
+  final Logger _logger;
 
   final Map<int, _TestInfo> _tests = <int, _TestInfo>{};
   final Map<int, String> _suites = <int, String>{};
@@ -251,7 +256,7 @@ class SummaryReporter {
   }
 
   void _printLine(String message) {
-    globals.printStatus(message);
+    _logger.printStatus(message);
     _lastLineWasProgress = false;
   }
 

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -1,0 +1,292 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import '../convert.dart';
+import '../globals.dart' as globals;
+
+/// A test reporter that displays compact progress and prints a summary of
+/// failed tests at the end.
+///
+/// This reporter processes JSON output from package:test's JSON reporter,
+/// displays test progress in a compact format (similar to the default compact
+/// reporter), and collects failed test names to print a summary at the end.
+///
+/// Usage:
+///   flutter test --reporter=summary
+class SummaryReporter {
+  SummaryReporter({
+    required this.supportsColor,
+    required this.stdout,
+  });
+
+  final bool supportsColor;
+  final io.Stdout stdout;
+
+  final Map<int, _TestInfo> _tests = <int, _TestInfo>{};
+  final Map<int, String> _suites = <int, String>{};
+  final List<_FailedTest> _failedTests = <_FailedTest>[];
+  final Stopwatch _stopwatch = Stopwatch();
+
+  int _passed = 0;
+  int _skipped = 0;
+  int _failed = 0;
+  String _currentTestName = '';
+  bool _lastLineWasProgress = false;
+
+  /// Process a single line of JSON output from the test runner.
+  void handleLine(String line) {
+    if (line.trim().isEmpty) {
+      return;
+    }
+
+    try {
+      final dynamic event = json.decode(line);
+      if (event is! Map<String, dynamic>) {
+        _printLine(line);
+        return;
+      }
+      _handleEvent(event);
+    } on FormatException {
+      _printLine(line);
+    }
+  }
+
+  void _handleEvent(Map<String, dynamic> event) {
+    final type = event['type'] as String?;
+
+    switch (type) {
+      case 'start':
+        _stopwatch.start();
+      case 'suite':
+        _handleSuite(event);
+      case 'testStart':
+        _handleTestStart(event);
+      case 'testDone':
+        _handleTestDone(event);
+      case 'error':
+        _handleError(event);
+      case 'print':
+        _handlePrint(event);
+      case 'done':
+        _handleDone(event);
+    }
+  }
+
+  void _handleSuite(Map<String, dynamic> event) {
+    final dynamic suite = event['suite'];
+    if (suite is! Map<String, dynamic>) {
+      return;
+    }
+
+    final id = suite['id'] as int?;
+    final path = suite['path'] as String?;
+
+    if (id != null && path != null) {
+      _suites[id] = path;
+    }
+  }
+
+  void _handleTestStart(Map<String, dynamic> event) {
+    final dynamic test = event['test'];
+    if (test is! Map<String, dynamic>) {
+      return;
+    }
+
+    final id = test['id'] as int?;
+    final name = test['name'] as String?;
+    final suiteId = test['suiteID'] as int?;
+
+    if (id != null && name != null) {
+      _tests[id] = _TestInfo(name: name, suiteId: suiteId);
+      _currentTestName = name;
+      _printProgress();
+    }
+  }
+
+  void _handleTestDone(Map<String, dynamic> event) {
+    final testId = event['testID'] as int?;
+    final result = event['result'] as String?;
+    final bool skipped = event['skipped'] as bool? ?? false;
+    final bool hidden = event['hidden'] as bool? ?? false;
+
+    if (testId == null) {
+      return;
+    }
+
+    final _TestInfo? testInfo = _tests[testId];
+    if (testInfo == null) {
+      return;
+    }
+
+    // Don't count hidden tests (like setUpAll/tearDownAll)
+    if (hidden) {
+      return;
+    }
+
+    if (skipped) {
+      _skipped++;
+    } else if (result == 'success') {
+      _passed++;
+    } else if (result == 'failure' || result == 'error') {
+      _failed++;
+      final String? suitePath = testInfo.suiteId != null ? _suites[testInfo.suiteId] : null;
+      _failedTests.add(_FailedTest(name: testInfo.name, suitePath: suitePath));
+    }
+
+    _printProgress();
+  }
+
+  void _handleError(Map<String, dynamic> event) {
+    final error = event['error'] as String?;
+    final stackTrace = event['stackTrace'] as String?;
+
+    if (error != null) {
+      if (_lastLineWasProgress) {
+        _clearLine();
+      }
+      _printLine('');
+      _printLine(error);
+      if (stackTrace != null) {
+        _printLine(stackTrace);
+      }
+      _lastLineWasProgress = false;
+    }
+  }
+
+  void _handlePrint(Map<String, dynamic> event) {
+    final message = event['message'] as String?;
+    if (message != null) {
+      if (_lastLineWasProgress) {
+        _clearLine();
+      }
+      _printLine(message);
+      _lastLineWasProgress = false;
+    }
+  }
+
+  void _handleDone(Map<String, dynamic> event) {
+    _stopwatch.stop();
+
+    final bool success = event['success'] as bool? ?? false;
+
+    if (_lastLineWasProgress) {
+      _clearLine();
+    }
+
+    if (success) {
+      _printFinalStatus('All tests passed!');
+    } else {
+      _printFinalStatus('Some tests failed.', isFailure: true);
+      _printFailureSummary();
+    }
+  }
+
+  void _printProgress() {
+    final buffer = StringBuffer();
+    final Duration elapsed = _stopwatch.elapsed;
+    final String minutes = elapsed.inMinutes.toString().padLeft(2, '0');
+    final String seconds = (elapsed.inSeconds % 60).toString().padLeft(2, '0');
+
+    buffer.write('$minutes:$seconds ');
+    buffer.write('$_green+$_passed$_reset');
+
+    if (_skipped > 0) {
+      buffer.write(' $_yellow~$_skipped$_reset');
+    }
+
+    if (_failed > 0) {
+      buffer.write(' $_red-$_failed$_reset');
+    }
+
+    buffer.write(': ');
+    buffer.write(_currentTestName);
+
+    final line = buffer.toString();
+    final String paddedLine = line.padRight(_terminalWidth);
+    stdout.write('\r$paddedLine');
+    _lastLineWasProgress = true;
+  }
+
+  void _printFinalStatus(String message, {bool isFailure = false}) {
+    final buffer = StringBuffer();
+    final Duration elapsed = _stopwatch.elapsed;
+    final String minutes = elapsed.inMinutes.toString().padLeft(2, '0');
+    final String seconds = (elapsed.inSeconds % 60).toString().padLeft(2, '0');
+
+    buffer.write('$minutes:$seconds ');
+    buffer.write('$_green+$_passed$_reset');
+
+    if (_skipped > 0) {
+      buffer.write(' $_yellow~$_skipped$_reset');
+    }
+
+    if (_failed > 0) {
+      buffer.write(' $_red-$_failed$_reset');
+    }
+
+    buffer.write(': ');
+
+    if (isFailure) {
+      buffer.write('$_red$message$_reset');
+    } else {
+      buffer.write(message);
+    }
+
+    _printLine(buffer.toString());
+  }
+
+  void _printFailureSummary() {
+    if (_failedTests.isEmpty) {
+      return;
+    }
+
+    _printLine('');
+    _printLine('${_red}Failing tests:$_reset');
+    for (final _FailedTest test in _failedTests) {
+      if (test.suitePath != null) {
+        _printLine('  ${test.suitePath}: ${test.name}');
+      } else {
+        _printLine('  ${test.name}');
+      }
+    }
+  }
+
+  void _printLine(String message) {
+    globals.printStatus(message);
+    _lastLineWasProgress = false;
+  }
+
+  void _clearLine() {
+    stdout.write('\r${' ' * _terminalWidth}\r');
+  }
+
+  int get _terminalWidth {
+    try {
+      return stdout.terminalColumns;
+    } on io.StdoutException {
+      return 80;
+    }
+  }
+
+  String get _green => supportsColor ? '\x1B[32m' : '';
+  String get _red => supportsColor ? '\x1B[31m' : '';
+  String get _yellow => supportsColor ? '\x1B[33m' : '';
+  String get _reset => supportsColor ? '\x1B[0m' : '';
+}
+
+class _TestInfo {
+  _TestInfo({required this.name, this.suiteId});
+
+  final String name;
+  final int? suiteId;
+}
+
+class _FailedTest {
+  _FailedTest({required this.name, this.suitePath});
+
+  final String name;
+  final String? suitePath;
+}

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -17,10 +17,7 @@ import '../globals.dart' as globals;
 /// Usage:
 ///   flutter test --reporter=summary
 class SummaryReporter {
-  SummaryReporter({
-    required this.supportsColor,
-    required this.stdout,
-  });
+  SummaryReporter({required this.supportsColor, required this.stdout});
 
   final bool supportsColor;
   final io.Stdout stdout;

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -17,11 +17,8 @@ import '../convert.dart';
 /// Usage:
 ///   flutter test --reporter=summary
 class SummaryReporter {
-  SummaryReporter({
-    required this.supportsColor,
-    required this.stdout,
-    required Logger logger,
-  }) : _logger = logger;
+  SummaryReporter({required this.supportsColor, required this.stdout, required Logger logger})
+    : _logger = logger;
 
   final bool supportsColor;
   final Stdout stdout;
@@ -84,7 +81,9 @@ class SummaryReporter {
   }
 
   void _handleTestStart(Map<String, Object?> event) {
-    if (event case {'test': {'id': final int id, 'name': final String name, 'suiteID': final int? suiteId}}) {
+    if (event case {
+      'test': {'id': final int id, 'name': final String name, 'suiteID': final int? suiteId},
+    }) {
       _tests[id] = _TestInfo(name: name, suiteId: suiteId);
       _currentTestName = name;
       _printProgress();

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -27,10 +27,10 @@ class SummaryReporter {
   final Stdout stdout;
   final Logger _logger;
 
-  final Map<int, _TestInfo> _tests = <int, _TestInfo>{};
-  final Map<int, String> _suites = <int, String>{};
-  final List<_FailedTest> _failedTests = <_FailedTest>[];
-  final Stopwatch _stopwatch = Stopwatch();
+  final _tests = <int, _TestInfo>{};
+  final _suites = <int, String>{};
+  final _failedTests = <_FailedTest>[];
+  final _stopwatch = Stopwatch();
 
   int _passed = 0;
   int _skipped = 0;

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -78,30 +78,13 @@ class SummaryReporter {
   }
 
   void _handleSuite(Map<String, Object?> event) {
-    final Object? suite = event['suite'];
-    if (suite is! Map<String, Object?>) {
-      return;
-    }
-
-    final id = suite['id'] as int?;
-    final path = suite['path'] as String?;
-
-    if (id != null && path != null) {
+    if (event case {'suite': {'id': final int id, 'path': final String path}}) {
       _suites[id] = path;
     }
   }
 
   void _handleTestStart(Map<String, Object?> event) {
-    final Object? test = event['test'];
-    if (test is! Map<String, Object?>) {
-      return;
-    }
-
-    final id = test['id'] as int?;
-    final name = test['name'] as String?;
-    final suiteId = test['suiteID'] as int?;
-
-    if (id != null && name != null) {
+    if (event case {'test': {'id': final int id, 'name': final String name, 'suiteID': final int? suiteId}}) {
       _tests[id] = _TestInfo(name: name, suiteId: suiteId);
       _currentTestName = name;
       _printProgress();
@@ -159,8 +142,7 @@ class SummaryReporter {
   }
 
   void _handlePrint(Map<String, Object?> event) {
-    final message = event['message'] as String?;
-    if (message != null) {
+    if (event case {'message': final String message}) {
       if (_lastLineWasProgress) {
         _clearLine();
       }

--- a/packages/flutter_tools/lib/src/test/summary_reporter.dart
+++ b/packages/flutter_tools/lib/src/test/summary_reporter.dart
@@ -4,6 +4,7 @@
 
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/terminal.dart';
 import '../convert.dart';
 
 /// A test reporter that displays compact progress and prints a summary of
@@ -272,10 +273,10 @@ class SummaryReporter {
     }
   }
 
-  String get _green => supportsColor ? '\x1B[32m' : '';
-  String get _red => supportsColor ? '\x1B[31m' : '';
-  String get _yellow => supportsColor ? '\x1B[33m' : '';
-  String get _reset => supportsColor ? '\x1B[0m' : '';
+  String get _green => supportsColor ? AnsiTerminal.green : '';
+  String get _red => supportsColor ? AnsiTerminal.red : '';
+  String get _yellow => supportsColor ? AnsiTerminal.yellow : '';
+  String get _reset => supportsColor ? AnsiTerminal.resetColor : '';
 }
 
 class _TestInfo {

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
 
 import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
 import 'package:test_core/src/platform.dart' // ignore: implementation_imports
@@ -13,10 +15,24 @@ import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 export 'package:test_api/backend.dart' show Runtime;
 export 'package:test_core/src/platform.dart' show PlatformPlugin;
 
+/// Callback for processing each line of test output.
+typedef OutputLineCallback = void Function(String line);
+
 abstract class TestWrapper {
   const factory TestWrapper() = _DefaultTestWrapper;
 
+  /// Runs the test package with the given arguments.
   Future<void> main(List<String> args);
+
+  /// Runs the test package with output interception.
+  ///
+  /// All stdout output from the test runner will be passed to [onOutputLine]
+  /// line-by-line, allowing for stream processing of test results.
+  Future<void> mainWithOutputCapture(
+    List<String> args, {
+    required OutputLineCallback onOutputLine,
+  });
+
   void registerPlatformPlugin(
     Iterable<Runtime> runtimes,
     FutureOr<PlatformPlugin> Function() platforms,
@@ -32,10 +48,132 @@ class _DefaultTestWrapper implements TestWrapper {
   }
 
   @override
+  Future<void> mainWithOutputCapture(
+    List<String> args, {
+    required OutputLineCallback onOutputLine,
+  }) async {
+    final io.Stdout originalStdout = io.stdout;
+    final buffer = StringBuffer();
+
+    void processBuffer() {
+      final content = buffer.toString();
+      if (content.isEmpty) {
+        return;
+      }
+      buffer.clear();
+
+      final List<String> lines = content.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        final String line = lines[i];
+        // The last element might be incomplete if content doesn't end with \n
+        if (i == lines.length - 1 && !content.endsWith('\n') && line.isNotEmpty) {
+          buffer.write(line);
+        } else if (line.isNotEmpty) {
+          onOutputLine(line);
+        }
+      }
+    }
+
+    await io.IOOverrides.runZoned(
+      () async {
+        await test.main(args);
+        processBuffer();
+      },
+      stdout: () => _InterceptingStdout(
+        originalStdout,
+        onWrite: (String data) {
+          buffer.write(data);
+          processBuffer();
+        },
+      ),
+    );
+  }
+
+  @override
   void registerPlatformPlugin(
     Iterable<Runtime> runtimes,
     FutureOr<PlatformPlugin> Function() platforms,
   ) {
     hack.registerPlatformPlugin(runtimes, platforms);
   }
+}
+
+/// A stdout wrapper that intercepts writes for processing.
+class _InterceptingStdout implements io.Stdout {
+  _InterceptingStdout(this._original, {required this.onWrite});
+
+  final io.Stdout _original;
+  final void Function(String data) onWrite;
+
+  @override
+  void write(Object? object) {
+    onWrite(object.toString());
+  }
+
+  @override
+  void writeln([Object? object = '']) {
+    onWrite('${object ?? ''}\n');
+  }
+
+  @override
+  void writeAll(Iterable<dynamic> objects, [String sep = '']) {
+    onWrite(objects.join(sep));
+  }
+
+  @override
+  void writeCharCode(int charCode) {
+    onWrite(String.fromCharCode(charCode));
+  }
+
+  @override
+  Encoding get encoding => _original.encoding;
+
+  @override
+  set encoding(Encoding encoding) => _original.encoding = encoding;
+
+  @override
+  void add(List<int> data) {
+    onWrite(utf8.decode(data));
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) =>
+      _original.addError(error, stackTrace);
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final List<int> data in stream) {
+      onWrite(utf8.decode(data));
+    }
+  }
+
+  @override
+  Future<void> close() => _original.close();
+
+  @override
+  Future<void> get done => _original.done;
+
+  @override
+  Future<void> flush() => _original.flush();
+
+  @override
+  bool get hasTerminal => _original.hasTerminal;
+
+  @override
+  io.IOSink get nonBlocking => _original.nonBlocking;
+
+  @override
+  bool get supportsAnsiEscapes => _original.supportsAnsiEscapes;
+
+  @override
+  int get terminalColumns => _original.terminalColumns;
+
+  @override
+  int get terminalLines => _original.terminalLines;
+
+  @override
+  String get lineTerminator => _original.lineTerminator;
+
+  @override
+  set lineTerminator(String value) => _original.lineTerminator = value;
 }

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io' as io;
+import 'dart:convert'; // flutter_ignore: dart_convert_import
+import 'dart:io' as io; // flutter_ignore: dart_io_import
 
 import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
 import 'package:test_core/src/platform.dart' // ignore: implementation_imports

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -28,10 +28,7 @@ abstract class TestWrapper {
   ///
   /// All stdout output from the test runner will be passed to [onOutputLine]
   /// line-by-line, allowing for stream processing of test results.
-  Future<void> mainWithOutputCapture(
-    List<String> args, {
-    required OutputLineCallback onOutputLine,
-  });
+  Future<void> mainWithOutputCapture(List<String> args, {required OutputLineCallback onOutputLine});
 
   void registerPlatformPlugin(
     Iterable<Runtime> runtimes,
@@ -137,8 +134,7 @@ class _InterceptingStdout implements io.Stdout {
   }
 
   @override
-  void addError(Object error, [StackTrace? stackTrace]) =>
-      _original.addError(error, stackTrace);
+  void addError(Object error, [StackTrace? stackTrace]) => _original.addError(error, stackTrace);
 
   @override
   Future<void> addStream(Stream<List<int>> stream) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -1765,6 +1765,14 @@ class FakePackageTest implements TestWrapper {
   }
 
   @override
+  Future<void> mainWithOutputCapture(
+    List<String> args, {
+    required OutputLineCallback onOutputLine,
+  }) async {
+    lastArgs = args;
+  }
+
+  @override
   void registerPlatformPlugin(
     Iterable<Runtime> runtimes,
     FutureOr<PlatformPlugin> Function() platforms,

--- a/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
+++ b/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
@@ -22,7 +22,7 @@ void main() {
     });
 
     testUsingContext('tracks failed tests from JSON output', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       // Simulate JSON reporter output
       reporter.handleLine(
@@ -57,7 +57,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('does not print summary when all tests pass', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(
@@ -73,7 +73,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('handles malformed JSON gracefully', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       // This should not throw
       reporter.handleLine('not valid json');
@@ -84,7 +84,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('ignores hidden tests', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(
@@ -100,7 +100,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('includes suite path in failure summary', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(
@@ -118,7 +118,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('handles skipped tests', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(
@@ -134,7 +134,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('outputs error messages', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(
@@ -153,7 +153,7 @@ void main() {
     }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('outputs print messages', () async {
-      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       reporter.handleLine('{"type":"start","time":0}');
       reporter.handleLine(

--- a/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
+++ b/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
@@ -1,0 +1,239 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/test/summary_reporter.dart';
+
+import '../src/common.dart';
+import '../src/context.dart';
+
+void main() {
+  group('SummaryReporter', () {
+    late BufferLogger logger;
+    late _FakeStdout fakeStdout;
+
+    setUp(() {
+      logger = BufferLogger.test();
+      fakeStdout = _FakeStdout();
+    });
+
+    testUsingContext('tracks failed tests from JSON output', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      // Simulate JSON reporter output
+      reporter.handleLine('{"protocolVersion":"0.1.1","runnerVersion":"1.24.9","type":"start","time":0}');
+      reporter.handleLine('{"suite":{"id":0,"path":"test/example_test.dart"},"type":"suite","time":5}');
+      reporter.handleLine('{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"test":{"id":2,"name":"failing test A","suiteID":0,"groupIDs":[]},"type":"testStart","time":30}');
+      reporter.handleLine('{"testID":2,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":40}');
+      reporter.handleLine('{"test":{"id":3,"name":"failing test B","suiteID":0,"groupIDs":[]},"type":"testStart","time":50}');
+      reporter.handleLine('{"testID":3,"result":"error","hidden":false,"skipped":false,"type":"testDone","time":60}');
+      reporter.handleLine('{"success":false,"type":"done","time":70}');
+
+      expect(logger.statusText, contains('Failing tests:'));
+      expect(logger.statusText, contains('failing test A'));
+      expect(logger.statusText, contains('failing test B'));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('does not print summary when all tests pass', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":true,"type":"done","time":30}');
+
+      expect(logger.statusText, contains('All tests passed!'));
+      expect(logger.statusText, isNot(contains('Failing tests:')));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('handles malformed JSON gracefully', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      // This should not throw
+      reporter.handleLine('not valid json');
+      reporter.handleLine('{"also": "not a test event"');
+      reporter.handleLine('');
+
+      // No crash means success
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('ignores hidden tests', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"test":{"id":1,"name":"(setUpAll)","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"result":"failure","hidden":true,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":false,"type":"done","time":30}');
+
+      // Hidden tests should not appear in summary
+      expect(logger.statusText, isNot(contains('(setUpAll)')));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('includes suite path in failure summary', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"suite":{"id":0,"path":"test/widget_test.dart"},"type":"suite","time":5}');
+      reporter.handleLine('{"test":{"id":1,"name":"my failing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":false,"type":"done","time":30}');
+
+      expect(logger.statusText, contains('test/widget_test.dart: my failing test'));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('handles skipped tests', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"test":{"id":1,"name":"skipped test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":true,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":true,"type":"done","time":30}');
+
+      // Skipped tests should not be in failed list
+      expect(logger.statusText, isNot(contains('Failing tests:')));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('outputs error messages', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"test":{"id":1,"name":"test with error","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine(r'{"testID":1,"error":"Expected: 2\n  Actual: 1","type":"error","time":15}');
+      reporter.handleLine('{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":false,"type":"done","time":30}');
+
+      expect(logger.statusText, contains('Expected: 2'));
+      expect(logger.statusText, contains('Actual: 1'));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('outputs print messages', () async {
+      final reporter = SummaryReporter(
+        supportsColor: false,
+        stdout: fakeStdout,
+      );
+
+      reporter.handleLine('{"type":"start","time":0}');
+      reporter.handleLine('{"test":{"id":1,"name":"test with print","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine('{"testID":1,"message":"Hello from test!","type":"print","time":15}');
+      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine('{"success":true,"type":"done","time":30}');
+
+      expect(logger.statusText, contains('Hello from test!'));
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+  });
+}
+
+/// A fake stdout implementation for testing that doesn't write to the real stdout.
+class _FakeStdout implements io.Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get output => _buffer.toString();
+
+  @override
+  void write(Object? object) {
+    _buffer.write(object);
+  }
+
+  @override
+  void writeln([Object? object = '']) {
+    _buffer.writeln(object);
+  }
+
+  @override
+  void writeAll(Iterable<dynamic> objects, [String sep = '']) {
+    _buffer.writeAll(objects, sep);
+  }
+
+  @override
+  void writeCharCode(int charCode) {
+    _buffer.writeCharCode(charCode);
+  }
+
+  @override
+  Encoding get encoding => utf8;
+
+  @override
+  set encoding(Encoding encoding) {}
+
+  @override
+  void add(List<int> data) {}
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => Future<void>.value();
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  bool get hasTerminal => false;
+
+  @override
+  io.IOSink get nonBlocking => throw UnimplementedError();
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  int get terminalColumns => 80;
+
+  @override
+  int get terminalLines => 24;
+
+  @override
+  String get lineTerminator => '\n';
+
+  @override
+  set lineTerminator(String value) {}
+}

--- a/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
+++ b/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
@@ -22,51 +22,58 @@ void main() {
     });
 
     testUsingContext('tracks failed tests from JSON output', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       // Simulate JSON reporter output
-      reporter.handleLine('{"protocolVersion":"0.1.1","runnerVersion":"1.24.9","type":"start","time":0}');
-      reporter.handleLine('{"suite":{"id":0,"path":"test/example_test.dart"},"type":"suite","time":5}');
-      reporter.handleLine('{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
-      reporter.handleLine('{"test":{"id":2,"name":"failing test A","suiteID":0,"groupIDs":[]},"type":"testStart","time":30}');
-      reporter.handleLine('{"testID":2,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":40}');
-      reporter.handleLine('{"test":{"id":3,"name":"failing test B","suiteID":0,"groupIDs":[]},"type":"testStart","time":50}');
-      reporter.handleLine('{"testID":3,"result":"error","hidden":false,"skipped":false,"type":"testDone","time":60}');
+      reporter.handleLine(
+        '{"protocolVersion":"0.1.1","runnerVersion":"1.24.9","type":"start","time":0}',
+      );
+      reporter.handleLine(
+        '{"suite":{"id":0,"path":"test/example_test.dart"},"type":"suite","time":5}',
+      );
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}',
+      );
+      reporter.handleLine(
+        '{"test":{"id":2,"name":"failing test A","suiteID":0,"groupIDs":[]},"type":"testStart","time":30}',
+      );
+      reporter.handleLine(
+        '{"testID":2,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":40}',
+      );
+      reporter.handleLine(
+        '{"test":{"id":3,"name":"failing test B","suiteID":0,"groupIDs":[]},"type":"testStart","time":50}',
+      );
+      reporter.handleLine(
+        '{"testID":3,"result":"error","hidden":false,"skipped":false,"type":"testDone","time":60}',
+      );
       reporter.handleLine('{"success":false,"type":"done","time":70}');
 
       expect(logger.statusText, contains('Failing tests:'));
       expect(logger.statusText, contains('failing test A'));
       expect(logger.statusText, contains('failing test B'));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('does not print summary when all tests pass', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":true,"type":"done","time":30}');
 
       expect(logger.statusText, contains('All tests passed!'));
       expect(logger.statusText, isNot(contains('Failing tests:')));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('handles malformed JSON gracefully', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       // This should not throw
       reporter.handleLine('not valid json');
@@ -74,95 +81,92 @@ void main() {
       reporter.handleLine('');
 
       // No crash means success
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('ignores hidden tests', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"test":{"id":1,"name":"(setUpAll)","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine('{"testID":1,"result":"failure","hidden":true,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"(setUpAll)","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"failure","hidden":true,"skipped":false,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":false,"type":"done","time":30}');
 
       // Hidden tests should not appear in summary
       expect(logger.statusText, isNot(contains('(setUpAll)')));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('includes suite path in failure summary', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"suite":{"id":0,"path":"test/widget_test.dart"},"type":"suite","time":5}');
-      reporter.handleLine('{"test":{"id":1,"name":"my failing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine('{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"suite":{"id":0,"path":"test/widget_test.dart"},"type":"suite","time":5}',
+      );
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"my failing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":false,"type":"done","time":30}');
 
       expect(logger.statusText, contains('test/widget_test.dart: my failing test'));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('handles skipped tests', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"test":{"id":1,"name":"skipped test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":true,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"skipped test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"success","hidden":false,"skipped":true,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":true,"type":"done","time":30}');
 
       // Skipped tests should not be in failed list
       expect(logger.statusText, isNot(contains('Failing tests:')));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('outputs error messages', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"test":{"id":1,"name":"test with error","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
-      reporter.handleLine(r'{"testID":1,"error":"Expected: 2\n  Actual: 1","type":"error","time":15}');
-      reporter.handleLine('{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"test with error","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
+      reporter.handleLine(
+        r'{"testID":1,"error":"Expected: 2\n  Actual: 1","type":"error","time":15}',
+      );
+      reporter.handleLine(
+        '{"testID":1,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":false,"type":"done","time":30}');
 
       expect(logger.statusText, contains('Expected: 2'));
       expect(logger.statusText, contains('Actual: 1'));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
 
     testUsingContext('outputs print messages', () async {
-      final reporter = SummaryReporter(
-        supportsColor: false,
-        stdout: fakeStdout,
-      );
+      final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout);
 
       reporter.handleLine('{"type":"start","time":0}');
-      reporter.handleLine('{"test":{"id":1,"name":"test with print","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}');
+      reporter.handleLine(
+        '{"test":{"id":1,"name":"test with print","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
+      );
       reporter.handleLine('{"testID":1,"message":"Hello from test!","type":"print","time":15}');
-      reporter.handleLine('{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}');
+      reporter.handleLine(
+        '{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}',
+      );
       reporter.handleLine('{"success":true,"type":"done","time":30}');
 
       expect(logger.statusText, contains('Hello from test!'));
-    }, overrides: <Type, Generator>{
-      Logger: () => logger,
-    });
+    }, overrides: <Type, Generator>{Logger: () => logger});
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
+++ b/packages/flutter_tools/test/general.shard/summary_reporter_test.dart
@@ -25,31 +25,18 @@ void main() {
       final reporter = SummaryReporter(supportsColor: false, stdout: fakeStdout, logger: logger);
 
       // Simulate JSON reporter output
-      reporter.handleLine(
+      final jsonLines = <String>[
         '{"protocolVersion":"0.1.1","runnerVersion":"1.24.9","type":"start","time":0}',
-      );
-      reporter.handleLine(
         '{"suite":{"id":0,"path":"test/example_test.dart"},"type":"suite","time":5}',
-      );
-      reporter.handleLine(
         '{"test":{"id":1,"name":"passing test","suiteID":0,"groupIDs":[]},"type":"testStart","time":10}',
-      );
-      reporter.handleLine(
         '{"testID":1,"result":"success","hidden":false,"skipped":false,"type":"testDone","time":20}',
-      );
-      reporter.handleLine(
         '{"test":{"id":2,"name":"failing test A","suiteID":0,"groupIDs":[]},"type":"testStart","time":30}',
-      );
-      reporter.handleLine(
         '{"testID":2,"result":"failure","hidden":false,"skipped":false,"type":"testDone","time":40}',
-      );
-      reporter.handleLine(
         '{"test":{"id":3,"name":"failing test B","suiteID":0,"groupIDs":[]},"type":"testStart","time":50}',
-      );
-      reporter.handleLine(
         '{"testID":3,"result":"error","hidden":false,"skipped":false,"type":"testDone","time":60}',
-      );
-      reporter.handleLine('{"success":false,"type":"done","time":70}');
+        '{"success":false,"type":"done","time":70}',
+      ];
+      jsonLines.forEach(reporter.handleLine);
 
       expect(logger.statusText, contains('Failing tests:'));
       expect(logger.statusText, contains('failing test A'));


### PR DESCRIPTION
  Adds a new 'summary' reporter that behaves like the compact reporter but prints a list of all failed tests at the end for easy identification.

  This is useful when running large test suites where failed tests can scroll off screen, making it difficult to identify which tests need attention.

  Usage: flutter test --reporter=summary

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

solves #102387 

### Implementation approach:
  - Wraps JSON reporter output and transforms to compact format in real-time
  - Collects failed test metadata during execution
  - Falls back to compact in lightweight engine mode (noted limitation)

###  References:
  - files dir decision from https://codewiki.google/ 
  - Development assisted by Claude Opus 4.5

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
