### PR TITLE
Make sure that an ErrorWidget doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/error_widget_test.dart
+++ b/packages/flutter/test/widgets/error_widget_test.dart
@@ -81,6 +81,16 @@ void main() {
       expect(find.byKey(container), findsOneWidget);
     },
   );
+
+  testWidgets('ErrorWidget does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: SizedBox.shrink(child: ErrorWidget('Exception'))),
+      ),
+    );
+    expect(tester.getSize(find.byType(ErrorWidget)), Size.zero);
+  });
 }
 
 // This widget throws during its regular build and then again when the


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the ErrorWidget widget.