### PR TITLE
In flutter_test_performance, consider the blank line at the start of "flutter test" output to be optional.

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -73,8 +73,7 @@ Future<int> runTest({bool coverage = false, bool noPub = false}) async {
       if (match == null) {
         badLines += 1;
       } else {
-        if (step.index <= TestStep.testLoading.index &&
-            match.group(1)!.startsWith('loading ')) {
+        if (step.index <= TestStep.testLoading.index && match.group(1)!.startsWith('loading ')) {
           // first the test loads
           step = TestStep.testLoading;
         } else if (step.index <= TestStep.testRunning.index &&

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -65,15 +65,15 @@ Future<int> runTest({bool coverage = false, bool noPub = false}) async {
       // ignore this line
       step = TestStep.runningPubGet;
     } else if (step.index <= TestStep.testWritesFirstCarriageReturn.index && entry.trim() == '') {
-      // we have a blank line at the start
+      // flutter_tools will print a blank line at the start of the test when using some versions
+      // of the Dart test package.  In test package version 1.29 this line is no longer present.
       step = TestStep.testWritesFirstCarriageReturn;
     } else {
       final Match? match = testOutputPattern.matchAsPrefix(entry);
       if (match == null) {
         badLines += 1;
       } else {
-        if (step.index >= TestStep.testWritesFirstCarriageReturn.index &&
-            step.index <= TestStep.testLoading.index &&
+        if (step.index <= TestStep.testLoading.index &&
             match.group(1)!.startsWith('loading ')) {
           // first the test loads
           step = TestStep.testLoading;


### PR DESCRIPTION
flutter_test_performance runs a "flutter test" command and parses its output.  The parser expects the output to begin with a blank line. That line is no longer present after the roll to version 1.29 of the Dart test package (see https://github.com/flutter/flutter/pull/180886)

Fixes https://github.com/flutter/flutter/issues/180903