### PR TITLE
fix: missing MSVC 2022

### DIFF
--- a/engine/src/build/vs_toolchain.py
+++ b/engine/src/build/vs_toolchain.py
@@ -169,11 +169,9 @@ def GetVisualStudioVersion():
   supported_versions_str = ', '.join('{} ({})'.format(v,k)
       for k,v in list(MSVS_VERSIONS.items()))
   available_versions = []
-  search_versions = list(supported_versions)
-  for version in supported_versions:
-    # Also look for the numeric version folder (e.g. "18")
-    if version in MSVS_VERSIONS:
-        search_versions.append(MSVS_VERSIONS[version])
+  # Also look for the numeric version folder (e.g. "18")
+  search_versions = list(supported_versions) + list(MSVS_VERSIONS.values())
+
 
   for version in search_versions:
     for path in (

--- a/engine/src/build/vs_toolchain.py
+++ b/engine/src/build/vs_toolchain.py
@@ -172,7 +172,6 @@ def GetVisualStudioVersion():
   # Also look for the numeric version folder (e.g. "18")
   search_versions = list(supported_versions) + list(MSVS_VERSIONS.values())
 
-
   for version in search_versions:
     for path in (
         os.environ.get('vs%s_install' % version),

--- a/engine/src/build/vs_toolchain.py
+++ b/engine/src/build/vs_toolchain.py
@@ -169,9 +169,9 @@ def GetVisualStudioVersion():
   supported_versions_str = ', '.join('{} ({})'.format(v,k)
       for k,v in list(MSVS_VERSIONS.items()))
   available_versions = []
+  search_versions = list(supported_versions)
   for version in supported_versions:
     # Also look for the numeric version folder (e.g. "18")
-    search_versions = [version]
     if version in MSVS_VERSIONS:
         search_versions.append(MSVS_VERSIONS[version])
 


### PR DESCRIPTION
codefu wins the shamecube award for bad python.

Tested on windows 11 enterprise + vc 2022:

```shell
Searching for installed Visual Studio versions: 2019, 2017, 2022, 2026, 16.0, 15.0, 17.0, 18
vs_path = "C:\\Program Files/Microsoft Visual Studio/2022/Community"
sdk_path = "C:\\Program Files (x86)\\Windows Kits\\10"
vs_version = "2022"
wdk_dir = ""
runtime_dirs = "C:\\Windows\\System32;C:\\Windows\\SysWOW64;Arm64Unused"
```

fixes #180660
