### PR TITLE
Make sure that a FlutterLogo doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/flutter_logo_test.dart
+++ b/packages/flutter/test/widgets/flutter_logo_test.dart
@@ -17,4 +17,14 @@ void main() {
 
     await expectLater(find.byKey(logo), matchesGoldenFile('flutter_logo.png'));
   });
+
+  testWidgets('FlutterLogo does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: SizedBox.shrink(child: FlutterLogo())),
+      ),
+    );
+    expect(tester.getSize(find.byType(FlutterLogo)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the FlutterLogo widget.