### PR TITLE
flutter clean: add --xcode-clean option to control Xcode cleaning

### DIFF
--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -58,7 +58,7 @@ class CleanCommand extends FlutterCommand {
     final FlutterProject flutterProject = FlutterProject.current();
     final Xcode? xcode = globals.xcode;
     if (xcode != null && xcode.isInstalledAndMeetsVersionCheck) {
-      final XcodeCleanScope xcodeCleanScope = switch (argResults?['xcode-clean'] as String) {
+      final XcodeCleanScope xcodeCleanScope = switch (argResults!['xcode-clean'] as String) {
         'workspace' => XcodeCleanScope.workspace,
         'skip' => XcodeCleanScope.skip,
         'app' => XcodeCleanScope.app,
@@ -125,7 +125,7 @@ class CleanCommand extends FlutterCommand {
           verbose: _verbose,
         );
       } else {
-        final Iterable<String> schemesToClean = switch (xcodeCleanScope) {
+        final List<String> schemesToClean = switch (xcodeCleanScope) {
           XcodeCleanScope.skip => const <String>[],
           XcodeCleanScope.workspace => projectInfo.schemes,
           XcodeCleanScope.app => _applicationSchemes(
@@ -202,7 +202,13 @@ class CleanCommand extends FlutterCommand {
     }
   }
 
-  Iterable<String> _applicationSchemes({
+  /// Returns schemes that are considered part of the application, and not a dependency.
+  ///
+  /// This is a heuristic that includes:
+  /// - The main scheme matching the host app name.
+  /// - Schemes that are flavors of the main scheme.
+  /// - Schemes that match a target name.
+  List<String> _applicationSchemes({
     required XcodeProjectInfo projectInfo,
     required XcodeBasedProject xcodeProject,
   }) {
@@ -226,6 +232,6 @@ class CleanCommand extends FlutterCommand {
 
       globals.printTrace('Skipping Xcode scheme "$scheme" (non-application scheme).');
       return false;
-    });
+    }).toList();
   }
 }

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -30,7 +30,7 @@ class CleanCommand extends FlutterCommand {
       help: 'Controls Xcode workspace cleanup.',
       allowed: <String>['workspace', 'app', 'skip'],
       allowedHelp: <String, String>{
-        'workspace': 'Clean all Xcode schemes (default).',
+        'workspace': 'Clean all Xcode schemes.',
         'app': 'Clean only application schemes.',
         'skip': 'Skip Xcode workspace cleaning.',
       },


### PR DESCRIPTION
This PR adds a new `--xcode-clean` option to `flutter clean` that allows controlling how Xcode workspaces are cleaned.

Large projects using Swift Package Manager can accumulate many Xcode schemes, which causes `flutter clean` to run `xcodebuild clean` serially for every scheme, significantly increasing execution time. This change allows users to limit Xcode cleaning to application-related schemes only, or skip Xcode workspace cleaning entirely when desired.

The default behavior remains unchanged: by default, all Xcode schemes continue to be cleaned to preserve existing workflows.

New options:
- `--xcode-clean=workspace` (default, current behavior): Clean all Xcode schemes.
- `--xcode-clean=app`: Clean only application schemes.
- `--xcode-clean=skip`: Skip Xcode workspace cleaning.

This provides a faster and more predictable cleanup experience for large SwiftPM-based workspaces while maintaining backward compatibility.

Fixes https://github.com/flutter/flutter/issues/173940, https://github.com/flutter/flutter/issues/180758

Tests: This change is test-exempt. It adds a new CLI option and preserves existing behavior by default.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] This PR is test-exempt.
- [x] All existing tests are passing.
