### PR TITLE
[ Tool ] Ensure `flutter.version.json` is regenerated on upgrade

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -240,8 +240,8 @@ class UpgradeCommandRunner {
     );
     await attemptReset(upstreamVersion.frameworkRevision);
 
-    // Regenerate the version file based on the latest branch state.
-    upstreamVersion.updateVersionFile();
+    // Regenerate the version file based on the latest branch state during the second half.
+    flutterVersion.deleteVersionFile();
 
     if (!testFlow) {
       await flutterUpgradeContinue(startedAt: startedAt);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -239,6 +239,10 @@ class UpgradeCommandRunner {
       'Upgrading Flutter to ${upstreamVersion.frameworkVersion} from ${flutterVersion.frameworkVersion} in $workingDirectory...',
     );
     await attemptReset(upstreamVersion.frameworkRevision);
+
+    // Regenerate the version file based on the latest branch state.
+    upstreamVersion.updateVersionFile();
+
     if (!testFlow) {
       await flutterUpgradeContinue(startedAt: startedAt);
     }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -236,6 +236,7 @@ abstract class FlutterVersion {
       : _getTimeSinceCommit(revision: engineRevision);
 
   void ensureVersionFile();
+  void updateVersionFile();
 
   @override
   String toString() {
@@ -595,6 +596,11 @@ class _FlutterVersionFromFile extends FlutterVersion {
   void ensureVersionFile() {
     _ensureLegacyVersionFile(fs: fs, flutterRoot: flutterRoot, frameworkVersion: frameworkVersion);
   }
+
+  @override
+  void updateVersionFile() {
+    // Do nothing.
+  }
 }
 
 class _FlutterVersionGit extends FlutterVersion {
@@ -690,11 +696,16 @@ class _FlutterVersionGit extends FlutterVersion {
   void ensureVersionFile() {
     _ensureLegacyVersionFile(fs: fs, flutterRoot: flutterRoot, frameworkVersion: frameworkVersion);
 
-    const encoder = JsonEncoder.withIndent('  ');
     final File newVersionFile = FlutterVersion.getVersionFile(fs, flutterRoot);
     if (!newVersionFile.existsSync()) {
-      newVersionFile.writeAsStringSync(encoder.convert(toJson()));
+      updateVersionFile();
     }
+  }
+
+  @override
+  void updateVersionFile() {
+    const encoder = JsonEncoder.withIndent('  ');
+    FlutterVersion.getVersionFile(fs, flutterRoot).writeAsStringSync(encoder.convert(toJson()));
   }
 
   @override

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -412,6 +412,9 @@ class FakeFlutterVersion implements FlutterVersion {
   bool get didFetchTagsAndUpdate => _didFetchTagsAndUpdate;
   var _didFetchTagsAndUpdate = false;
 
+  bool get didUpdateVersionFile => _didUpdateVersionFile;
+  var _didUpdateVersionFile = false;
+
   /// Will be returned by [fetchTagsAndGetVersion] if not null.
   final FlutterVersion? nextFlutterVersion;
 
@@ -510,6 +513,11 @@ class FakeFlutterVersion implements FlutterVersion {
 
   @override
   final String? engineContentHash;
+
+  @override
+  void updateVersionFile() {
+    _didUpdateVersionFile = true;
+  }
 }
 
 // A test implementation of [FeatureFlags] that allows enabling without reading

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -412,8 +412,11 @@ class FakeFlutterVersion implements FlutterVersion {
   bool get didFetchTagsAndUpdate => _didFetchTagsAndUpdate;
   var _didFetchTagsAndUpdate = false;
 
-  bool get didUpdateVersionFile => _didUpdateVersionFile;
-  var _didUpdateVersionFile = false;
+  bool get didEnsureVersionFile => _didEnsureVersionFile;
+  var _didEnsureVersionFile = false;
+
+  bool get didDeleteVersionFile => _didDeleteVersionFile;
+  var _didDeleteVersionFile = false;
 
   /// Will be returned by [fetchTagsAndGetVersion] if not null.
   final FlutterVersion? nextFlutterVersion;
@@ -486,7 +489,14 @@ class FakeFlutterVersion implements FlutterVersion {
   }
 
   @override
-  Future<void> ensureVersionFile() async {}
+  Future<void> ensureVersionFile() async {
+    _didEnsureVersionFile = true;
+  }
+
+  @override
+  void deleteVersionFile() {
+    _didDeleteVersionFile = true;
+  }
 
   @override
   String getBranchName({bool redactUnknownBranches = false}) {
@@ -513,11 +523,6 @@ class FakeFlutterVersion implements FlutterVersion {
 
   @override
   final String? engineContentHash;
-
-  @override
-  void updateVersionFile() {
-    _didUpdateVersionFile = true;
-  }
 }
 
 // A test implementation of [FeatureFlags] that allows enabling without reading


### PR DESCRIPTION
The tool performs various checks to determine whether or not to regenerate version information as part of a `flutter upgrade` instead of just regenerating `flutter.version.json` as part of each `flutter upgrade`. This has lead to some situations where the actual framework version doesn't match that reported by the `flutter.version.json`.

This change updates `flutter upgrade` to always regenerate `flutter.version.json` after checking out the new version of the framework to ensure that it contains the latest version information.

Fixes https://github.com/flutter/flutter/issues/178926