### PR TITLE
clean up usages of resetXyz for TestFlutterView

### DIFF
--- a/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
@@ -105,7 +105,7 @@ void main() {
     // Resize the screen to small screen and make sure no overflowed error appears.
     tester.view.physicalSize = const Size(200, 160);
     tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.reset);
     await tester.pump();
 
     expect(tester.takeException(), isNull);

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -3236,6 +3236,8 @@ void main() {
 
       tester.view.devicePixelRatio = 1;
       tester.binding.platformDispatcher.textScaleFactorTestValue = 1;
+      addTearDown(tester.view.reset);
+      addTearDown(tester.binding.platformDispatcher.clearTextScaleFactorTestValue);
       setWindowToPortrait(tester, size: const Size(402, 874));
 
       var count = 0;

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -3004,9 +3004,10 @@ void main() {
   testWidgets('BottomNavigationBar linear landscape layout label RenderFlex overflow', (
     WidgetTester tester,
   ) async {
-    //Regression test for https://github.com/flutter/flutter/issues/112163
+    // Regression test for https://github.com/flutter/flutter/issues/112163
 
     tester.view.physicalSize = const Size(540, 340);
+    addTearDown(tester.view.resetPhysicalSize);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -3053,8 +3054,6 @@ void main() {
       find.byType(MaterialApp),
       matchesGoldenFile('bottom_navigation_bar.label_overflow.png'),
     );
-
-    addTearDown(tester.view.resetPhysicalSize);
   });
 
   testWidgets('BottomNavigationBar keys passed through', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -592,4 +592,5 @@ void widgetSetup(WidgetTester tester, double viewWidth, {double viewHeight = 100
   tester.view.devicePixelRatio = 2;
   final double dpi = tester.view.devicePixelRatio;
   tester.view.physicalSize = Size(viewWidth * dpi, viewHeight * dpi);
+  addTearDown(tester.view.reset);
 }

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -4037,6 +4037,7 @@ void main() {
       const trailingKey = Key('trailing');
       tester.view.physicalSize = const Size(800, 600);
       tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(
@@ -4091,6 +4092,7 @@ void main() {
     const trailingKey = Key('trailing');
     tester.view.physicalSize = const Size(800, 600);
     tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -3987,8 +3987,7 @@ void main() {
   testWidgets('Tap on button behind snack bar defined by width', (WidgetTester tester) async {
     tester.view.physicalSize = const Size.square(200);
     tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.reset);
 
     const buttonText = 'Show snackbar';
     const snackbarContent = 'Snackbar';
@@ -4045,8 +4044,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/78537.
     tester.view.physicalSize = const Size.square(200);
     tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.reset);
 
     const buttonText = 'Show snackbar';
     const snackbarContent = 'Snackbar';
@@ -4105,8 +4103,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/78537.
     tester.view.physicalSize = const Size.square(200);
     tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.reset);
 
     const buttonText = 'Show snackbar';
     const snackbarContent = 'Snackbar';
@@ -4203,8 +4200,7 @@ void main() {
       // Regression test for https://github.com/flutter/flutter/issues/148566.
       tester.view.physicalSize = const Size.square(200);
       tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.reset);
 
       const buttonText = 'Show snackbar';
       const snackbarContent = 'Snackbar';

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -1559,7 +1559,7 @@ void main() {
       physicalDoubleTapSlop: 100,
       physicalTouchSlop: 100,
     );
-    addTearDown(() => tester.view.resetGestureSettings());
+    addTearDown(tester.view.resetGestureSettings);
 
     expect(
       MediaQueryData.fromView(tester.view).gestureSettings.touchSlop,

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2114,8 +2114,7 @@ void main() {
       await tester.pumpAndSettle();
       viewport = getViewport(tester, childKey);
       expect(viewport.viewportDimension, const Size(300.0, 300.0));
-      tester.view.resetPhysicalSize();
-      tester.view.resetDevicePixelRatio();
+      tester.view.reset();
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Rebuilds when delegate changes', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2110,11 +2110,11 @@ void main() {
       expect(viewport.viewportDimension, const Size(800.0, 600.0));
       tester.view.physicalSize = const Size(300.0, 300.0);
       tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
       await tester.pumpAndSettle();
       viewport = getViewport(tester, childKey);
       expect(viewport.viewportDimension, const Size(300.0, 300.0));
-      tester.view.reset();
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Rebuilds when delegate changes', (WidgetTester tester) async {


### PR DESCRIPTION
While reviewing https://github.com/flutter/flutter/pull/180728 we noticed that usage of `TestFlutterView.resetXyz()` was quite liberal and some places benefit from using `TestFlutterView.reset()`, to avoid repetition.

This PR cleans that up.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
