### PR TITLE
Add missing 'throw' to ImageFilter.shader's validation check

### DIFF
--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -4400,6 +4400,7 @@ abstract class ImageFilter {
       if (invalidSampler) {
         buffer.write('The shader is missing a sampler uniform.\n');
       }
+      throw StateError(buffer.toString());
     }
     return _FragmentShaderImageFilter(shader);
   }

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -489,39 +489,37 @@ void main() async {
     shader.dispose();
   });
 
-  test('ImageFilter.shader errors if shader does not have correct uniform layout', () async {
-    // TODO(gaaclarke): This test was disabled for a long time and has been
-    // atrophied. Fix it or remove it.
-    print('Atrophied test is disabled.');
-    return;
-    // ignore: dead_code
-    const shaders = <String>[
-      'no_uniforms.frag.iplr',
-      'missing_size.frag.iplr',
-      'missing_texture.frag.iplr',
-    ];
-    const errors = <(bool, bool)>[(true, true), (true, false), (false, false)];
-    for (var i = 0; i < 3; i++) {
-      final String fileName = shaders[i];
-      final FragmentProgram program = await FragmentProgram.fromAsset(fileName);
-      final FragmentShader shader = program.fragmentShader();
+  _runImpellerTest(
+    'ImageFilter.shader errors if shader does not have correct uniform layout',
+    () async {
+      const shaders = <String>[
+        'no_uniforms.frag.iplr',
+        'missing_size.frag.iplr',
+        'missing_texture.frag.iplr',
+      ];
+      const errors = <(bool, bool)>[(true, true), (true, false), (false, false)];
+      for (var i = 0; i < 3; i++) {
+        final String fileName = shaders[i];
+        final FragmentProgram program = await FragmentProgram.fromAsset(fileName);
+        final FragmentShader shader = program.fragmentShader();
 
-      Object? error;
-      try {
-        ImageFilter.shader(shader);
-      } catch (err) {
-        error = err;
+        Object? error;
+        try {
+          ImageFilter.shader(shader);
+        } catch (err) {
+          error = err;
+        }
+        expect(error is StateError, true);
+        final (bool floatError, bool samplerError) = errors[i];
+        if (floatError) {
+          expect(error.toString(), contains('shader has fewer than two float'));
+        }
+        if (samplerError) {
+          expect(error.toString(), contains('shader is missing a sampler uniform'));
+        }
       }
-      expect(error is StateError, true);
-      final (bool floatError, bool samplerError) = errors[i];
-      if (floatError) {
-        expect(error.toString(), contains('shader has fewer than two float'));
-      }
-      if (samplerError) {
-        expect(error.toString(), contains('shader is missing a sampler uniform'));
-      }
-    }
-  });
+    },
+  );
 
   _runImpellerTest('Shader Compiler appropriately pads vec3 uniform arrays', () async {
     // TODO(gaaclarke): This test was disabled for a long time and has been

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -492,15 +492,14 @@ void main() async {
   _runImpellerTest(
     'ImageFilter.shader errors if shader does not have correct uniform layout',
     () async {
-      const shaders = <String>[
-        'no_uniforms.frag.iplr',
-        'missing_size.frag.iplr',
-        'missing_texture.frag.iplr',
+      const List<({String file, bool floatError, bool samplerError})> testCases = [
+        (file: 'no_uniforms.frag.iplr', floatError: true, samplerError: true),
+        (file: 'missing_size.frag.iplr', floatError: true, samplerError: false),
+        (file: 'missing_texture.frag.iplr', floatError: false, samplerError: true),
       ];
-      const errors = <(bool, bool)>[(true, true), (true, false), (false, false)];
-      for (var i = 0; i < 3; i++) {
-        final String fileName = shaders[i];
-        final FragmentProgram program = await FragmentProgram.fromAsset(fileName);
+
+      for (final testCase in testCases) {
+        final FragmentProgram program = await FragmentProgram.fromAsset(testCase.file);
         final FragmentShader shader = program.fragmentShader();
 
         Object? error;
@@ -509,13 +508,13 @@ void main() async {
         } catch (err) {
           error = err;
         }
-        expect(error is StateError, true);
-        final (bool floatError, bool samplerError) = errors[i];
-        if (floatError) {
-          expect(error.toString(), contains('shader has fewer than two float'));
+        expect(error, isA<StateError>());
+        final String errorMessage = error.toString();
+        if (testCase.floatError) {
+          expect(errorMessage, contains('shader has fewer than two float'));
         }
-        if (samplerError) {
-          expect(error.toString(), contains('shader is missing a sampler uniform'));
+        if (testCase.samplerError) {
+          expect(errorMessage, contains('shader is missing a sampler uniform'));
         }
       }
     },

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -509,7 +509,7 @@ void main() async {
           error = err;
         }
         expect(error, isA<StateError>());
-        final String errorMessage = error.toString();
+        final errorMessage = error.toString();
         if (testCase.floatError) {
           expect(errorMessage, contains('shader has fewer than two float'));
         }


### PR DESCRIPTION
An error StringBuffer was created and populated, but was left unused. This PR `throw`s it.

This fixes and re-enables fragment_shader_test.dart's ImageFilter error test. The test is re-enabled as an impeller-only test because ImageFilter.shader requires impeller.

Fixes #180763

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
