### PR TITLE
Make sure that a FocusScope doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1081,6 +1081,24 @@ void main() {
         expect(keyEventHandled, isTrue);
       },
     );
+
+    testWidgets('FocusScope does not crash at zero area', (WidgetTester tester) async {
+      tester.view.physicalSize = Size.zero;
+      final focusScopeNode = FocusScopeNode();
+      addTearDown(tester.view.reset);
+      addTearDown(focusScopeNode.dispose);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: FocusScope(node: focusScopeNode, child: const Text('X')),
+          ),
+        ),
+      );
+      expect(tester.getSize(find.byType(FocusScope)), Size.zero);
+      focusScopeNode.requestFocus();
+      await tester.pump();
+    });
   });
 
   group('Focus', () {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the FocusScope widget.