### PR TITLE
[ Tool ] Handle `DartDevelopmentServiceException` when launching web applications

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -399,11 +399,10 @@ class ResidentWebRunner extends ResidentRunner {
     } on DartDevelopmentServiceException catch (error) {
       // The application may have started shutting down before DDS was able to finish establishing
       // its connection to DWDS. Don't treat this as an unhandled exception.
+      appFailedToStart();
       if (error.errorCode == DartDevelopmentServiceException.failedToStartError) {
-        appFailedToStart();
         throwToolExit(kExitMessage);
       }
-      appFailedToStart();
       rethrow;
     } on Exception {
       appFailedToStart();

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dds/dds.dart';
 import 'package:dwds/dwds.dart';
 import 'package:package_config/package_config.dart';
 import 'package:unified_analytics/unified_analytics.dart';
@@ -377,24 +378,33 @@ class ResidentWebRunner extends ResidentRunner {
       });
     } on WebSocketException catch (error, stackTrace) {
       appFailedToStart();
-      _logger.printError('$error', stackTrace: stackTrace);
+      _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
     } on ChromeDebugException catch (error, stackTrace) {
       appFailedToStart();
-      _logger.printError('$error', stackTrace: stackTrace);
+      _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
     } on AppConnectionException catch (error, stackTrace) {
       appFailedToStart();
-      _logger.printError('$error', stackTrace: stackTrace);
+      _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
     } on SocketException catch (error, stackTrace) {
       appFailedToStart();
-      _logger.printError('$error', stackTrace: stackTrace);
+      _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
     } on HttpException catch (error, stackTrace) {
       appFailedToStart();
-      _logger.printError('$error', stackTrace: stackTrace);
+      _logger.printError(error.toString(), stackTrace: stackTrace);
       throwToolExit(kExitMessage);
+    } on DartDevelopmentServiceException catch (error) {
+      // The application may have started shutting down before DDS was able to finish establishing
+      // its connection to DWDS. Don't treat this as an unhandled exception.
+      if (error.errorCode == DartDevelopmentServiceException.failedToStartError) {
+        appFailedToStart();
+        throwToolExit(kExitMessage);
+      }
+      appFailedToStart();
+      rethrow;
     } on Exception {
       appFailedToStart();
       rethrow;

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -271,6 +271,24 @@ name: my_app
   );
 
   testUsingContext(
+    'Does not crash if the application exits during DDS startup',
+    () async {
+      // Regression test for https://github.com/flutter/flutter/issues/178151
+      final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+      fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+      setupMocks();
+      webDevFS.exception = DartDevelopmentServiceException.failedToStart();
+
+      await expectLater(residentWebRunner.run(), throwsToolExit());
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+      Pub: ThrowingPub.new,
+    },
+  );
+
+  testUsingContext(
     'WebRunner copies compiled app.dill to cache during startup',
     () async {
       final debuggingOptions = DebuggingOptions.enabled(


### PR DESCRIPTION
DWDS can throw `DartDvelopmentServiceException` if DDS fails to connect to DWDS due to the target application shutting down immediately after launch.

This change adds logic to catch this exception and exit gracefully.

Fixes https://github.com/flutter/flutter/issues/178151