### PR TITLE
Create `FlexiableAction<T>` binds to `Intent` that extends `T`

### DIFF
--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -517,6 +517,23 @@ void main() {
       expect(invokedAction, isNull);
       expect(invokedDispatcher, isNull);
     });
+
+    testWidgets('DoNothingAction can binds to any Intent', (WidgetTester tester) async {
+      final GlobalKey globalKey = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Actions(
+            actions: <Type, Action<Intent>>{DeleteCharacterIntent: DoNothingAction()},
+            child: Focus(autofocus: true, child: SizedBox.expand(key: globalKey)),
+          ),
+        ),
+      );
+      await tester.pump();
+      final BuildContext context = globalKey.currentContext!;
+      Actions.invoke(context, const DeleteCharacterIntent(forward: true));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
   });
 
   group('Listening', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180435
Proposal https://github.com/flutter/flutter/issues/180635

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
