### PR TITLE
Reenable 4 fragment shader tests

### DIFF
--- a/engine/src/flutter/lib/ui/fixtures/shaders/BUILD.gn
+++ b/engine/src/flutter/lib/ui/fixtures/shaders/BUILD.gn
@@ -18,7 +18,12 @@ if (enable_unittests) {
 
   impellerc("ink_sparkle") {
     shaders = [ "//flutter/impeller/fixtures/ink_sparkle.frag" ]
-    shader_target_flags = [ "--sksl" ]
+    shader_target_flags = [
+      "--sksl",
+      "--runtime-stage-metal",
+      "--runtime-stage-gles",
+      "--runtime-stage-vulkan",
+    ]
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
     iplr = true

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -448,7 +448,7 @@ void main() async {
     });
   }
 
-  _runSkiaTest('FragmentShader simple shader renders correctly', () async {
+  test('FragmentShader simple shader renders correctly', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('functions.frag.iplr');
     final FragmentShader shader = program.fragmentShader()..setFloat(0, 1.0);
     await _expectShaderRendersGreen(shader);

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -429,23 +429,23 @@ void main() async {
     (FilterQuality.medium, 'fragment_shader_texture_with_quality_medium.png'),
     (FilterQuality.high, 'fragment_shader_texture_with_quality_high.png'),
   ]) {
-    _runSkiaTest(
-      'FragmentShader renders sampler with filter quality ${filterQuality.name}',
-      () async {
-        final FragmentProgram program = await FragmentProgram.fromAsset('texture.frag.iplr');
-        final Image image = _createOvalGradientImage(imageDimension: 16);
-        final FragmentShader shader = program.fragmentShader()
-          ..setImageSampler(0, image, filterQuality: filterQuality);
-        shader.getUniformFloat('u_size', 0).set(300);
-        shader.getUniformFloat('u_size', 1).set(300);
+    test('FragmentShader renders sampler with filter quality ${filterQuality.name}', () async {
+      final FragmentProgram program = await FragmentProgram.fromAsset('texture.frag.iplr');
+      final Image image = _createOvalGradientImage(imageDimension: 16);
+      final FragmentShader shader = program.fragmentShader()
+        ..setImageSampler(0, image, filterQuality: filterQuality);
+      shader.setFloat(0, 300);
+      shader.setFloat(1, 300);
+      // TODO(180595): Switch these to the getUniformFloat API.
+      // shader.getUniformFloat('u_size', 0).set(300);
+      // shader.getUniformFloat('u_size', 1).set(300);
 
-        final Image shaderImage = await _imageFromShader(shader: shader, imageDimension: 300);
+      final Image shaderImage = await _imageFromShader(shader: shader, imageDimension: 300);
 
-        await comparer.addGoldenImage(shaderImage, goldenFilename);
-        shader.dispose();
-        image.dispose();
-      },
-    );
+      await comparer.addGoldenImage(shaderImage, goldenFilename);
+      shader.dispose();
+      image.dispose();
+    });
   }
 
   _runSkiaTest('FragmentShader simple shader renders correctly', () async {

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -331,7 +331,7 @@ void main() async {
       }
     });
 
-    _runSkiaTest('FragmentProgram getUniformFloat unknown', () async {
+    test('FragmentProgram getUniformFloat unknown', () async {
       try {
         shader.getUniformFloat('unknown');
         fail('Unreachable');

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -456,10 +456,6 @@ void main() async {
   });
 
   _runSkiaTest('FragmentShader with uniforms renders correctly', () async {
-    // Fails in impeller.
-    // Expected: a numeric value within <0.00196078431372549> of <1.0>
-    //  Actual: <0.0>
-    //  Which:  differs by <1.0>
     final FragmentProgram program = await FragmentProgram.fromAsset('uniforms.frag.iplr');
 
     final FragmentShader shader = program.fragmentShader()
@@ -482,14 +478,6 @@ void main() async {
   });
 
   _runSkiaTest('FragmentShader shader with array uniforms renders correctly', () async {
-    // Fails in impeller.
-    // Expected: '#ff00ff00'
-    //   Actual: '#ff0000ff'
-    //    Which: is different.
-    //           Expected: #ff00ff00
-    //             Actual: #ff0000ff
-    //                          ^
-    //            Differ at offset 5
     final FragmentProgram program = await FragmentProgram.fromAsset('uniform_arrays.frag.iplr');
 
     final FragmentShader shader = program.fragmentShader();

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -456,6 +456,10 @@ void main() async {
   });
 
   _runSkiaTest('FragmentShader with uniforms renders correctly', () async {
+    // Fails in impeller.
+    // Expected: a numeric value within <0.00196078431372549> of <1.0>
+    //  Actual: <0.0>
+    //  Which:  differs by <1.0>
     final FragmentProgram program = await FragmentProgram.fromAsset('uniforms.frag.iplr');
 
     final FragmentShader shader = program.fragmentShader()
@@ -478,6 +482,14 @@ void main() async {
   });
 
   _runSkiaTest('FragmentShader shader with array uniforms renders correctly', () async {
+    // Fails in impeller.
+    // Expected: '#ff00ff00'
+    //   Actual: '#ff0000ff'
+    //    Which: is different.
+    //           Expected: #ff00ff00
+    //             Actual: #ff0000ff
+    //                          ^
+    //            Differ at offset 5
     final FragmentProgram program = await FragmentProgram.fromAsset('uniform_arrays.frag.iplr');
 
     final FragmentShader shader = program.fragmentShader();
@@ -584,7 +596,7 @@ void main() async {
     expect(identical(filter, filter_3), false);
   });
 
-  _runSkiaTest('FragmentShader The ink_sparkle shader is accepted', () async {
+  test('FragmentShader The ink_sparkle shader is accepted', () async {
     final FragmentProgram program = await FragmentProgram.fromAsset('ink_sparkle.frag.iplr');
     final FragmentShader shader = program.fragmentShader();
 


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/180764

turns on 4 disabled tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
