### PR TITLE
[Impeller] Fix crash trying to check for duplicate vertices in shadow_path code

### DIFF
--- a/engine/src/flutter/impeller/entity/geometry/shadow_path_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/shadow_path_geometry.cc
@@ -1359,8 +1359,11 @@ uint16_t PolygonInfo::AppendVertex(const Point& vertex, Scalar gaussian) {
   FML_DCHECK(index == gaussians_.size());
   // TODO(jimgraham): Turn this condition into a failure of the tessellation
   FML_DCHECK(index <= std::numeric_limits<uint16_t>::max());
-  if (gaussian == gaussians_.back() && vertex == vertices_.back()) {
-    return index - 1;
+  if (index > 0u) {
+    FML_DCHECK(!gaussians_.empty() && !vertices_.empty());
+    if (gaussian == gaussians_.back() && vertex == vertices_.back()) {
+      return index - 1;
+    }
   }
   vertices_.push_back(vertex);
   gaussians_.push_back(gaussian);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180827

The new general convex path shadow code was checking for duplicate vertices without actually checking if the vectors contained any vertices. Thus, <vector>.back() was being called on empty vectors, which is bad. This led to a crash in G3 as their code is being run with a vector implementation that protects against this, but apparently we do not have such a vector implementation in our local building and testing.

No tests because this covered by existing test cases and a new FML_DCHECK, however I'm not sure if we have DCHECKs enabled in CI...?