### PR TITLE
Fix vertical SegmentedButton not filling available width under bounded constraints

### DIFF
--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -998,6 +998,14 @@ class _RenderSegmentedButton<T> extends RenderBox
       maxWidth = math.max(maxWidth, boxWidth);
       child = childAfter(child);
     }
+
+    // When the parent enforces a bounded width, ensure each child
+    // occupies the full available width, preventing segments from
+    // shrinking to their intrinsic content size.
+    if (constraints.hasBoundedWidth) {
+      maxWidth = math.max(maxWidth, constraints.maxWidth);
+    }
+
     return Size(maxWidth, childHeight);
   }
 

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -1001,8 +1001,10 @@ class _RenderSegmentedButton<T> extends RenderBox
 
     var childSize = Size(maxWidth, childHeight);
 
-    // When the parent provides a tight width constraint, use that width for
-    // layout so the visual size and the interactive area match. This preserves
+    // When the parent provides a tight width constraint in the vertical
+    // direction, use that width for layout so the visual size and the
+    // interactive area match. This preserves the intrinsic (shrink-wrap)
+    // sizing behavior when the width is unconstrained.
     if (constraints.hasTightWidth && childSize.width < constraints.maxWidth) {
       childSize = Size(constraints.maxWidth, childSize.height);
     }

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -999,14 +999,15 @@ class _RenderSegmentedButton<T> extends RenderBox
       child = childAfter(child);
     }
 
-    // When the parent enforces a bounded width, ensure each child
-    // occupies the full available width, preventing segments from
-    // shrinking to their intrinsic content size.
-    if (constraints.hasBoundedWidth) {
-      maxWidth = math.max(maxWidth, constraints.maxWidth);
+    var childSize = Size(maxWidth, childHeight);
+
+    // When the parent provides a tight width constraint, use that width for
+    // layout so the visual size and the interactive area match. This preserves
+    if (constraints.hasTightWidth && childSize.width < constraints.maxWidth) {
+      childSize = Size(constraints.maxWidth, childSize.height);
     }
 
-    return Size(maxWidth, childHeight);
+    return childSize;
   }
 
   Size _computeOverallSizeFromChildSize(Size childSize) {

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -1631,12 +1631,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // 1. RenderBox do SegmentedButton
     final RenderBox segmentedBox = tester.renderObject(find.byType(SegmentedButton<String>));
 
     expect(segmentedBox.size.width, screenWidth);
 
-    // 2. RenderBoxes dos segmentos internos
     final Finder segmentMaterials = find.descendant(
       of: find.byType(SegmentedButton<String>),
       matching: find.byType(Material),
@@ -1645,11 +1643,7 @@ void main() {
     for (final Element element in segmentMaterials.evaluate()) {
       final segmentBox = element.renderObject! as RenderBox;
 
-      expect(
-        segmentBox.size.width,
-        screenWidth,
-        reason: 'Cada segmento deve ocupar a largura total do container pai',
-      );
+      expect(segmentBox.size.width, screenWidth);
     }
   });
 }

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -1604,25 +1604,12 @@ void main() {
               width: double.infinity,
               child: SegmentedButton<String>(
                 direction: Axis.vertical,
-                showSelectedIcon: false,
-                style: SegmentedButton.styleFrom(
-                  fixedSize: const Size(double.infinity, 300),
-                  minimumSize: const Size(double.infinity, 500),
-                  maximumSize: Size.infinite,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(5),
-                    side: const BorderSide(),
-                  ),
-                ),
                 segments: const [
                   ButtonSegment(value: 'All', label: Text('All')),
                   ButtonSegment(value: 'Top free', label: Text('Top free')),
                   ButtonSegment(value: 'Top paid', label: Text('Top paid')),
                 ],
                 selected: const {'All'},
-                onSelectionChanged: (newSelection) {
-                  // dummy test; nothing needed
-                },
               ),
             ),
           ),

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -1592,7 +1592,7 @@ void main() {
     tester.view
       ..physicalSize = const Size(800, 1200)
       ..devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.reset);
 
     const double screenWidth = 800;
 

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -1587,6 +1587,71 @@ void main() {
     );
     expect(tester.getSize(find.byType(SegmentedButton<String>)), Size.zero);
   });
+
+  testWidgets('SegmentedButton should expand to fill the full width', (WidgetTester tester) async {
+    tester.view
+      ..physicalSize = const Size(800, 1200)
+      ..devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    const double screenWidth = 800;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<String>(
+                direction: Axis.vertical,
+                showSelectedIcon: false,
+                style: SegmentedButton.styleFrom(
+                  fixedSize: const Size(double.infinity, 300),
+                  minimumSize: const Size(double.infinity, 500),
+                  maximumSize: Size.infinite,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5),
+                    side: const BorderSide(),
+                  ),
+                ),
+                segments: const [
+                  ButtonSegment(value: 'All', label: Text('All')),
+                  ButtonSegment(value: 'Top free', label: Text('Top free')),
+                  ButtonSegment(value: 'Top paid', label: Text('Top paid')),
+                ],
+                selected: const {'All'},
+                onSelectionChanged: (newSelection) {
+                  // dummy test; nothing needed
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 1. RenderBox do SegmentedButton
+    final RenderBox segmentedBox = tester.renderObject(find.byType(SegmentedButton<String>));
+
+    expect(segmentedBox.size.width, screenWidth);
+
+    // 2. RenderBoxes dos segmentos internos
+    final Finder segmentMaterials = find.descendant(
+      of: find.byType(SegmentedButton<String>),
+      matching: find.byType(Material),
+    );
+
+    for (final Element element in segmentMaterials.evaluate()) {
+      final segmentBox = element.renderObject! as RenderBox;
+
+      expect(
+        segmentBox.size.width,
+        screenWidth,
+        reason: 'Cada segmento deve ocupar a largura total do container pai',
+      );
+    }
+  });
 }
 
 Set<WidgetState> enabled = const <WidgetState>{};


### PR DESCRIPTION
Fixes an issue where vertical segments used intrinsic width instead of expanding to fill the parent's bounded width, resulting in narrow tap targets.

Fixes [#178901](https://github.com/flutter/flutter/issues/178901)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
