### PR TITLE
Do not dispose CupertinoSheetTransition animation on update and throw ticker error

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -411,10 +411,8 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
   @override
   void didUpdateWidget(covariant CupertinoSheetTransition oldWidget) {
     super.didUpdateWidget(oldWidget);
-    print('didUpdateWidget');
     if (oldWidget.primaryRouteAnimation != widget.primaryRouteAnimation ||
         oldWidget.secondaryRouteAnimation != widget.secondaryRouteAnimation) {
-      print('dispose curve');
       _disposeCurve();
       _setupAnimation();
     }

--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -401,14 +401,20 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
   void initState() {
     super.initState();
 
+    _stretchDragController = AnimationController(
+      duration: const Duration(microseconds: 1),
+      vsync: this,
+    );
     _setupAnimation();
   }
 
   @override
   void didUpdateWidget(covariant CupertinoSheetTransition oldWidget) {
     super.didUpdateWidget(oldWidget);
+    print('didUpdateWidget');
     if (oldWidget.primaryRouteAnimation != widget.primaryRouteAnimation ||
         oldWidget.secondaryRouteAnimation != widget.secondaryRouteAnimation) {
+      print('dispose curve');
       _disposeCurve();
       _setupAnimation();
     }
@@ -417,6 +423,7 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
   @override
   void dispose() {
     _disposeCurve();
+    _stretchDragController.dispose();
     super.dispose();
   }
 
@@ -431,10 +438,6 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
       reverseCurve: Curves.easeInToLinear,
       parent: widget.secondaryRouteAnimation,
     );
-    _stretchDragController = AnimationController(
-      duration: const Duration(microseconds: 1),
-      vsync: this,
-    );
     // Maintain the same stretch distance (0.008 of screen height) regardless of custom topGap.
     const double stretchDistance = _kTopGapRatio - _kStretchedTopGapRatio;
     final double stretchedTopGap = widget.topGap - stretchDistance;
@@ -446,7 +449,6 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
   }
 
   void _disposeCurve() {
-    _stretchDragController.dispose();
     _primaryPositionCurve?.dispose();
     _secondaryPositionCurve?.dispose();
     _primaryPositionCurve = null;

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -1617,7 +1617,6 @@ void main() {
     },
   );
 
