### PR TITLE
Fix some type checks in the `Actions` widget

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1672,7 +1672,7 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
   Object? invoke(T intent, [BuildContext? context]) {
     final Action<Intent>? overrideAction = getOverrideAction(intent);
     final Object? returnValue = overrideAction == null
-        ? invokeDefaultAction(intent, callingAction, context)
+        ? invokeDefaultAction(intent, _currentCallingAction, context)
         : _invokeOverride(overrideAction, intent, context);
     return returnValue;
   }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -188,7 +188,6 @@ abstract class Action<T extends Intent> with Diagnosticable {
   }
 
   // Checks if the intent's type is a subtype of T.
-  // This is an instance method instead of standalone function because
   bool _debugCanHandleIntent<I extends Intent>(I? intent) {
     final Object? badIntentString = switch (intent) {
       T() => null,

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -181,10 +181,28 @@ abstract class Action<T extends Intent> with Diagnosticable {
 
   final ObserverList<ActionListenerCallback> _listeners = ObserverList<ActionListenerCallback>();
 
-  Action<T>? _currentCallingAction;
+  Action<Intent>? _currentCallingAction;
   // ignore: use_setters_to_change_properties, (code predates enabling of this lint)
-  void _updateCallingAction(Action<T>? value) {
+  void _updateCallingAction(Action<Intent>? value) {
     _currentCallingAction = value;
+  }
+
+  // Checks if the intent's type is a subtype of T.
+  // This is an instance method instead of standalone function because
+  bool _debugCanHandleIntent<I extends Intent>(I? intent) {
+    final Object? badIntentString = switch (intent) {
+      T() => null,
+      // The List literal is needed to reify the type I
+      // ignore: literal_only_boolean_expressions
+      null when <I>[] is List<T> => null,
+      null => I.toString(),
+      Object(:final runtimeType) => runtimeType,
+    };
+    assert(
+      badIntentString == null,
+      'An Intent of type $badIntentString cannot be handled by $runtimeType: the Intent must be of a subtype of $T.',
+    );
+    return badIntentString == null;
   }
 
   /// The [Action] overridden by this [Action].
@@ -229,7 +247,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
   /// ```
   /// {@end-tool}
   @protected
-  Action<T>? get callingAction => _currentCallingAction;
+  Action<Intent>? get callingAction => _currentCallingAction;
 
   /// Gets the type of intent this action responds to.
   Type get intentType => T;
@@ -856,55 +874,43 @@ class Actions extends StatefulWidget {
   ///  * [find], which is similar to this function, but will throw if
   ///    no [Actions] ancestor is found.
   static Action<T>? maybeFind<T extends Intent>(BuildContext context, {T? intent}) {
-    Action<T>? action;
-
-    // Specialize the type if a runtime example instance of the intent is given.
-    // This allows this function to be called by code that doesn't know the
-    // concrete type of the intent at compile time.
-    final Type type = intent?.runtimeType ?? T;
-    assert(
-      type != Intent,
-      'The type passed to "find" resolved to "Intent": either a non-Intent '
-      'generic type argument or an example intent derived from Intent must be '
-      'specified. Intent may be used as the generic type as long as the optional '
-      '"intent" argument is passed.',
-    );
-
+    Action<Intent>? action;
     _visitActionsAncestors(context, (InheritedElement element) {
       final actions = element.widget as _ActionsScope;
-      final Action<T>? result = _castAction(actions, intent: intent);
+      final Action<Intent>? result = _getActionForIntent<T>(actions, intent);
       if (result != null) {
         context.dependOnInheritedElement(element);
         action = result;
         return true;
       }
+
       return false;
     });
 
-    return action;
+    if (action case final Action<T>? action) {
+      return action;
+    }
+    assert(
+      false,
+      'An ${action.runtimeType} cannot be cast to an Action<$T>. '
+      'This is a current limitation of the Actions widget, '
+      'see https://github.com/flutter/flutter/issues/180871 for more details. '
+      'Consider using Actions.invoke or Actions.maybeInvoke instead, '
+      'or explicitly relax the type constraint specified in this method. '
+      'For example, use Actions.maybeFind<Intent> instead of Actions.maybeFind<MyIntent>(). ',
+    );
+    return null;
   }
 
-  static Action<T>? _maybeFindWithoutDependingOn<T extends Intent>(
-    BuildContext context, {
+  static Action<Intent>? _maybeFindWithoutDependingOn<T extends Intent>(
+    BuildContext context,
     T? intent,
-  }) {
-    Action<T>? action;
-
-    // Specialize the type if a runtime example instance of the intent is given.
-    // This allows this function to be called by code that doesn't know the
-    // concrete type of the intent at compile time.
-    final Type type = intent?.runtimeType ?? T;
-    assert(
-      type != Intent,
-      'The type passed to "find" resolved to "Intent": either a non-Intent '
-      'generic type argument or an example intent derived from Intent must be '
-      'specified. Intent may be used as the generic type as long as the optional '
-      '"intent" argument is passed.',
-    );
+  ) {
+    Action<Intent>? action;
 
     _visitActionsAncestors(context, (InheritedElement element) {
       final actions = element.widget as _ActionsScope;
-      final Action<T>? result = _castAction(actions, intent: intent);
+      final Action<Intent>? result = _getActionForIntent<T>(actions, intent);
       if (result != null) {
         action = result;
         return true;
@@ -915,19 +921,13 @@ class Actions extends StatefulWidget {
     return action;
   }
 
-  // Find the [Action] that handles the given `intent` in the given
-  // `_ActionsScope`, and verify it has the right type parameter.
-  static Action<T>? _castAction<T extends Intent>(_ActionsScope actionsMarker, {T? intent}) {
+  static Action<Intent>? _getActionForIntent<T extends Intent>(
+    _ActionsScope actionsMarker,
+    T? intent,
+  ) {
     final Action<Intent>? mappedAction = actionsMarker.actions[intent?.runtimeType ?? T];
-    if (mappedAction is Action<T>?) {
-      return mappedAction;
-    } else {
-      assert(
-        false,
-        '$T cannot be handled by an Action of runtime type ${mappedAction.runtimeType}.',
-      );
-      return null;
-    }
+    assert(mappedAction?._debugCanHandleIntent(intent) ?? true);
+    return mappedAction;
   }
 
   /// Returns the [ActionDispatcher] associated with the [Actions] widget that
@@ -957,7 +957,7 @@ class Actions extends StatefulWidget {
 
     final bool actionFound = _visitActionsAncestors(context, (InheritedElement element) {
       final actions = element.widget as _ActionsScope;
-      final Action<T>? result = _castAction(actions, intent: intent);
+      final Action<Intent>? result = _getActionForIntent(actions, intent);
       if (result != null && result._isEnabled(intent, context)) {
         // Invoke the action we found using the relevant dispatcher from the Actions
         // Element we found.
@@ -1002,7 +1002,7 @@ class Actions extends StatefulWidget {
     Object? returnValue;
     _visitActionsAncestors(context, (InheritedElement element) {
       final actions = element.widget as _ActionsScope;
-      final Action<T>? result = _castAction(actions, intent: intent);
+      final Action<Intent>? result = _getActionForIntent(actions, intent);
       if (result != null && result._isEnabled(intent, context)) {
         // Invoke the action we found using the relevant dispatcher from the Actions
         // element we found.
@@ -1629,23 +1629,23 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
   BuildContext get lookupContext;
 
   // How to invoke [defaultAction], given the caller [fromAction].
-  Object? invokeDefaultAction(T intent, Action<T>? fromAction, BuildContext? context);
+  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context);
 
-  Action<T>? getOverrideAction({bool declareDependency = false}) {
-    final Action<T>? override = declareDependency
-        ? Actions.maybeFind(lookupContext)
-        : Actions._maybeFindWithoutDependingOn(lookupContext);
+  Action<Intent>? getOverrideAction<U extends Intent>(U? intent, {bool declareDependency = false}) {
+    final Action<Intent>? override = declareDependency
+        ? Actions.maybeFind<U>(lookupContext, intent: intent)
+        : Actions._maybeFindWithoutDependingOn<U>(lookupContext, intent);
     assert(!identical(override, this));
     return override;
   }
 
   @override
-  void _updateCallingAction(Action<T>? value) {
+  void _updateCallingAction(Action<Intent>? value) {
     super._updateCallingAction(value);
     defaultAction._updateCallingAction(value);
   }
 
-  Object? _invokeOverride(Action<T> overrideAction, T intent, BuildContext? context) {
+  Object? _invokeOverride(Action<Intent> overrideAction, T intent, BuildContext? context) {
     assert(!debugAssertMutuallyRecursive);
     assert(() {
       debugAssertMutuallyRecursive = true;
@@ -1663,14 +1663,14 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
 
   @override
   Object? invoke(T intent, [BuildContext? context]) {
-    final Action<T>? overrideAction = getOverrideAction();
+    final Action<Intent>? overrideAction = getOverrideAction(intent);
     final Object? returnValue = overrideAction == null
         ? invokeDefaultAction(intent, callingAction, context)
         : _invokeOverride(overrideAction, intent, context);
     return returnValue;
   }
 
-  bool isOverrideActionEnabled(Action<T> overrideAction) {
+  bool isOverrideActionEnabled(Action<Intent> overrideAction) {
     assert(!debugAssertIsActionEnabledMutuallyRecursive);
     assert(() {
       debugAssertIsActionEnabledMutuallyRecursive = true;
@@ -1688,7 +1688,7 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
 
   @override
   bool get isActionEnabled {
-    final Action<T>? overrideAction = getOverrideAction(declareDependency: true);
+    final Action<Intent>? overrideAction = getOverrideAction<T>(null, declareDependency: true);
     final bool returnValue = overrideAction != null
         ? isOverrideActionEnabled(overrideAction)
         : defaultAction.isActionEnabled;
@@ -1703,7 +1703,8 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
       return true;
     }());
 
-    final Action<T>? overrideAction = getOverrideAction();
+    final Action<Intent>? overrideAction = getOverrideAction(intent);
+    assert(overrideAction?._debugCanHandleIntent(intent) ?? true);
     overrideAction?._updateCallingAction(defaultAction);
     final bool returnValue = (overrideAction ?? defaultAction)._isEnabled(intent, context);
     overrideAction?._updateCallingAction(null);
@@ -1721,7 +1722,7 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
       debugAssertConsumeKeyMutuallyRecursive = true;
       return true;
     }());
-    final Action<T>? overrideAction = getOverrideAction();
+    final Action<Intent>? overrideAction = getOverrideAction(intent);
     overrideAction?._updateCallingAction(defaultAction);
     final bool isEnabled = (overrideAction ?? defaultAction).consumesKey(intent);
     overrideAction?._updateCallingAction(null);
@@ -1750,7 +1751,7 @@ class _OverridableAction<T extends Intent> extends ContextAction<T>
   final BuildContext lookupContext;
 
   @override
-  Object? invokeDefaultAction(T intent, Action<T>? fromAction, BuildContext? context) {
+  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
     if (fromAction == null) {
       return defaultAction.invoke(intent);
     } else {
@@ -1776,13 +1777,14 @@ class _OverridableContextAction<T extends Intent> extends ContextAction<T>
   final BuildContext lookupContext;
 
   @override
-  Object? _invokeOverride(Action<T> overrideAction, T intent, BuildContext? context) {
+  Object? _invokeOverride(Action<Intent> overrideAction, T intent, BuildContext? context) {
     assert(context != null);
     assert(!debugAssertMutuallyRecursive);
     assert(() {
       debugAssertMutuallyRecursive = true;
       return true;
     }());
+    assert(overrideAction._debugCanHandleIntent(intent));
 
     // Wrap the default Action together with the calling context in case
     // overrideAction is not a ContextAction and thus have no access to the
@@ -1803,7 +1805,7 @@ class _OverridableContextAction<T extends Intent> extends ContextAction<T>
   }
 
   @override
-  Object? invokeDefaultAction(T intent, Action<T>? fromAction, BuildContext? context) {
+  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
     if (fromAction == null) {
       return defaultAction.invoke(intent, context);
     } else {
@@ -1825,12 +1827,12 @@ class _ContextActionToActionAdapter<T extends Intent> extends Action<T> {
   final ContextAction<T> action;
 
   @override
-  void _updateCallingAction(Action<T>? value) {
+  void _updateCallingAction(Action<Intent>? value) {
     action._updateCallingAction(value);
   }
 
   @override
-  Action<T>? get callingAction => action.callingAction;
+  Action<Intent>? get callingAction => action.callingAction;
 
   @override
   bool isEnabled(T intent) => action.isEnabled(intent, invokeContext);

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -831,6 +831,8 @@ class Actions extends StatefulWidget {
   /// If no [Actions] widget surrounds the given context, this function will
   /// assert in debug mode, and throw an exception in release mode.
   ///
+  /// {@macro flutter.widgets.actions.findLimitations}
+  ///
   /// See also:
   ///
   ///  * [maybeFind], which is similar to this function, but will return null if
@@ -869,6 +871,20 @@ class Actions extends StatefulWidget {
   ///
   /// If no [Actions] widget surrounds the given context, this function will
   /// return null.
+  ///
+  /// {@template flutter.widgets.actions.findLimitations}
+  /// ### Limitations
+  ///
+  /// The type parameter `T` in `Action<T>` is contravariant. However, dart doesn't
+  /// support custom contravariance. For example, an `Action<Intent>` can handle
+  /// any `Intent` subtype, thus should always be a valid candidate.
+  /// But an `Action<Intent>` can not be cast to `Action<T>` for arbitrary `T`
+  /// thus can not be returned from this method, unless `T == Intent`.
+  ///
+  /// To work around this, it is strongly recommended that callers explicitly
+  /// set the type parameter to `Intent` when the `intent` parameter is not null:
+  /// `Actions.maybeFind<Intent>(context, intent)`.
+  /// {@endtemplate}
   ///
   /// See also:
   ///
@@ -1623,25 +1639,28 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
   // When debugAssertMutuallyRecursive is true, this action will throw an
   // assertion error when the override calls this action's "invoke" method and
   // the override is already being invoked from within the "invoke" method.
-  bool debugAssertMutuallyRecursive = false;
-  bool debugAssertIsActionEnabledMutuallyRecursive = false;
-  bool debugAssertIsEnabledMutuallyRecursive = false;
-  bool debugAssertConsumeKeyMutuallyRecursive = false;
+  bool _debugAssertMutuallyRecursive = false;
+  bool _debugAssertIsActionEnabledMutuallyRecursive = false;
+  bool _debugAssertIsEnabledMutuallyRecursive = false;
+  bool _debugAssertConsumeKeyMutuallyRecursive = false;
 
   // The default action to invoke if an enabled override Action can't be found
   // using [lookupContext].
-  Action<T> get defaultAction;
+  Action<T> get _defaultAction;
 
   // The [BuildContext] used to find the override of this [Action].
-  BuildContext get lookupContext;
+  BuildContext get _lookupContext;
 
   // How to invoke [defaultAction], given the caller [fromAction].
-  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context);
+  Object? _invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context);
 
-  Action<Intent>? getOverrideAction<U extends Intent>(U? intent, {bool declareDependency = false}) {
+  Action<Intent>? _getOverrideAction<U extends Intent>(
+    U? intent, {
+    bool declareDependency = false,
+  }) {
     final Action<Intent>? override = declareDependency
-        ? Actions.maybeFind(lookupContext, intent: intent)
-        : Actions._maybeFindWithoutDependingOn(lookupContext, intent);
+        ? Actions.maybeFind(_lookupContext, intent: intent)
+        : Actions._maybeFindWithoutDependingOn(_lookupContext, intent);
     assert(!identical(override, this));
     return override;
   }
@@ -1649,20 +1668,20 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
   @override
   void _updateCallingAction(Action<Intent>? value) {
     super._updateCallingAction(value);
-    defaultAction._updateCallingAction(value);
+    _defaultAction._updateCallingAction(value);
   }
 
   Object? _invokeOverride(Action<Intent> overrideAction, T intent, BuildContext? context) {
-    assert(!debugAssertMutuallyRecursive);
+    assert(!_debugAssertMutuallyRecursive);
     assert(() {
-      debugAssertMutuallyRecursive = true;
+      _debugAssertMutuallyRecursive = true;
       return true;
     }());
-    overrideAction._updateCallingAction(defaultAction);
+    overrideAction._updateCallingAction(_defaultAction);
     final Object? returnValue = overrideAction._invoke(intent, context);
     overrideAction._updateCallingAction(null);
     assert(() {
-      debugAssertMutuallyRecursive = false;
+      _debugAssertMutuallyRecursive = false;
       return true;
     }());
     return returnValue;
@@ -1670,24 +1689,24 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
 
   @override
   Object? invoke(T intent, [BuildContext? context]) {
-    final Action<Intent>? overrideAction = getOverrideAction(intent);
+    final Action<Intent>? overrideAction = _getOverrideAction(intent);
     final Object? returnValue = overrideAction == null
-        ? invokeDefaultAction(intent, _currentCallingAction, context)
+        ? _invokeDefaultAction(intent, _currentCallingAction, context)
         : _invokeOverride(overrideAction, intent, context);
     return returnValue;
   }
 
-  bool isOverrideActionEnabled(Action<Intent> overrideAction) {
-    assert(!debugAssertIsActionEnabledMutuallyRecursive);
+  bool _isOverrideActionEnabled(Action<Intent> overrideAction) {
+    assert(!_debugAssertIsActionEnabledMutuallyRecursive);
     assert(() {
-      debugAssertIsActionEnabledMutuallyRecursive = true;
+      _debugAssertIsActionEnabledMutuallyRecursive = true;
       return true;
     }());
-    overrideAction._updateCallingAction(defaultAction);
+    overrideAction._updateCallingAction(_defaultAction);
     final bool isOverrideEnabled = overrideAction.isActionEnabled;
     overrideAction._updateCallingAction(null);
     assert(() {
-      debugAssertIsActionEnabledMutuallyRecursive = false;
+      _debugAssertIsActionEnabledMutuallyRecursive = false;
       return true;
     }());
     return isOverrideEnabled;
@@ -1695,28 +1714,28 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
 
   @override
   bool get isActionEnabled {
-    final Action<Intent>? overrideAction = getOverrideAction<T>(null, declareDependency: true);
+    final Action<Intent>? overrideAction = _getOverrideAction<T>(null, declareDependency: true);
     final bool returnValue = overrideAction != null
-        ? isOverrideActionEnabled(overrideAction)
-        : defaultAction.isActionEnabled;
+        ? _isOverrideActionEnabled(overrideAction)
+        : _defaultAction.isActionEnabled;
     return returnValue;
   }
 
   @override
   bool isEnabled(T intent, [BuildContext? context]) {
-    assert(!debugAssertIsEnabledMutuallyRecursive);
+    assert(!_debugAssertIsEnabledMutuallyRecursive);
     assert(() {
-      debugAssertIsEnabledMutuallyRecursive = true;
+      _debugAssertIsEnabledMutuallyRecursive = true;
       return true;
     }());
 
-    final Action<Intent>? overrideAction = getOverrideAction(intent);
+    final Action<Intent>? overrideAction = _getOverrideAction(intent);
     assert(overrideAction?._debugCanHandleIntent(intent) ?? true);
-    overrideAction?._updateCallingAction(defaultAction);
-    final bool returnValue = (overrideAction ?? defaultAction)._isEnabled(intent, context);
+    overrideAction?._updateCallingAction(_defaultAction);
+    final bool returnValue = (overrideAction ?? _defaultAction)._isEnabled(intent, context);
     overrideAction?._updateCallingAction(null);
     assert(() {
-      debugAssertIsEnabledMutuallyRecursive = false;
+      _debugAssertIsEnabledMutuallyRecursive = false;
       return true;
     }());
     return returnValue;
@@ -1724,17 +1743,17 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
 
   @override
   bool consumesKey(T intent) {
-    assert(!debugAssertConsumeKeyMutuallyRecursive);
+    assert(!_debugAssertConsumeKeyMutuallyRecursive);
     assert(() {
-      debugAssertConsumeKeyMutuallyRecursive = true;
+      _debugAssertConsumeKeyMutuallyRecursive = true;
       return true;
     }());
-    final Action<Intent>? overrideAction = getOverrideAction(intent);
-    overrideAction?._updateCallingAction(defaultAction);
-    final bool isEnabled = (overrideAction ?? defaultAction).consumesKey(intent);
+    final Action<Intent>? overrideAction = _getOverrideAction(intent);
+    overrideAction?._updateCallingAction(_defaultAction);
+    final bool isEnabled = (overrideAction ?? _defaultAction).consumesKey(intent);
     overrideAction?._updateCallingAction(null);
     assert(() {
-      debugAssertConsumeKeyMutuallyRecursive = false;
+      _debugAssertConsumeKeyMutuallyRecursive = false;
       return true;
     }());
     return isEnabled;
@@ -1743,52 +1762,58 @@ mixin _OverridableActionMixin<T extends Intent> on Action<T> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Action<T>>('defaultAction', defaultAction));
+    properties.add(DiagnosticsProperty<Action<T>>('defaultAction', _defaultAction));
   }
 }
 
 class _OverridableAction<T extends Intent> extends ContextAction<T>
     with _OverridableActionMixin<T> {
-  _OverridableAction({required this.defaultAction, required this.lookupContext});
+  _OverridableAction({required Action<T> defaultAction, required BuildContext lookupContext})
+    : _lookupContext = lookupContext,
+      _defaultAction = defaultAction;
 
   @override
-  final Action<T> defaultAction;
+  final Action<T> _defaultAction;
 
   @override
-  final BuildContext lookupContext;
+  final BuildContext _lookupContext;
 
   @override
-  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
+  Object? _invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
     if (fromAction == null) {
-      return defaultAction.invoke(intent);
+      return _defaultAction.invoke(intent);
     } else {
-      final Object? returnValue = defaultAction.invoke(intent);
+      final Object? returnValue = _defaultAction.invoke(intent);
       return returnValue;
     }
   }
 
   @override
   ContextAction<T> _makeOverridableAction(BuildContext context) {
-    return _OverridableAction<T>(defaultAction: defaultAction, lookupContext: context);
+    return _OverridableAction<T>(defaultAction: _defaultAction, lookupContext: context);
   }
 }
 
 class _OverridableContextAction<T extends Intent> extends ContextAction<T>
     with _OverridableActionMixin<T> {
-  _OverridableContextAction({required this.defaultAction, required this.lookupContext});
+  _OverridableContextAction({
+    required ContextAction<T> defaultAction,
+    required BuildContext lookupContext,
+  }) : _lookupContext = lookupContext,
+       _defaultAction = defaultAction;
 
   @override
-  final ContextAction<T> defaultAction;
+  final ContextAction<T> _defaultAction;
 
   @override
-  final BuildContext lookupContext;
+  final BuildContext _lookupContext;
 
   @override
   Object? _invokeOverride(Action<Intent> overrideAction, T intent, BuildContext? context) {
     assert(context != null);
-    assert(!debugAssertMutuallyRecursive);
+    assert(!_debugAssertMutuallyRecursive);
     assert(() {
-      debugAssertMutuallyRecursive = true;
+      _debugAssertMutuallyRecursive = true;
       return true;
     }());
     assert(overrideAction._debugCanHandleIntent(intent));
@@ -1798,32 +1823,32 @@ class _OverridableContextAction<T extends Intent> extends ContextAction<T>
     // calling BuildContext.
     final Action<T> wrappedDefault = _ContextActionToActionAdapter<T>(
       invokeContext: context!,
-      action: defaultAction,
+      action: _defaultAction,
     );
     overrideAction._updateCallingAction(wrappedDefault);
     final Object? returnValue = overrideAction._invoke(intent, context);
     overrideAction._updateCallingAction(null);
 
     assert(() {
-      debugAssertMutuallyRecursive = false;
+      _debugAssertMutuallyRecursive = false;
       return true;
     }());
     return returnValue;
   }
 
   @override
-  Object? invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
+  Object? _invokeDefaultAction(T intent, Action<Intent>? fromAction, BuildContext? context) {
     if (fromAction == null) {
-      return defaultAction.invoke(intent, context);
+      return _defaultAction.invoke(intent, context);
     } else {
-      final Object? returnValue = defaultAction.invoke(intent, context);
+      final Object? returnValue = _defaultAction.invoke(intent, context);
       return returnValue;
     }
   }
 
   @override
   ContextAction<T> _makeOverridableAction(BuildContext context) {
-    return _OverridableContextAction<T>(defaultAction: defaultAction, lookupContext: context);
+    return _OverridableContextAction<T>(defaultAction: _defaultAction, lookupContext: context);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -873,13 +873,15 @@ class Actions extends StatefulWidget {
   /// return null.
   ///
   /// {@template flutter.widgets.actions.findLimitations}
-  /// ### Limitations
+  /// ## Limitations:
   ///
-  /// The type parameter `T` in `Action<T>` is contravariant. However, dart doesn't
-  /// support custom contravariance. For example, an `Action<Intent>` can handle
-  /// any `Intent` subtype, thus should always be a valid candidate.
-  /// But an `Action<Intent>` can not be cast to `Action<T>` for arbitrary `T`
-  /// thus can not be returned from this method, unless `T == Intent`.
+  /// The return type `Action<T>?` may prevent this method from returning
+  /// perfectly capable `Action`s bound to the given [Intent]. For instance, an
+  /// `Action<Intent>` can be bound to any `Intent` because its type signature
+  /// claims it can take any [Intent] object. However this method will not be
+  /// able to return an `Action<Intent>` unless `T` is exactly `Intent`, because
+  /// `Action<Intent>` is not a subtype of `Action<T>?`. The method will return
+  /// null in this case, and assert in debug mode.
   ///
   /// To work around this, it is strongly recommended that callers explicitly
   /// set the type parameter to `Intent` when the `intent` parameter is not null:

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -875,17 +875,19 @@ class Actions extends StatefulWidget {
   /// {@template flutter.widgets.actions.findLimitations}
   /// ## Limitations:
   ///
-  /// The return type `Action<T>?` may prevent this method from returning
-  /// perfectly capable `Action`s bound to the given [Intent]. For instance, an
-  /// `Action<Intent>` can be bound to any `Intent` because its type signature
-  /// claims it can take any [Intent] object. However this method will not be
-  /// able to return an `Action<Intent>` unless `T` is exactly `Intent`, because
-  /// `Action<Intent>` is not a subtype of `Action<T>?`. The method will return
-  /// null in this case, and assert in debug mode.
+  /// It is strongly recommended that callers explicitly set the type parameter
+  /// to `Intent` when the `intent` parameter is not null:
   ///
-  /// To work around this, it is strongly recommended that callers explicitly
-  /// set the type parameter to `Intent` when the `intent` parameter is not null:
-  /// `Actions.maybeFind<Intent>(context, intent)`.
+  /// ```dart
+  /// Actions.find<Intent>(context, intent); // GOOD
+  /// Actions.find(context, intent); // BAD
+  /// ```
+  ///
+  /// If the type parameter is not set to `Intent` when the `intent` parameter is
+  /// not null, this method might be unable to return a perfectly capable `Action`.
+  /// For instance, this method cannot return an `Action<Intent>` - an action
+  /// that can be bound to any intent - unless `T` is exactly `Intent`.
+  /// This will trigger assertions in debug mode.
   /// {@endtemplate}
   ///
   /// See also:

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -23,6 +23,10 @@ import 'framework.dart';
 import 'media_query.dart';
 import 'shortcuts.dart';
 
+// Examples can assume:
+// late BuildContext context;
+// late Intent intent;
+
 /// Returns the parent [BuildContext] of a given `context`.
 ///
 /// [BuildContext] (or rather, [Element]) doesn't have a `parent` accessor, but
@@ -879,8 +883,8 @@ class Actions extends StatefulWidget {
   /// to `Intent` when the `intent` parameter is not null:
   ///
   /// ```dart
-  /// Actions.find<Intent>(context, intent); // GOOD
-  /// Actions.find(context, intent); // BAD
+  /// Actions.find<Intent>(context, intent: intent); // GOOD
+  /// Actions.find(context, intent: intent); // BAD
   /// ```
   ///
   /// If the type parameter is not set to `Intent` when the `intent` parameter is

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2002,7 +2002,10 @@ abstract class _NonOverrideAction<T extends Intent> extends ContextAction<T> {
 
   @override
   Object? invoke(T intent, [BuildContext? context]) {
-    return callingAction?.invoke(intent) ?? invokeAction(intent, context);
+    if (callingAction case final callingAction?) {
+      return callingAction.invoke(intent);
+    }
+    return invokeAction(intent, context);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2002,10 +2002,7 @@ abstract class _NonOverrideAction<T extends Intent> extends ContextAction<T> {
 
   @override
   Object? invoke(T intent, [BuildContext? context]) {
-    if (callingAction != null) {
-      return callingAction!.invoke(intent);
-    }
-    return invokeAction(intent, context);
+    return callingAction?.invoke(intent) ?? invokeAction(intent, context);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -921,8 +921,8 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   @protected
   KeyEventResult handleKeypress(BuildContext context, KeyEvent event) {
     // Marking some variables as "late" ensures that they aren't evaluated unless needed.
-    late final Intent? intent = _find(event, HardwareKeyboard.instance);
-    late final BuildContext? context = primaryFocus?.context;
+    final Intent? intent = _find(event, HardwareKeyboard.instance);
+    final BuildContext? context = primaryFocus?.context;
     late final Action<Intent>? action = Actions.maybeFind<Intent>(context!, intent: intent);
 
     if (intent != null && context != null && action != null) {

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1666,6 +1666,38 @@ void main() {
       expect(exception, isNull);
     });
 
+    testWidgets('error message when Actions.maybeFind can not cast Action', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return Builder(
+              builder: (BuildContext context) {
+                return Actions(
+                  actions: <Type, Action<Intent>>{LogIntent: DoNothingAction()},
+                  child: Builder(
+                    builder: (BuildContext context1) {
+                      invokingContext = context1;
+                      return const SizedBox();
+                    },
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      );
+
+      Object? exception;
+      try {
+        Actions.maybeFind(invokingContext!, intent: LogIntent(log: invocations));
+      } catch (e) {
+        exception = e;
+      }
+      expect(exception.toString(), contains('This is a current limitation of the Actions widget'));
+    });
+
     testWidgets('Make an overridable action overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
@@ -2013,7 +2045,7 @@ class LogInvocationAction extends Action<LogIntent> {
 
   @override
   void invoke(LogIntent intent) {
-    final Action<Intent>? callingAction = this.callingAction;
+    final Action<LogIntent>? callingAction = this.callingAction;
     if (callingAction == null) {
       intent.log.add('$actionName.invoke');
     } else {
@@ -2045,7 +2077,7 @@ class LogInvocationContextAction extends ContextAction<LogIntent> {
   @override
   void invoke(LogIntent intent, [BuildContext? context]) {
     invokeContext = context;
-    final Action<Intent>? callingAction = this.callingAction;
+    final Action<LogIntent>? callingAction = this.callingAction;
     if (callingAction == null) {
       intent.log.add('$actionName.invoke');
     } else {

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1663,6 +1663,53 @@ void main() {
       } catch (e) {
         exception = e;
       }
+      expect(invocations, isEmpty);
+      expect(exception, isNull);
+    });
+
+    testWidgets('Contravariant action override', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return Actions(
+              actions: <Type, Action<Intent>>{
+                LogIntent: Action<LogIntent>.overridable(
+                  defaultAction: LogInvocationAction(actionName: 'action1', shouldCallSuper: false),
+                  context: context,
+                ),
+              },
+              // DoNothingAction extends Action<Intent> and should be able to
+              // handle any Intent.
+              child: Builder(
+                builder: (BuildContext context) {
+                  return Actions(
+                    actions: <Type, Action<Intent>>{
+                      LogIntent: Action<Intent>.overridable(
+                        defaultAction: DoNothingAction(),
+                        context: context,
+                      ),
+                    },
+                    child: Builder(
+                      builder: (BuildContext context1) {
+                        invokingContext = context1;
+                        return const SizedBox();
+                      },
+                    ),
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      );
+
+      Object? exception;
+      try {
+        Actions.invoke(invokingContext!, LogIntent(log: invocations));
+      } catch (e) {
+        exception = e;
+      }
+      expect(invocations, <String>['action1.invoke']);
       expect(exception, isNull);
     });
 
@@ -2034,18 +2081,20 @@ class LogIntent extends Intent {
 }
 
 class LogInvocationAction extends Action<LogIntent> {
-  LogInvocationAction({required this.actionName, this.enabled = true});
+  LogInvocationAction({required this.actionName, this.enabled = true, this.shouldCallSuper = true});
 
   final String actionName;
 
   final bool enabled;
+
+  final bool shouldCallSuper;
 
   @override
   bool get isActionEnabled => enabled;
 
   @override
   void invoke(LogIntent intent) {
-    final Action<LogIntent>? callingAction = this.callingAction;
+    final Action<LogIntent>? callingAction = shouldCallSuper ? this.callingAction : null;
     if (callingAction == null) {
       intent.log.add('$actionName.invoke');
     } else {

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1622,10 +1622,48 @@ void main() {
       } catch (e) {
         exception = e;
       }
-      expect(
-        exception?.toString(),
-        contains('cannot be handled by an Action of runtime type TestContextAction.'),
+      expect(exception?.toString(), contains('cannot be handled by TestContextAction: '));
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/180435.
+    testWidgets('Contravariant action override', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return Actions(
+              // DoNothingAction extends Action<Intent> and should be able to
+              // handle any Intent.
+              actions: <Type, Action<Intent>>{LogIntent: DoNothingAction()},
+              child: Builder(
+                builder: (BuildContext context) {
+                  return Actions(
+                    actions: <Type, Action<Intent>>{
+                      LogIntent: Action<LogIntent>.overridable(
+                        defaultAction: LogInvocationAction(actionName: 'action1'),
+                        context: context,
+                      ),
+                    },
+                    child: Builder(
+                      builder: (BuildContext context1) {
+                        invokingContext = context1;
+                        return const SizedBox();
+                      },
+                    ),
+                  );
+                },
+              ),
+            );
+          },
+        ),
       );
+
+      Object? exception;
+      try {
+        Actions.invoke(invokingContext!, LogIntent(log: invocations));
+      } catch (e) {
+        exception = e;
+      }
+      expect(exception, isNull);
     });
 
     testWidgets('Make an overridable action overridable', (WidgetTester tester) async {
@@ -1975,7 +2013,7 @@ class LogInvocationAction extends Action<LogIntent> {
 
   @override
   void invoke(LogIntent intent) {
-    final Action<LogIntent>? callingAction = this.callingAction;
+    final Action<Intent>? callingAction = this.callingAction;
     if (callingAction == null) {
       intent.log.add('$actionName.invoke');
     } else {
@@ -2007,7 +2045,7 @@ class LogInvocationContextAction extends ContextAction<LogIntent> {
   @override
   void invoke(LogIntent intent, [BuildContext? context]) {
     invokeContext = context;
-    final Action<LogIntent>? callingAction = this.callingAction;
+    final Action<Intent>? callingAction = this.callingAction;
     if (callingAction == null) {
       intent.log.add('$actionName.invoke');
     } else {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180435
Related https://github.com/flutter/flutter/issues/180871, 

The type parameter `T` in `Action<T extends Intent>` is contravariant which dart doesnt support yet, so unfortunately compile time type check is not enough, also the assert in `_castAction` is incorrect.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
