### PR TITLE
fix: widget inspector nav bar overlap

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3064,7 +3064,7 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
     // a RenderStack containing a _RenderInspectorOverlay as a child.
     return Padding(
       padding: EdgeInsetsGeometry.only(
-        bottom: MediaQuery.of(context).viewPadding.bottom,
+        bottom: MediaQuery.viewPaddingOf(context).bottom,
       ),
       child: Stack(
         children: <Widget>[

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -37,6 +37,7 @@ import 'gesture_detector.dart';
 import 'icon_data.dart';
 import 'service_extensions.dart';
 import 'view.dart';
+import 'media_query.dart';
 
 /// Signature for the builder callback used by
 /// [WidgetInspector.exitWidgetSelectionButtonBuilder].
@@ -3061,29 +3062,36 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
     // Be careful changing this build method. The _InspectorOverlayLayer
     // assumes the root RenderObject for the WidgetInspector will be
     // a RenderStack containing a _RenderInspectorOverlay as a child.
-    return Stack(
-      children: <Widget>[
-        GestureDetector(
-          onTap: _handleTap,
-          onPanDown: _handlePanDown,
-          onPanEnd: _handlePanEnd,
-          onPanUpdate: _handlePanUpdate,
-          behavior: HitTestBehavior.opaque,
-          excludeFromSemantics: true,
-          child: IgnorePointer(
-            ignoring: _isSelectModeWithSelectionOnTapEnabled,
-            key: _ignorePointerKey,
-            child: widget.child,
+    return Padding(
+      padding: EdgeInsetsGeometry.only(
+        bottom: MediaQuery.of(context).viewPadding.bottom,
+      ),
+      child: Stack(
+        children: <Widget>[
+          GestureDetector(
+            onTap: _handleTap,
+            onPanDown: _handlePanDown,
+            onPanEnd: _handlePanEnd,
+            onPanUpdate: _handlePanUpdate,
+            behavior: HitTestBehavior.opaque,
+            excludeFromSemantics: true,
+            child: IgnorePointer(
+              ignoring: _isSelectModeWithSelectionOnTapEnabled,
+              key: _ignorePointerKey,
+              child: widget.child,
+            ),
           ),
-        ),
-        Positioned.fill(child: _InspectorOverlay(selection: selection)),
-        if (isSelectMode && widget.exitWidgetSelectionButtonBuilder != null)
-          _WidgetInspectorButtonGroup(
-            tapBehaviorButtonBuilder: widget.tapBehaviorButtonBuilder,
-            exitWidgetSelectionButtonBuilder: widget.exitWidgetSelectionButtonBuilder!,
-            moveExitWidgetSelectionButtonBuilder: widget.moveExitWidgetSelectionButtonBuilder,
-          ),
-      ],
+          Positioned.fill(child: _InspectorOverlay(selection: selection)),
+          if (isSelectMode && widget.exitWidgetSelectionButtonBuilder != null)
+            _WidgetInspectorButtonGroup(
+              tapBehaviorButtonBuilder: widget.tapBehaviorButtonBuilder,
+              exitWidgetSelectionButtonBuilder:
+                  widget.exitWidgetSelectionButtonBuilder!,
+              moveExitWidgetSelectionButtonBuilder:
+                  widget.moveExitWidgetSelectionButtonBuilder,
+            ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR fixes an issue where the Widget Inspector overlay could overlap with the system bottom navigation bar (or gesture area), making inspector controls partially inaccessible.

The issue occurred because the inspector layout did not account for the bottom safe area and navigation bar height when positioning overlays and controls. This change updates the layout logic to respect the bottom inset, ensuring the Widget Inspector UI is fully visible and usable across devices with navigation bars or gesture navigation enabled.

Before this change, inspector UI elements could be obscured by the navigation bar. After this change, the inspector properly avoids the bottom system UI and no longer overlaps.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), where applicable.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
