### PR TITLE
Make sure that a FormField doesn't crash at 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -1816,6 +1816,20 @@ void main() {
       ),
     );
   });
+
+  testWidgets('FormField does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(
+            child: FormField<String>(builder: (FormFieldState<String> field) => const Text('X')),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(FormField<String>)), Size.zero);
+  });
 }
 
 class _PlatformAnnounceScenario {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the FormField widget.