### PR TITLE
Bump target Windows version to 10

### DIFF
--- a/engine/src/build/config/win/BUILD.gn
+++ b/engine/src/build/config/win/BUILD.gn
@@ -112,17 +112,8 @@ config("common_linker_setup") {
 # Subsystem --------------------------------------------------------------------
 
 # This is appended to the subsystem to specify a minimum version.
-if (current_cpu == "x64") {
-  # The number after the comma is the minimum required OS version.
-  # 5.02 = Windows Server 2003.
-  subsystem_version_suffix = ",5.02"
-} else if (current_cpu == "arm64") {
-  # Windows ARM64 requires Windows 10.
-  subsystem_version_suffix = ",10.0"
-} else {
-  # 5.01 = Windows XP.
-  subsystem_version_suffix = ",5.01"
-}
+# The number after the comma is the minimum required OS version.
+subsystem_version_suffix = ",10.0"
 
 config("console") {
   ldflags = [ "/SUBSYSTEM:CONSOLE$subsystem_version_suffix" ]

--- a/engine/src/build/config/win/BUILD.gn
+++ b/engine/src/build/config/win/BUILD.gn
@@ -13,7 +13,7 @@ config("sdk") {
     "_ATL_NO_OPENGL",
     "_WINDOWS",
     "CERT_CHAIN_PARA_HAS_EXTRA_FIELDS",
-    "NTDDI_VERSION=0x06030000",
+    "NTDDI_VERSION=0x0A000006",  # NTDDI_WIN10_RS5
     "PSAPI_VERSION=1",
     "WIN32",
     "_SECURE_ATL",
@@ -31,8 +31,8 @@ config("sdk") {
 # targets need to manually override it for their compiles.
 config("winver") {
   defines = [
-    "_WIN32_WINNT=0x0603",
-    "WINVER=0x0603",
+    "_WIN32_WINNT=0x0A00",  # _WIN32_WINNT_WIN10
+    "WINVER=0x0A00",  # _WIN32_WINNT_WIN10
   ]
 }
 


### PR DESCRIPTION
Based on https://docs.flutter.dev/reference/supported-platforms Flutter only supports Windows 10 or above. 

This makes Flutter buildroot configuration match Dart's.