### PR TITLE
Run hook_user_defines and link_hook integration tests on CI

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -244,6 +244,9 @@ Future<void> _runIntegrationToolTests() async {
     testPaths: selectIndexOfTotalSubshard<String>(allTests),
     collectMetrics: true,
   );
+
+  await runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'hook_user_defines'));
+  await runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'link_hook'));
 }
 
 Future<void> _runWidgetPreviewScaffoldToolTests() async {

--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -2,10 +2,12 @@ name: hook_user_defines
 description: 'Project for testing user-defines.'
 version: 0.0.1
 
+# This packages is not part of the workspace on purpose to test the user-defines
+# in this pubspec.
+# resolution: workspace
+
 environment:
   sdk: ^3.9.0-0
-
-resolution: workspace
 
 hooks:
   user_defines:
@@ -13,11 +15,11 @@ hooks:
       magic_value: 1000
 
 dependencies:
-  hooks: any
-  logging: any
-  native_toolchain_c: any
+  hooks: 1.0.0
+  logging: 1.3.0
+  native_toolchain_c: 0.17.4
 
 dev_dependencies:
-  test: any
+  test: 1.28.0
 
-# PUBSPEC CHECKSUM: meinbq
+# PUBSPEC CHECKSUM: qlfuuh

--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -2,7 +2,7 @@ name: hook_user_defines
 description: 'Project for testing user-defines.'
 version: 0.0.1
 
-# This packages is not part of the workspace on purpose to test the user-defines
+# This package is not part of the workspace on purpose to test the user-defines
 # in this pubspec.
 # resolution: workspace
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -183,7 +183,7 @@ class UpdatePackagesCommand extends FlutterCommand {
     );
     // This package is intentionally not part of the workspace to test
     // user-defines in its local pubspec.
-    final hooksUserDefineIntegrationTestDirectory = rootDirectory
+    final Directory hooksUserDefineIntegrationTestDirectory = rootDirectory
         .childDirectory('dev')
         .childDirectory('integration_tests')
         .childDirectory('hook_user_defines');

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -235,7 +235,7 @@ class UpdatePackagesCommand extends FlutterCommand {
     // See https://github.com/flutter/flutter/pull/170364.
     await _pubGet(toolProject, false);
     await _pubGet(widgetPreviewScaffoldProject, false);
-    await _pubGet(hooksUserDefineIntegrationTestDirectory, false);
+    await _pubGet(FlutterProject.fromDirectory(hooksUserDefineIntegrationTestDirectory), false);
 
     await _downloadCoverageData();
 

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -181,6 +181,13 @@ class UpdatePackagesCommand extends FlutterCommand {
           .childDirectory('widget_preview_scaffold.shard')
           .childDirectory('widget_preview_scaffold'),
     );
+    // This package is intentionally not part of the workspace to test
+    // user-defines in its local pubspec.
+    final hooksUserDefineIntegrationTestDirectory = rootDirectory
+        .childDirectory('dev')
+        .childDirectory('integration_tests')
+        .childDirectory('hook_user_defines');
+
     final packages = <Directory>[...runner!.getRepoPackages(), rootDirectory];
 
     if (!updateHashes) {
@@ -208,6 +215,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         rootDirectory.childDirectory('packages').childDirectory('flutter'),
         rootDirectory.childDirectory('packages').childDirectory('flutter_test'),
         rootDirectory.childDirectory('packages').childDirectory('flutter_localizations'),
+        hooksUserDefineIntegrationTestDirectory,
       ]) {
         _updatePubspec(package, deps);
       }
@@ -220,11 +228,14 @@ class UpdatePackagesCommand extends FlutterCommand {
     _checkWithFlutterTools(rootDirectory);
     _checkPins(rootDirectory);
 
+    // Pub get for the workspace.
     await _pubGet(rootProject, !forceUpgrade && cherryPicks.isEmpty && !updateHashes);
 
+    // Manually do a pub get for packages not part of the workspace.
     // See https://github.com/flutter/flutter/pull/170364.
     await _pubGet(toolProject, false);
     await _pubGet(widgetPreviewScaffoldProject, false);
+    await _pubGet(hooksUserDefineIntegrationTestDirectory, false);
 
     await _downloadCoverageData();
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -92,6 +92,31 @@ dev_dependencies:
 ''';
 
 // An example pubspec.yaml from flutter, not necessary for it to be up to date.
+const kNonWorkspacePubspecYaml = r'''
+name: hook_user_defines
+description: 'Project for testing user-defines.'
+version: 0.0.1
+
+environment:
+  sdk: ^3.9.0-0
+
+hooks:
+  user_defines:
+    hook_user_defines: # package name
+      magic_value: 1000
+
+dependencies:
+  hooks: 1.0.0
+  logging: 1.3.0
+  native_toolchain_c: 0.17.4
+
+dev_dependencies:
+  test: 1.28.0
+
+# PUBSPEC CHECKSUM: qlfuuh
+''';
+
+// An example pubspec.yaml from flutter, not necessary for it to be up to date.
 const kFlutterPubspecYaml = r'''
 name: flutter
 description: A framework for writing Flutter applications
@@ -197,6 +222,7 @@ void main() {
     late Directory flutterSdk;
     late Directory flutterTools;
     late Directory widgetPreviewScaffold;
+    late Directory hookUserDefinesIntegrationTest;
     late _FakePub pub;
     late FakeProcessManager processManager;
     late BufferLogger logger;
@@ -245,6 +271,13 @@ void main() {
       widgetPreviewScaffold.childFile('pubspec.yaml')
         ..createSync(recursive: true)
         ..writeAsStringSync(kWidgetTestPubspecYaml);
+      hookUserDefinesIntegrationTest = flutterSdk
+          .childDirectory('dev')
+          .childDirectory('integration_tests')
+          .childDirectory('hook_user_defines');
+      hookUserDefinesIntegrationTest.childFile('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(kNonWorkspacePubspecYaml);
       Cache.flutterRoot = flutterSdk.absolute.path;
       pub = _FakePub();
       processManager = FakeProcessManager.empty();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ workspace:
   - dev/integration_tests/external_textures
   - dev/integration_tests/flavors
   - dev/integration_tests/flutter_gallery
-  - dev/integration_tests/hook_user_defines
+  # - dev/integration_tests/hook_user_defines  # Intentionally not part of the workspace to test user-defines in its pubspec.
   - dev/integration_tests/ios_add2app_life_cycle/flutterapp
   - dev/integration_tests/ios_app_with_extensions
   - dev/integration_tests/ios_platform_view_tests


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180575.

As per the [readme](https://github.com/flutter/flutter/blob/master/dev/integration_tests/README.md#:~:text=Adding%20code%20to%20this%20directory%20will%20not%20automatically%20cause%20it%20to%20be%20run%20by%20any%20already%20existing%20ci%20tooling.), tests in dev/integration_tests are not automatically run on CI:

> Adding code to this directory will not automatically cause it to be run by any already existing ci tooling.

This PR fixes the problem by running the `hook_user_defines` and `link_hook` integration tests as part of the tools integration test shard.

One of the tests actually broke while it wasn't running on CI. This is fixed by removing it from the workspace to ensure the local user-defines in its pubspec are applied.