### PR TITLE
Manually roll test dependencies

### DIFF
--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -20,6 +20,6 @@ dependencies:
   native_toolchain_c: 0.17.4
 
 dev_dependencies:
-  test: 1.28.0
+  test: 1.29.0
 
-# PUBSPEC CHECKSUM: qlfuuh
+# PUBSPEC CHECKSUM: 76vsd6

--- a/dev/integration_tests/widget_preview_scaffold/pubspec.yaml
+++ b/dev/integration_tests/widget_preview_scaffold/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   stream_channel: 2.1.4
   string_scanner: 1.4.1
   term_glyph: 1.2.2
-  test_api: 0.7.8
+  test_api: 0.7.9
   typed_data: 1.4.0
   unified_analytics: 8.0.10
   url_launcher_android: 6.3.28
@@ -64,8 +64,8 @@ dependencies:
 dev_dependencies:
   flutter_tools:
     path: ../../../packages/flutter_tools/
-  test: 1.28.0
+  test: 1.29.0
 
 flutter:
   uses-material-design: true
-# PUBSPEC CHECKSUM: p85g55
+# PUBSPEC CHECKSUM: 95q6le

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
   # this, make sure the tests are still running correctly.
-  test_api: 0.7.8
+  test_api: 0.7.9
   matcher: 0.12.18
 
   # Used by golden file comparator
@@ -47,4 +47,4 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
 
-# PUBSPEC CHECKSUM: pbetap
+# PUBSPEC CHECKSUM: tcp4n8

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -66,8 +66,8 @@ dependencies:
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
   # this, make sure the tests are still running correctly.
-  test_api: 0.7.8
-  test_core: 0.6.14
+  test_api: 0.7.9
+  test_core: 0.6.15
 
   vm_service: 15.0.2
 
@@ -122,10 +122,10 @@ dev_dependencies:
   js: 0.7.2
   json_annotation: 4.9.0
   node_preamble: 2.0.2
-  test: 1.28.0
+  test: 1.29.0
 
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: ot91td
+# PUBSPEC CHECKSUM: 3bnrvh

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -827,26 +827,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.29.0"
   test_api:
     dependency: "direct main"
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   test_core:
     dependency: "direct main"
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.15"
   typed_data:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -170,9 +170,9 @@ dependencies:
   string_scanner: 1.4.1
   sync_http: 0.3.1
   term_glyph: 1.2.2
-  test: 1.28.0
-  test_api: 0.7.8
-  test_core: 0.6.14
+  test: 1.29.0
+  test_api: 0.7.9
+  test_core: 0.6.15
   typed_data: 1.4.0
   url_launcher: 6.3.2
   url_launcher_android: 6.3.28
@@ -215,4 +215,4 @@ dependencies:
 dev_dependencies:
   ffigen: 20.1.1
 
-# PUBSPEC CHECKSUM: 50ht8v
+# PUBSPEC CHECKSUM: k5vudu


### PR DESCRIPTION
Manually updating test dependencies because the pub autoroller seems busted, https://github.com/flutter/flutter/issues/180503.

This one required manually updating the pubspec files because `flutter update-packages --force-upgrade` also seemed unable to deal with the fact that multiple dependencies across packages had to be updated in sync. There's probably also something broken with the `flutter update-packages` command. This is something that used to work.