### PR TITLE
widget_inspector: respect SafeArea insets for overlay buttons

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -26,6 +26,7 @@ import 'dart:ui'
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:meta/meta_meta.dart';
 
@@ -3061,29 +3062,33 @@ class _WidgetInspectorState extends State<WidgetInspector> with WidgetsBindingOb
     // Be careful changing this build method. The _InspectorOverlayLayer
     // assumes the root RenderObject for the WidgetInspector will be
     // a RenderStack containing a _RenderInspectorOverlay as a child.
-    return Stack(
-      children: <Widget>[
-        GestureDetector(
-          onTap: _handleTap,
-          onPanDown: _handlePanDown,
-          onPanEnd: _handlePanEnd,
-          onPanUpdate: _handlePanUpdate,
-          behavior: HitTestBehavior.opaque,
-          excludeFromSemantics: true,
-          child: IgnorePointer(
-            ignoring: _isSelectModeWithSelectionOnTapEnabled,
-            key: _ignorePointerKey,
-            child: widget.child,
+    return SafeArea(
+      child: Stack(
+        children: <Widget>[
+          GestureDetector(
+            onTap: _handleTap,
+            onPanDown: _handlePanDown,
+            onPanEnd: _handlePanEnd,
+            onPanUpdate: _handlePanUpdate,
+            behavior: HitTestBehavior.opaque,
+            excludeFromSemantics: true,
+            child: IgnorePointer(
+              ignoring: _isSelectModeWithSelectionOnTapEnabled,
+              key: _ignorePointerKey,
+              child: widget.child,
+            ),
           ),
-        ),
-        Positioned.fill(child: _InspectorOverlay(selection: selection)),
-        if (isSelectMode && widget.exitWidgetSelectionButtonBuilder != null)
-          _WidgetInspectorButtonGroup(
-            tapBehaviorButtonBuilder: widget.tapBehaviorButtonBuilder,
-            exitWidgetSelectionButtonBuilder: widget.exitWidgetSelectionButtonBuilder!,
-            moveExitWidgetSelectionButtonBuilder: widget.moveExitWidgetSelectionButtonBuilder,
-          ),
-      ],
+          Positioned.fill(child: _InspectorOverlay(selection: selection)),
+          if (isSelectMode && widget.exitWidgetSelectionButtonBuilder != null)
+            _WidgetInspectorButtonGroup(
+              tapBehaviorButtonBuilder: widget.tapBehaviorButtonBuilder,
+              exitWidgetSelectionButtonBuilder:
+                  widget.exitWidgetSelectionButtonBuilder!,
+              moveExitWidgetSelectionButtonBuilder:
+                  widget.moveExitWidgetSelectionButtonBuilder,
+            ),
+        ],
+      ),
     );
   }
 }

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -3422,6 +3422,53 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       }
     });
 
+    testWidgets('WidgetInspector buttons respect SafeArea insets', (WidgetTester tester) async {
+  const double bottomInset = 48.0;
+  const double leftInset = 24.0;
+
+  const Key exitKey = ValueKey('exit-select-mode');
+
+  await tester.pumpWidget(
+    MediaQuery(
+      data: const MediaQueryData(
+        padding: EdgeInsets.only(bottom: bottomInset, left: leftInset),
+      ),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: WidgetInspector(
+          // Put any child; size matters so use SizedBox.expand.
+          child: const SizedBox.expand(),
+
+          // This makes the button findable.
+          exitWidgetSelectionButtonBuilder: (BuildContext context, VoidCallback onPressed) {
+            return SizedBox(
+              key: exitKey,
+              width: 40,
+              height: 40,
+              child: GestureDetector(onTap: onPressed),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+
+  await tester.pump();
+
+  final Finder exitFinder = find.byKey(exitKey);
+  expect(exitFinder, findsOneWidget);
+
+  final Rect rect = tester.getRect(exitFinder);
+  final Size logicalSize = tester.view.physicalSize / tester.view.devicePixelRatio;
+
+  // Not behind the bottom system UI.
+  expect(rect.bottom, lessThanOrEqualTo(logicalSize.height - bottomInset));
+
+  // Not behind left system UI (gesture/3-button area).
+  expect(rect.left, greaterThanOrEqualTo(leftInset));
+});
+
+
     testWidgets('cyclic diagnostics regression test', (WidgetTester tester) async {
       const group = 'test-group';
       final a = CyclicDiagnostic('a');


### PR DESCRIPTION
Fixes WidgetInspector overlay controls being positioned behind system UI when MediaQuery padding includes bottom/left insets.

Adds a regression test that enables select mode and asserts the exit selection button stays within the visible safe area (bottom/left).

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Summary

WidgetInspector’s select-mode overlay controls (e.g. the “exit select mode” button) could be positioned without fully respecting `MediaQuery.padding`, causing them to appear behind system UI areas (gesture/navigation insets) when bottom/left insets are present.

This PR updates the overlay button positioning to respect SafeArea insets and keeps the controls visible and tappable.

## Testing

- Added a widget test that:
  - wraps `WidgetInspector` in a `MediaQuery` with bottom + left padding,
  - enables select mode so the overlay button group is shown,
  - asserts the exit button is not laid out behind the bottom inset and not behind the left inset.

## Screenshots

**After (fixed)**  

<img width="1080" height="2400" alt="Screenshot_1767942803" src="https://github.com/user-attachments/assets/195194fd-4462-44a0-9f5f-e06b755bfcfe" />
<img width="451" height="1002" alt="fix " src="https://github.com/user-attachments/assets/aa1d5b35-7914-42a0-8273-6f45d0298d9b" />


**Before (broken)**  
<img width="1080" height="2400" alt="Screenshot_1767941318" src="https://github.com/user-attachments/assets/5bfa1c9d-f549-4ef9-8ead-16d155e47681" />
<img width="1080" height="2400" alt="Screenshot_1767941274" src="https://github.com/user-attachments/assets/1545361c-26d3-4da9-b325-6ea38c0aff21" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
