### PR TITLE
Fix 'ImageFilter.shader can be applied to canvas operations' test

### DIFF
--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -543,11 +543,6 @@ void main() async {
   });
 
   _runImpellerTest('ImageFilter.shader can be applied to canvas operations', () async {
-    // TODO(gaaclarke): This test was disabled for a long time and has been
-    // atrophied. Fix it or remove it.
-    print('Atrophied test is disabled.');
-    return;
-    // ignore: dead_code
     final FragmentProgram program = await FragmentProgram.fromAsset('filter_shader.frag.iplr');
     final FragmentShader shader = program.fragmentShader();
     final recorder = PictureRecorder();
@@ -559,9 +554,16 @@ void main() async {
     );
     final Image image = await recorder.endRecording().toImage(1, 1);
     final ByteData data = (await image.toByteData())!;
-    final color = Color(data.buffer.asUint32List()[0]);
+    expect(data.lengthInBytes, 4);
 
-    expect(color, const Color(0xFF00FF00));
+    final Uint8List colorComponentsRGBA = data.buffer.asUint8List();
+    final color = Color.fromARGB(
+      colorComponentsRGBA[3],
+      colorComponentsRGBA[0],
+      colorComponentsRGBA[1],
+      colorComponentsRGBA[2],
+    );
+    expect(color, const Color(0xFF0000FF));
   });
 
   // For an explaination of the problem see https://github.com/flutter/flutter/issues/163302 .

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -553,6 +553,9 @@ void main() async {
         ..imageFilter = ImageFilter.shader(shader),
     );
     final Image image = await recorder.endRecording().toImage(1, 1);
+
+    // Image's byte data consists of color values for each pixel in RGBA format. The image is 1
+    // pixel, so the byte data is expected to be 4 bytes.
     final ByteData data = (await image.toByteData())!;
     expect(data.lengthInBytes, 4);
 
@@ -563,6 +566,8 @@ void main() async {
       colorComponentsRGBA[1],
       colorComponentsRGBA[2],
     );
+    // filter_shader.frag swaps red and blue color channels. The drawn color is red, so the expected
+    // result color is blue.
     expect(color, const Color(0xFF0000FF));
   });
 


### PR DESCRIPTION
The test draws a red pixel onto a canvas with an ImageFilter that swaps colors channels with
`frag_color = texture(u_texture, FlutterFragCoord().xy / u_size).bgra;`.

This PR fixes two things:
- When reading the output color, we can't construct a `Color` directly from the byte data. The byte data is RGBA. But the `Color` int constructor takes ARGB. So this was incorrectly reading the output color. Instead, read the RGBA components individually and use them to construct a color with `Color.fromARGB`.
- The input color red, when given to the color-swapping `bgra` shader, outputs blue (0xFF0000FF), not green (0xFF00FF00).

Fixes #180927

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
