### PR TITLE
[web] Pass form validation errors to screen readers via aria-description

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -342,7 +342,22 @@ class SemanticTextField extends SemanticRole {
     } else {
       editableElement.removeAttribute('aria-required');
     }
+
+    // Apply hint as aria-description on the editable element so screen readers
+    // announce it along with the input field. This enables form validation
+    // errors to be announced when the error text is passed via the hint property.
+    _updateHintDescription();
+
     _updateInputType();
+  }
+
+  void _updateHintDescription() {
+    final String? hint = semanticsObject.hint;
+    if (hint != null && hint.trim().isNotEmpty) {
+      editableElement.setAttribute('aria-description', hint);
+    } else {
+      editableElement.removeAttribute('aria-description');
+    }
   }
 
   void _updateEnabledState() {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1792,10 +1792,19 @@ class _TextFieldState extends State<TextField>
           child: AnimatedBuilder(
             animation: controller, // changes the _currentLength
             builder: (BuildContext context, Widget? child) {
+              // Pass error or hint text to semantics so screen readers announce it
+              // along with the input field (via aria-description on web).
+              // Error takes priority over hint since it requires user action.
+              // Note: The visual hintText is already shown as placeholder, so we
+              // only need to expose it via semantics when there's no error.
+              final String? errorText =
+                  widget.decoration?.errorText ?? widget.decoration?.error?.toString();
+              final String? semanticsHint = errorText ?? widget.decoration?.hintText;
               return Semantics(
                 enabled: _isEnabled,
                 maxValueLength: semanticsMaxValueLength,
                 currentValueLength: _currentLength,
+                hint: semanticsHint,
                 onTap: widget.readOnly
                     ? null
                     : () {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9357,6 +9357,7 @@ void main() {
               children: <TestSemantics>[
                 TestSemantics(
                   label: 'label',
+                  hint: 'hint',
                   textDirection: TextDirection.ltr,
                   inputType: ui.SemanticsInputType.text,
                   maxValueLength: 10,
@@ -9398,6 +9399,7 @@ void main() {
               children: <TestSemantics>[
                 TestSemantics.rootChild(
                   label: 'label',
+                  hint: 'hint', // hintText is now passed to semantics hint
                   textDirection: TextDirection.ltr,
                   textSelection: const TextSelection(baseOffset: 0, extentOffset: 0),
                   inputType: ui.SemanticsInputType.text,
@@ -9473,6 +9475,7 @@ void main() {
               children: <TestSemantics>[
                 TestSemantics(
                   label: 'label',
+                  hint: 'hint',
                   textDirection: TextDirection.ltr,
                   inputType: ui.SemanticsInputType.text,
                   currentValueLength: 0,
@@ -9535,6 +9538,7 @@ void main() {
                 children: <TestSemantics>[
                   TestSemantics.rootChild(
                     label: 'label',
+                    hint: 'oh no!',
                     textDirection: TextDirection.ltr,
                     actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                     flags: <SemanticsFlag>[
@@ -9567,6 +9571,87 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     });
   }
+
+  testWidgets('TextField passes errorText to semantics hint', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+    final TextEditingController controller = _textEditingController();
+    final Key key = UniqueKey();
+
+    await tester.pumpWidget(
+      overlay(
+        child: TextField(
+          key: key,
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: 'Email',
+            hintText: 'Enter your email',
+            errorText: 'Email is required',
+          ),
+        ),
+      ),
+    );
+
+    final SemanticsNode node = tester.getSemantics(find.byKey(key));
+
+    // The semantics hint should be the error text (error takes priority over hintText)
+    expect(node.hint, 'Email is required');
+
+    semantics.dispose();
+  });
+
+  testWidgets('TextField passes hintText to semantics hint when no error', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final TextEditingController controller = _textEditingController();
+    final Key key = UniqueKey();
+
+    await tester.pumpWidget(
+      overlay(
+        child: TextField(
+          key: key,
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Email', hintText: 'Enter your email'),
+        ),
+      ),
+    );
+
+    final SemanticsNode node = tester.getSemantics(find.byKey(key));
+
+    // The semantics hint should be the hintText when no error
+    expect(node.hint, 'Enter your email');
+
+    semantics.dispose();
+  });
+
+  testWidgets('TextField errorText takes priority over hintText for semantics hint', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    final TextEditingController controller = _textEditingController();
+    final Key key = UniqueKey();
+
+    // When both hintText and errorText are present, errorText should be used
+    // for the semantics hint since errors require immediate user action
+    await tester.pumpWidget(
+      overlay(
+        child: TextField(
+          key: key,
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: 'Email',
+            hintText: 'Enter your email',
+            errorText: 'Email is required',
+          ),
+        ),
+      ),
+    );
+
+    final SemanticsNode node = tester.getSemantics(find.byKey(key));
+    expect(node.hint, 'Email is required'); // Error takes priority over hint
+
+    semantics.dispose();
+  });
 
   testWidgets('floating label does not overlap with value at large textScaleFactors', (
     WidgetTester tester,


### PR DESCRIPTION
Fixes part of #180496

## Summary
Pass form validation errors to screen readers via `aria-description` on text fields.

**Before:** 
https://flutter-demo-04-before.web.app/

**After:** 
https://flutter-demo-04-after.web.app/

## Limitations & Future Work

This handles **string-based errors** (`errorText`). For more complex cases(brought in https://github.com/flutter/flutter/issues/180496#issuecomment-3713178684), a follow-up implementation using `aria-describedby` with element IDs is tracked in #180496:

- Custom error widgets (`InputDecoration.error`)
- Errors outside `InputDecoration`
- Custom announcement ordering

The `aria-description` approach (current) and `aria-describedby` approach (future) can coexist per ARIA specifications.

## Related
- Related discussion: #169157 comments