### PR TITLE
Add WidgetStatesController support to ExpansionTile

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -485,35 +485,36 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
-  /// Controls the [WidgetStates] of the internal [ListTile] used by this
-  /// [ExpansionTile].
-  ///
-  /// This allows listening to and controlling states such as
-  /// [WidgetState.hovered], [WidgetState.focused], and [WidgetState.pressed]
-  /// for the tile's header.
-  ///
   /// {@tool snippet}
   /// This example listens for hover and press states on an [ExpansionTile].
   ///
   /// ```dart
-  /// final WidgetStatesController controller = WidgetStatesController();
+  /// class ExpansionTileStatesExample extends StatelessWidget {
+  ///   ExpansionTileStatesExample({super.key});
   ///
-  /// ExpansionTile(
-  ///   title: const Text('Settings'),
-  ///   statesController: controller,
-  /// );
+  ///   final WidgetStatesController controller = WidgetStatesController();
   ///
-  /// controller.addListener(() {
-  ///   if (controller.value.contains(WidgetState.hovered)) {
-  ///     debugPrint('Tile is hovered');
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     controller.addListener(() {
+  ///       if (controller.value.contains(WidgetState.hovered)) {
+  ///         debugPrint('Tile is hovered');
+  ///       }
+  ///     });
+  ///
+  ///     return MaterialApp(
+  ///       home: Scaffold(
+  ///         body: ExpansionTile(
+  ///           title: const Text('Settings'),
+  ///           statesController: controller,
+  ///         ),
+  ///       ),
+  ///     );
   ///   }
-  /// });
+  /// }
   /// ```
   /// {@end-tool}
-  ///
-  /// If null, the backing [ListTile] will create and manage its own
-  /// [WidgetStatesController].
-  final WidgetStatesController? statesController;
+
 
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -485,7 +485,6 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
-
   /// Controls the [WidgetStates] of the internal [ListTile] used by this
   /// [ExpansionTile].
   ///
@@ -515,8 +514,6 @@ class ExpansionTile extends StatefulWidget {
   /// If null, the backing [ListTile] will create and manage its own
   /// [WidgetStatesController].
   final WidgetStatesController? statesController;
-
-
 
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -493,14 +493,11 @@ class ExpansionTile extends StatefulWidget {
   /// [WidgetState.hovered], [WidgetState.focused], and [WidgetState.pressed]
   /// for the tile's header.
   ///
-  /// If null, the backing [ListTile] will create and manage its own
-  /// [WidgetStatesController].
-  ///
-  /// {@tool dartpad}
+  /// {@tool snippet}
   /// This example listens for hover and press states on an [ExpansionTile].
   ///
   /// ```dart
-  /// final controller = WidgetStatesController();
+  /// final WidgetStatesController controller = WidgetStatesController();
   ///
   /// ExpansionTile(
   ///   title: const Text('Settings'),
@@ -514,7 +511,11 @@ class ExpansionTile extends StatefulWidget {
   /// });
   /// ```
   /// {@end-tool}
+  ///
+  /// If null, the backing [ListTile] will create and manage its own
+  /// [WidgetStatesController].
   final WidgetStatesController? statesController;
+
 
 
   @override

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -493,6 +493,9 @@ class ExpansionTile extends StatefulWidget {
   /// [WidgetState.hovered], [WidgetState.focused], and [WidgetState.pressed]
   /// for the tile's header.
   ///
+  /// If null, the backing [ListTile] will create and manage its own
+  /// [WidgetStatesController].
+  ///
   /// {@tool dartpad}
   /// This example listens for hover and press states on an [ExpansionTile].
   ///
@@ -511,11 +514,7 @@ class ExpansionTile extends StatefulWidget {
   /// });
   /// ```
   /// {@end-tool}
-  ///
-  /// If null, the backing [ListTile] will create and manage its own
-  /// [WidgetStatesController].
   final WidgetStatesController? statesController;
-
 
 
   @override

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -493,9 +493,29 @@ class ExpansionTile extends StatefulWidget {
   /// [WidgetState.hovered], [WidgetState.focused], and [WidgetState.pressed]
   /// for the tile's header.
   ///
-  /// If null, the [ExpansionTile] creates and manages its own
+  /// {@tool dartpad}
+  /// This example listens for hover and press states on an [ExpansionTile].
+  ///
+  /// ```dart
+  /// final controller = WidgetStatesController();
+  ///
+  /// ExpansionTile(
+  ///   title: const Text('Settings'),
+  ///   statesController: controller,
+  /// );
+  ///
+  /// controller.addListener(() {
+  ///   if (controller.value.contains(WidgetState.hovered)) {
+  ///     debugPrint('Tile is hovered');
+  ///   }
+  /// });
+  /// ```
+  /// {@end-tool}
+  ///
+  /// If null, the backing [ListTile] will create and manage its own
   /// [WidgetStatesController].
   final WidgetStatesController? statesController;
+
 
 
   @override

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -485,37 +485,6 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
-  /// {@tool snippet}
-  /// This example listens for hover and press states on an [ExpansionTile].
-  ///
-  /// ```dart
-  /// class ExpansionTileStatesExample extends StatelessWidget {
-  ///   ExpansionTileStatesExample({super.key});
-  ///
-  ///   final WidgetStatesController controller = WidgetStatesController();
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     controller.addListener(() {
-  ///       if (controller.value.contains(WidgetState.hovered)) {
-  ///         debugPrint('Tile is hovered');
-  ///       }
-  ///     });
-  ///
-  ///     return MaterialApp(
-  ///       home: Scaffold(
-  ///         body: ExpansionTile(
-  ///           title: const Text('Settings'),
-  ///           statesController: controller,
-  ///         ),
-  ///       ),
-  ///     );
-  ///   }
-  /// }
-  /// ```
-  /// {@end-tool}
-
-
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -152,6 +152,7 @@ class ExpansionTile extends StatefulWidget {
     this.enabled = true,
     this.expansionAnimationStyle,
     this.internalAddSemanticForOnTap = false,
+    this.statesController,
   }) : assert(
          expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
          'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -484,6 +485,19 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
+
+  /// Controls the [WidgetStates] of the internal [ListTile] used by this
+  /// [ExpansionTile].
+  ///
+  /// This allows listening to and controlling states such as
+  /// [WidgetState.hovered], [WidgetState.focused], and [WidgetState.pressed]
+  /// for the tile's header.
+  ///
+  /// If null, the [ExpansionTile] creates and manages its own
+  /// [WidgetStatesController].
+  final WidgetStatesController? statesController;
+
+
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }
@@ -626,6 +640,7 @@ class _ExpansionTileState extends State<ExpansionTile> {
             : null,
         minTileHeight: widget.minTileHeight,
         internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
+        statesController: widget.statesController,
       ),
     );
 

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -485,6 +485,36 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
+  /// {@tool snippet}
+  /// This example listens for hover and press states on an [ExpansionTile].
+  ///
+  /// ```dart
+  /// class ExpansionTileStatesExample extends StatelessWidget {
+  ///   ExpansionTileStatesExample({super.key});
+  ///
+  ///   final WidgetStatesController controller = WidgetStatesController();
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     controller.addListener(() {
+  ///       if (controller.value.contains(WidgetState.hovered)) {
+  ///         debugPrint('Tile is hovered');
+  ///       }
+  ///     });
+  ///
+  ///     return MaterialApp(
+  ///       home: Scaffold(
+  ///         body: ExpansionTile(
+  ///           title: const Text('Settings'),
+  ///           statesController: controller,
+  ///         ),
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2073,4 +2073,22 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
     );
   });
+
+  testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
+  final controller = WidgetStatesController();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          title: const Text('Tile'),
+          statesController: controller,
+        ),
+      ),
+    ),
+  );
+
+  final listTile = tester.widget<ListTile>(find.byType(ListTile));
+  expect(listTile.statesController, controller);
+});
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2088,4 +2088,15 @@ void main() {
     final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
     expect(listTile.statesController, controller);
   });
+
+  testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: ExpansionTile(title: Text('Tile'))),
+      ),
+    );
+
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+    expect(listTile.statesController, isNull);
+  });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2088,7 +2088,7 @@ void main() {
     ),
   );
 
-  final listTile = tester.widget<ListTile>(find.byType(ListTile));
+  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
   expect(listTile.statesController, controller);
 });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2075,20 +2075,17 @@ void main() {
   });
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
-  final controller = WidgetStatesController();
+    final controller = WidgetStatesController();
 
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Material(
-        child: ExpansionTile(
-          title: const Text('Tile'),
-          statesController: controller,
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ExpansionTile(title: const Text('Tile'), statesController: controller),
         ),
       ),
-    ),
-  );
+    );
 
-  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
-  expect(listTile.statesController, controller);
-});
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+    expect(listTile.statesController, controller);
+  });
 }


### PR DESCRIPTION
This change exposes a `WidgetStatesController` on `ExpansionTile` and forwards
it to the backing `ListTile`, allowing callers to observe and control hovered,
pressed and focused states of the tile header.

Fixes #180161
