### PR TITLE
[A11y ] Add `clearSemantics`in table

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -615,6 +615,13 @@ class RenderTable extends RenderBox {
   final Map<int, SemanticsNode> _cachedRows = <int, SemanticsNode>{};
   final Map<_Index, SemanticsNode> _cachedCells = <_Index, SemanticsNode>{};
 
+  @override
+  void clearSemantics() {
+    super.clearSemantics();
+    _cachedRows.clear();
+    _cachedCells.clear();
+  }
+
   /// Provides custom semantics for tables by generating nodes for rows and maybe cells.
   ///
   /// Table rows are not RenderObjects, so their semantics nodes must be created separately.

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2347,6 +2347,43 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('Semantic nodes do not throw an error after clearSemantics', (
+    WidgetTester tester,
+  ) async {
+    var semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataTable(
+            columns: const <DataColumn>[
+              DataColumn(label: Text('Column 1')),
+              DataColumn(label: Text('Column 2')),
+            ],
+            rows: const <DataRow>[
+              DataRow(
+                cells: <DataCell>[DataCell(Text('Data Cell 1')), DataCell(Text('Data Cell 2'))],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Dispose the semantics to trigger clearSemantics.
+    semantics.dispose();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
+    // Initialize the semantics again.
+    semantics = SemanticsTester(tester);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
+    semantics.dispose();
+  }, semanticsEnabled: false);
+
   // Regression test for https://github.com/flutter/flutter/issues/171264
   testWidgets('DataTable cell has correct semantics rect ', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);


### PR DESCRIPTION
According to comments in `rendering/object.dart`, If new [SemanticsNode]s are instantiated in [assembleSemanticsNode] they must be disposed in [clearSemantics].


fix: https://github.com/flutter/flutter/issues/180666 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
