### PR TITLE
Fix/widget inspector overlapping nav bar

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -27,7 +27,6 @@ import 'dart:ui'
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/material.dart';
 import 'package:meta/meta_meta.dart';
 
 import 'basic.dart';
@@ -38,6 +37,7 @@ import 'gesture_detector.dart';
 import 'icon_data.dart';
 import 'service_extensions.dart';
 import 'view.dart';
+import 'safe_area.dart';
 
 /// Signature for the builder callback used by
 /// [WidgetInspector.exitWidgetSelectionButtonBuilder].

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -37,7 +37,7 @@ import 'gesture_detector.dart';
 import 'icon_data.dart';
 import 'service_extensions.dart';
 import 'view.dart';
-import 'safe_area.dart';
+import 'media_query.dart';
 
 /// Signature for the builder callback used by
 /// [WidgetInspector.exitWidgetSelectionButtonBuilder].
@@ -3070,7 +3070,10 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
     // Be careful changing this build method. The _InspectorOverlayLayer
     // assumes the root RenderObject for the WidgetInspector will be
     // a RenderStack containing a _RenderInspectorOverlay as a child.
-    return SafeArea(
+    return Padding(
+      padding: EdgeInsetsGeometry.only(
+        bottom: MediaQuery.of(context).viewPadding.bottom,
+      ),
       child: Stack(
         children: <Widget>[
           GestureDetector(
@@ -3100,7 +3103,6 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
     );
   }
 }
-
 /// Enables the Flutter DevTools Widget Inspector for a [Widget] subtree.
 ///
 /// The widget inspector is enabled by default, so this widget is only useful if


### PR DESCRIPTION
This PR fixes an issue where the Widget Inspector overlay could overlap with the system bottom navigation bar (or gesture area), making inspector controls partially inaccessible.

The issue occurred because the inspector layout did not account for the bottom safe area and navigation bar height when positioning overlays and controls. This change updates the layout logic to respect the bottom inset, ensuring the Widget Inspector UI is fully visible and usable across devices with navigation bars or gesture navigation enabled.

Before this change, inspector UI elements could be obscured by the navigation bar. After this change, the inspector properly avoids the bottom system UI and no longer overlaps.

Fixes #XXXXX

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), where applicable.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


before
<img width="1080" height="2400" alt="Screenshot_1767941274" src="https://github.com/user-attachments/assets/ec36730b-96f2-47d8-80f4-39d6cdb9acaf" />

after
<img width="1080" height="2400" alt="Screenshot_1767945239" src="https://github.com/user-attachments/assets/5a057c49-ce68-4d52-841a-6b992b1e6fe7" />
