### PR TITLE
fix: there are no riscv fuchsia artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -683,7 +683,6 @@ class FlutterRunnerDebugSymbols extends CachedArtifact {
     }
     await _downloadDebugSymbols('x64', artifactUpdater);
     await _downloadDebugSymbols('arm64', artifactUpdater);
-    await _downloadDebugSymbols('riscv64', artifactUpdater);
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -574,7 +574,6 @@ void main() {
     expect(packageResolver.resolved, <List<String>>[
       <String>['fuchsia-debug-symbols-x64', '123456'],
       <String>['fuchsia-debug-symbols-arm64', '123456'],
-      <String>['fuchsia-debug-symbols-riscv64', '123456'],
     ]);
   });
 


### PR DESCRIPTION
In #178711, `packages/flutter_tools/lib/src/flutter_cache.dart` was updated to add 'riscv' downloading in the `FlutterRunnerDebugSymbols`.  This class is not well named and is responsible for downloading "the debug symbols for flutter runner for Fuchsia development."

We do not produce fuchsia riscv.

Fixes #180775