### PR TITLE
[web] Use defensive null check in text editing placeElement

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1176,6 +1176,10 @@ class GloballyPositionedTextEditingStrategy extends DefaultTextEditingStrategy {
       // only after placing it to the correct position. Hence autofill menu
       // does not appear on top-left of the page.
       // Refocus on the elements after applying the geometry.
+      // placeForm() involves DOM manipulation which can trigger synchronous
+      // events (like blur). These events might invalidate the current
+      // inputConfiguration or disable the strategy before placeForm() returns.
+      // Therefore, we must defensively check if the element is still valid/present.
       focusedFormElement?.focusWithoutScroll();
       moveFocusToActiveDomElement();
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1176,7 +1176,7 @@ class GloballyPositionedTextEditingStrategy extends DefaultTextEditingStrategy {
       // only after placing it to the correct position. Hence autofill menu
       // does not appear on top-left of the page.
       // Refocus on the elements after applying the geometry.
-      focusedFormElement!.focusWithoutScroll();
+      focusedFormElement?.focusWithoutScroll();
       moveFocusToActiveDomElement();
     }
   }


### PR DESCRIPTION
Fixes #178619

Uses defensive null check (?.) instead of null assertion (!) when calling focusWithoutScroll() on focusedFormElement in GloballyPositionedTextEditingStrategy.placeElement().

This prevents a crash that can occur due to a race condition where hasAutofillGroup returns true but focusedFormElement is null by the time it's accessed.