### PR TITLE
Filter error messages from `emulator -list-avds` output

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -71,13 +71,18 @@ class AndroidEmulators extends EmulatorDiscovery {
   /// Parse the given `emulator -list-avds` output in [text], and fill out the given list
   /// of emulators by reading information from the relevant ini files.
   void _extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
-    for (final String id in text.trim().split('\n').where((String l) => l != '')) {
+    final Iterable<String> ids = text
+        .split('\n')
+        .map((String l) => l.trim())
+        // Emulator IDs cannot contain spaces,
+        // strip blank lines and error messages that can appear in the output.
+        .where((String l) => l.isNotEmpty && !l.contains(' '));
+    for (final id in ids) {
       emulators.add(_loadEmulatorInfo(id));
     }
   }
 
   AndroidEmulator _loadEmulatorInfo(String id) {
-    id = id.trim();
     final String? avdPath = _androidSdk?.getAvdPath();
     final androidEmulatorWithoutProperties = AndroidEmulator(
       id,

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -76,8 +76,7 @@ class AndroidEmulators extends EmulatorDiscovery {
     final Iterable<String> ids = text
         .split('\n')
         .map((String l) => l.trim())
-        // Emulator IDs cannot contain spaces,
-        // strip blank lines and error messages that can appear in the output.
+        // Strip blank lines and error messages that can appear in the output.
         .where((String l) => l.isNotEmpty && _emulatorIdRegex.hasMatch(l));
     for (final id in ids) {
       emulators.add(_loadEmulatorInfo(id));

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -68,7 +68,7 @@ class AndroidEmulators extends EmulatorDiscovery {
     return emulators;
   }
 
-  static final RegExp _emulatorIdRegex = RegExp(r'^[A-Za-z0-9_]+$');
+  static final RegExp _emulatorIdRegex = RegExp(r'^[A-Za-z0-9_.-]+$');
 
   /// Parse the given `emulator -list-avds` output in [text], and fill out the given list
   /// of emulators by reading information from the relevant ini files.

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -68,6 +68,8 @@ class AndroidEmulators extends EmulatorDiscovery {
     return emulators;
   }
 
+  static final RegExp _emulatorIdRegex = RegExp(r'^[A-Za-z0-9_]+$');
+
   /// Parse the given `emulator -list-avds` output in [text], and fill out the given list
   /// of emulators by reading information from the relevant ini files.
   void _extractEmulatorAvdInfo(String text, List<AndroidEmulator> emulators) {
@@ -76,7 +78,7 @@ class AndroidEmulators extends EmulatorDiscovery {
         .map((String l) => l.trim())
         // Emulator IDs cannot contain spaces,
         // strip blank lines and error messages that can appear in the output.
-        .where((String l) => l.isNotEmpty && !l.contains(' '));
+        .where((String l) => l.isNotEmpty && _emulatorIdRegex.hasMatch(l));
     for (final id in ids) {
       emulators.add(_loadEmulatorInfo(id));
     }

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -88,7 +88,8 @@ void main() {
               stdout:
                   'INFO    | Storing crashdata in: /tmp/some.db, detection is enabled for process: 95538\n'
                   'WARNING | Crash annotation is very large (16415), only 16384 bytes will be recorded, 31 bytes are lost.\n'
-                  'Emulator_API_33',
+                  'Emulator_API_33\n'
+                  'pixel-4.api-30',
             ),
           ]),
           androidSdk: sdk,
@@ -96,8 +97,9 @@ void main() {
         );
 
         final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators();
-        expect(emulators, hasLength(1));
+        expect(emulators, hasLength(2));
         expect(emulators.first.id, 'Emulator_API_33');
+        expect(emulators.last.id, 'pixel-4.api-30');
       },
       // Exclude the iOS emulator discovery.
       overrides: <Type, Generator>{Platform: () => FakePlatform()},

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -7,6 +7,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
@@ -73,6 +74,34 @@ void main() {
 
       await expectLater(() async => emulatorManager.getAllAvailableEmulators(), returnsNormally);
     });
+
+    testUsingContext(
+      'getEmulators ignores info and warning messages in android emulator output',
+      () async {
+        final emulatorManager = EmulatorManager(
+          java: FakeJava(),
+          fileSystem: MemoryFileSystem.test(),
+          logger: BufferLogger.test(),
+          processManager: FakeProcessManager.list(<FakeCommand>[
+            const FakeCommand(
+              command: <String>['emulator', '-list-avds'],
+              stdout:
+                  'INFO    | Storing crashdata in: /tmp/some.db, detection is enabled for process: 95538\n'
+                  'WARNING | Crash annotation is very large (16415), only 16384 bytes will be recorded, 31 bytes are lost.\n'
+                  'Emulator_API_33',
+            ),
+          ]),
+          androidSdk: sdk,
+          androidWorkflow: AndroidWorkflow(androidSdk: sdk, featureFlags: TestFeatureFlags()),
+        );
+
+        final List<Emulator> emulators = await emulatorManager.getAllAvailableEmulators();
+        expect(emulators, hasLength(1));
+        expect(emulators.first.id, 'Emulator_API_33');
+      },
+      // Exclude the iOS emulator discovery.
+      overrides: <Type, Generator>{Platform: () => FakePlatform()},
+    );
 
     testUsingContext('printEmulators prints the emulators information with header', () {
       Emulator.printEmulators(emulators, testLogger);


### PR DESCRIPTION
Adds a simple heuristic to filter out the info and error messages that `emulator -list-avds` can output sometimes. The heuristic assumes that emulator names can only contain `a-z0-9_.-` in their names.

Fixes https://github.com/flutter/flutter/issues/146125

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
