### PR TITLE
Fix RawAutocomplete unmounted crash during async optionsBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -475,6 +475,10 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     final int callId = _onChangedCallId;
     final Iterable<T> options = await widget.optionsBuilder(value);
 
+    if (!mounted) {
+      return;
+    }
+
     // Makes sure that previous call results do not replace new ones.
     if (callId != _onChangedCallId || !shouldUpdateOptions) {
       return;

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -3535,4 +3537,68 @@ void main() {
       expect(find.byKey(optionsKey), findsOne);
     },
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/170403.
+  testWidgets('does not crash when disposed during async optionsBuilder', (
+    WidgetTester tester,
+  ) async {
+    final optionsCompleter = Completer<List<String>>();
+    late StateSetter setState;
+    var showAutocomplete = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter innerSetState) {
+              setState = innerSetState;
+              if (!showAutocomplete) {
+                return const SizedBox.shrink();
+              }
+              return RawAutocomplete<String>(
+                optionsBuilder: (TextEditingValue textEditingValue) async {
+                  return optionsCompleter.future;
+                },
+                fieldViewBuilder:
+                    (
+                      BuildContext context,
+                      TextEditingController fieldTextEditingController,
+                      FocusNode fieldFocusNode,
+                      VoidCallback onFieldSubmitted,
+                    ) {
+                      return TextField(
+                        focusNode: fieldFocusNode,
+                        controller: fieldTextEditingController,
+                      );
+                    },
+                optionsViewBuilder:
+                    (
+                      BuildContext context,
+                      AutocompleteOnSelected<String> onSelected,
+                      Iterable<String> options,
+                    ) {
+                      return Container();
+                    },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Focus the field to trigger optionsBuilder.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    // Dispose the widget while optionsBuilder is still pending.
+    setState(() {
+      showAutocomplete = false;
+    });
+    await tester.pump();
+
+    optionsCompleter.complete(<String>['option1', 'option2']);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
 }


### PR DESCRIPTION
Adds a mounted check after the async optionsBuilder call to prevent accessing state on an unmounted widget.

Fixes #170403

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