-<<<<<<< HEAD
   group('topGap parameter tests', () {
     testWidgets('sheet uses default topGap when not specified', (WidgetTester tester) async {
       final GlobalKey scaffoldKey = GlobalKey();
@@ -1968,7 +1967,7 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
     });
-=======
+  });
   testWidgets('didUpdateWidget in sheet transition does not try and use multiple tickers', (
     WidgetTester tester,
   ) async {
@@ -1995,6 +1994,5 @@ void main() {
     await tester.pumpAndSettle();
 
     // expect(find.text('Increase Count'), findsOneWidget);
->>>>>>> 7fab17d486f (Do not dispose of controller on update)
   });
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -1971,28 +1971,35 @@ void main() {
   testWidgets('didUpdateWidget in sheet transition does not try and use multiple tickers', (
     WidgetTester tester,
   ) async {
-    final GlobalKey scaffoldKey = GlobalKey();
+    final animation = AnimationController(vsync: const TestVSync());
+    final secondaryAnimation = AnimationController(vsync: const TestVSync());
 
-    await tester.pumpWidget(_RebuildingPage(scaffoldKey: scaffoldKey));
+    await tester.pumpWidget(
+      CupertinoSheetTransition(
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
+        topGap: 0.08,
+        linearTransition: false,
+        child: const SizedBox(height: 100, width: 100),
+      ),
+    );
 
-    await tester.tap(find.text('Push Page 2'));
+    final newAnimation = AnimationController(vsync: const TestVSync());
+
+    // Should not throw an exception.
+    await tester.pumpWidget(
+      CupertinoSheetTransition(
+        primaryRouteAnimation: newAnimation,
+        secondaryRouteAnimation: secondaryAnimation,
+        topGap: 0.08,
+        linearTransition: false,
+        child: const SizedBox(height: 100, width: 100),
+      ),
+    );
+
     await tester.pumpAndSettle();
-
-    expect(find.text('Increase Count'), findsOneWidget);
-    Navigator.of(scaffoldKey.currentContext!).pop();
-
-    // await tester.pump();
-
-    await tester.tap(find.text('Increase Count'));
-
-    // await tester.tap(find.text('Increase Count'));
-    // Navigator.of(scaffoldKey.currentContext!).push(
-    //   CupertinoPageRoute(
-    //     builder: (BuildContext context) => const CupertinoPageScaffold(child: Text('Page 3')),
-    //   ),
-    // );
-    await tester.pumpAndSettle();
-
-    // expect(find.text('Increase Count'), findsOneWidget);
+    animation.dispose();
+    secondaryAnimation.dispose();
+    newAnimation.dispose();
   });
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -13,6 +13,69 @@ import '../widgets/navigator_utils.dart';
 // Matches _kTopGapRatio in cupertino/sheet.dart.
 const double _kTopGapRatio = 0.08;
 
+class _RebuildingPage extends StatefulWidget {
+  const _RebuildingPage({required this.scaffoldKey});
+
+  final GlobalKey scaffoldKey;
+
+  @override
+  _RebuildingPageState createState() => _RebuildingPageState();
+}
+
+class _RebuildingPageState extends State<_RebuildingPage> {
+  late int counter;
+
+  @override
+  void initState() {
+    super.initState();
+    counter = 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      home: CupertinoPageScaffold(
+        key: widget.scaffoldKey,
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              const Text('Page 1'),
+              CupertinoButton(
+                onPressed: () {
+                  Navigator.push<void>(
+                    widget.scaffoldKey.currentContext!,
+                    CupertinoSheetRoute<void>(
+                      builder: (BuildContext context) {
+                        return CupertinoPageScaffold(
+                          child: Center(
+                            child: Column(
+                              children: <Widget>[
+                                const Text('Page two'),
+                                Text('Counter Value: $counter'),
+                                CupertinoButton(
+                                  onPressed: () => setState(() {
+                                    counter++;
+                                  }),
+                                  child: const Text('Increase Count'),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: const Text('Push Page 2'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
   testWidgets('Sheet route does not cover the whole screen', (WidgetTester tester) async {
     final GlobalKey scaffoldKey = GlobalKey();
@@ -1554,6 +1617,7 @@ void main() {
     },
   );
 
+<<<<<<< HEAD
   group('topGap parameter tests', () {
     testWidgets('sheet uses default topGap when not specified', (WidgetTester tester) async {
       final GlobalKey scaffoldKey = GlobalKey();
@@ -1904,5 +1968,33 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
     });
+=======
+  testWidgets('didUpdateWidget in sheet transition does not try and use multiple tickers', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(_RebuildingPage(scaffoldKey: scaffoldKey));
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Increase Count'), findsOneWidget);
+    Navigator.of(scaffoldKey.currentContext!).pop();
+
+    // await tester.pump();
+
+    await tester.tap(find.text('Increase Count'));
+
+    // await tester.tap(find.text('Increase Count'));
+    // Navigator.of(scaffoldKey.currentContext!).push(
+    //   CupertinoPageRoute(
+    //     builder: (BuildContext context) => const CupertinoPageScaffold(child: Text('Page 3')),
+    //   ),
+    // );
+    await tester.pumpAndSettle();
+
+    // expect(find.text('Increase Count'), findsOneWidget);
+>>>>>>> 7fab17d486f (Do not dispose of controller on update)
   });
 }

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -13,69 +13,6 @@ import '../widgets/navigator_utils.dart';
 // Matches _kTopGapRatio in cupertino/sheet.dart.
 const double _kTopGapRatio = 0.08;
 
-class _RebuildingPage extends StatefulWidget {
-  const _RebuildingPage({required this.scaffoldKey});
-
-  final GlobalKey scaffoldKey;
-
-  @override
-  _RebuildingPageState createState() => _RebuildingPageState();
-}
-
-class _RebuildingPageState extends State<_RebuildingPage> {
-  late int counter;
-
-  @override
-  void initState() {
-    super.initState();
-    counter = 0;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoApp(
-      home: CupertinoPageScaffold(
-        key: widget.scaffoldKey,
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              const Text('Page 1'),
-              CupertinoButton(
-                onPressed: () {
-                  Navigator.push<void>(
-                    widget.scaffoldKey.currentContext!,
-                    CupertinoSheetRoute<void>(
-                      builder: (BuildContext context) {
-                        return CupertinoPageScaffold(
-                          child: Center(
-                            child: Column(
-                              children: <Widget>[
-                                const Text('Page two'),
-                                Text('Counter Value: $counter'),
-                                CupertinoButton(
-                                  onPressed: () => setState(() {
-                                    counter++;
-                                  }),
-                                  child: const Text('Increase Count'),
-                                ),
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                },
-                child: const Text('Push Page 2'),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 void main() {
   testWidgets('Sheet route does not cover the whole screen', (WidgetTester tester) async {
     final GlobalKey scaffoldKey = GlobalKey();

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -1935,6 +1935,9 @@ void main() {
     );
 
     await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
     animation.dispose();
     secondaryAnimation.dispose();
     newAnimation.dispose();


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes #179337 by moving the disposal of an animation controller outside of the didUpdate method flow. It was unnecessary to rebuild this controller on update, and was originally put there to follow the pattern of the other animations. However, unlike the other animations, this one is not chained to animations from outside of the transition's place in the tree, and was throwing exceptions from the ticker mixin in some cases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
