### PR TITLE
Remove MaterialButtons and Divider from draggable_scrollable_sheet_test.dart

### DIFF
--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -7,6 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'utils.dart';
+
+// TODO(navaronbracke): Remove MaterialApp and material import
+
 void main() {
   Widget boilerplateWidget(
     VoidCallback? onButtonPressed, {
@@ -34,7 +38,7 @@ void main() {
         child: Stack(
           key: stackKey,
           children: <Widget>[
-            TextButton(onPressed: onButtonPressed, child: const Text('TapHere')),
+            TestButton(onPressed: onButtonPressed, child: const Text('TapHere')),
             DraggableScrollableActuator(
               child: DraggableScrollableSheet(
                 controller: controller,
@@ -96,17 +100,13 @@ void main() {
                 );
                 return ScrollConfiguration(
                   behavior: behavior,
-                  child: ListView.separated(
+                  child: ListView.builder(
                     physics: const BouncingScrollPhysics(),
                     controller: scrollController,
-                    separatorBuilder: (_, _) => const Divider(),
                     itemCount: 100,
                     itemBuilder: (_, int index) => SizedBox(
                       height: 100,
-                      child: ColoredBox(
-                        color: Colors.primaries[index % Colors.primaries.length],
-                        child: Text('Item $index'),
-                      ),
+                      child: ColoredBox(color: getTestColor(index), child: Text('Item $index')),
                     ),
                   ),
                 );
@@ -411,17 +411,13 @@ void main() {
                 maxChildSize: 0.9,
                 expand: false,
                 builder: (_, ScrollController scrollController) {
-                  return ListView.separated(
+                  return ListView.builder(
                     physics: const BouncingScrollPhysics(),
                     controller: scrollController,
-                    separatorBuilder: (_, _) => const Divider(),
                     itemCount: 100,
                     itemBuilder: (_, int index) => SizedBox(
                       height: 100,
-                      child: ColoredBox(
-                        color: Colors.primaries[index % Colors.primaries.length],
-                        child: Text('Item $index'),
-                      ),
+                      child: ColoredBox(color: getTestColor(index), child: Text('Item $index')),
                     ),
                   );
                 },
@@ -803,41 +799,39 @@ void main() {
         MaterialApp(
           home: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
-              return Scaffold(
-                body: DraggableScrollableSheet(
-                  initialChildSize: 0.25,
-                  snap: true,
-                  snapSizes: const <double>[0.25, 0.5, 1.0],
-                  builder: (BuildContext context, ScrollController scrollController) {
-                    return PrimaryScrollController(
-                      controller: scrollController,
-                      child: AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 500),
-                        child: s.isEven
-                            ? ListView(
-                                children: <Widget>[
-                                  ElevatedButton(
-                                    onPressed: () => setState(() => ++s),
-                                    child: const Text('Switch to 2'),
-                                  ),
-                                  Container(height: 400, color: Colors.blue),
-                                ],
-                              )
-                            : SingleChildScrollView(
-                                child: Column(
-                                  children: <Widget>[
-                                    ElevatedButton(
-                                      onPressed: () => setState(() => ++s),
-                                      child: const Text('Switch to 1'),
-                                    ),
-                                    Container(height: 400, color: Colors.blue),
-                                  ],
+              return DraggableScrollableSheet(
+                initialChildSize: 0.25,
+                snap: true,
+                snapSizes: const <double>[0.25, 0.5, 1.0],
+                builder: (BuildContext context, ScrollController scrollController) {
+                  return PrimaryScrollController(
+                    controller: scrollController,
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 500),
+                      child: s.isEven
+                          ? ListView(
+                              children: <Widget>[
+                                TestButton(
+                                  onPressed: () => setState(() => ++s),
+                                  child: const Text('Switch to 2'),
                                 ),
+                                Container(height: 400, color: const Color(0xFF0000FF)),
+                              ],
+                            )
+                          : SingleChildScrollView(
+                              child: Column(
+                                children: <Widget>[
+                                  TestButton(
+                                    onPressed: () => setState(() => ++s),
+                                    child: const Text('Switch to 1'),
+                                  ),
+                                  Container(height: 400, color: const Color(0xFF0000FF)),
+                                ],
                               ),
-                      ),
-                    );
-                  },
-                ),
+                            ),
+                    ),
+                  );
+                },
               );
             },
           ),
@@ -1635,21 +1629,19 @@ void main() {
     addTearDown(controller.dispose);
     Widget buildFrame(ScrollPhysics? physics) {
       return MaterialApp(
-        home: Scaffold(
-          body: DraggableScrollableSheet(
-            controller: controller,
-            initialChildSize: 0.25,
-            builder: (BuildContext context, ScrollController scrollController) {
-              return ListView(
-                physics: physics,
-                controller: scrollController,
-                children: <Widget>[
-                  const Text('Drag me!'),
-                  Container(height: 10000.0, color: Colors.blue),
-                ],
-              );
-            },
-          ),
+        home: DraggableScrollableSheet(
+          controller: controller,
+          initialChildSize: 0.25,
+          builder: (BuildContext context, ScrollController scrollController) {
+            return ListView(
+              physics: physics,
+              controller: scrollController,
+              children: <Widget>[
+                const Text('Drag me!'),
+                Container(height: 10000.0, color: const Color(0xFF0000FF)),
+              ],
+            );
+          },
         ),
       );
     }
@@ -1681,8 +1673,8 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) => Scaffold(
-            body: DraggableScrollableSheet(
+          builder: (BuildContext context, StateSetter setState) {
+            return DraggableScrollableSheet(
               initialChildSize: 0.25,
               snap: true,
               snapSizes: const <double>[0.25, 0.5, 1.0],
@@ -1692,13 +1684,13 @@ void main() {
                   controller: scrollController,
                   children: <Widget>[
                     const Text('Drag me!'),
-                    ElevatedButton(onPressed: () => setState(() {}), child: const Text('Rebuild')),
-                    Container(height: 10000, color: Colors.blue),
+                    TestButton(onPressed: () => setState(() {}), child: const Text('Rebuild')),
+                    Container(height: 10000, color: const Color(0xFF0000FF)),
                   ],
                 );
               },
-            ),
-          ),
+            );
+          },
         ),
       ),
     );
@@ -1729,8 +1721,8 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) => Scaffold(
-            body: DraggableScrollableSheet(
+          builder: (BuildContext context, StateSetter setState) {
+            return DraggableScrollableSheet(
               initialChildSize: 0.25,
               snap: true,
               snapSizes: const <double>[0.25, 0.5, 1.0],
@@ -1739,18 +1731,18 @@ void main() {
                 return ListView(
                   controller: scrollController,
                   children: <Widget>[
-                    ElevatedButton(
+                    TestButton(
                       onPressed: () => setState(() {
                         controller = controller2;
                       }),
                       child: const Text('Switch controller'),
                     ),
-                    Container(height: 10000, color: Colors.blue),
+                    Container(height: 10000, color: const Color(0xFF0000FF)),
                   ],
                 );
               },
-            ),
-          ),
+            );
+          },
         ),
       ),
     );
@@ -1789,8 +1781,8 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) => Scaffold(
-            body: DraggableScrollableSheet(
+          builder: (BuildContext context, StateSetter setState) {
+            return DraggableScrollableSheet(
               initialChildSize: 0.25,
               snap: true,
               snapSizes: const <double>[0.25, 0.5, 1.0],
@@ -1799,18 +1791,18 @@ void main() {
                 return ListView(
                   controller: scrollController,
                   children: <Widget>[
-                    ElevatedButton(
+                    TestButton(
                       onPressed: () => setState(() {
                         controller = controller2;
                       }),
                       child: const Text('Switch controller'),
                     ),
-                    Container(height: 10000, color: Colors.blue),
+                    Container(height: 10000, color: const Color(0xFF0000FF)),
                   ],
                 );
               },
-            ),
-          ),
+            );
+          },
         ),
       ),
     );
@@ -1918,44 +1910,43 @@ void main() {
       final children = List<Widget>.generate(12, (int index) {
         return Padding(
           padding: const EdgeInsets.only(bottom: 10),
-          child: Container(color: Colors.green, height: 100, child: Text('Item $index')),
+          child: Container(color: const Color(0xFF00FF00), height: 100, child: Text('Item $index')),
         );
       });
-      children.insert(0, Container(color: Colors.green, height: 100));
+      children.insert(0, Container(color: const Color(0xFF00FF00), height: 100));
 
       await tester.pumpWidget(
         MaterialApp(
           home: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
-              return Scaffold(
-                body: DraggableScrollableSheet(
-                  initialChildSize: 0.25,
-                  snap: true,
-                  snapSizes: const <double>[0.25, 0.5, 1.0],
-                  controller: controller,
-                  builder: (BuildContext context, ScrollController scrollController) {
-                    return NotificationListener<DraggableScrollableNotification>(
-                      onNotification: (DraggableScrollableNotification notification) {
-                        lastExtent = notification.extent;
-                        return false;
-                      },
-                      child: ColoredBox(
-                        color: const Color(0xFFABCDEF),
-                        child: CustomScrollView(
-                          physics: const BouncingScrollPhysics(),
-                          controller: scrollController,
-                          slivers: <Widget>[
-                            SliverList(
-                              delegate: SliverChildBuilderDelegate((_, int index) {
-                                return children[index];
-                              }, childCount: children.length),
+              return DraggableScrollableSheet(
+                initialChildSize: 0.25,
+                snap: true,
+                snapSizes: const <double>[0.25, 0.5, 1.0],
+                controller: controller,
+                builder: (BuildContext context, ScrollController scrollController) {
+                  return NotificationListener<DraggableScrollableNotification>(
+                    onNotification: (DraggableScrollableNotification notification) {
+                      lastExtent = notification.extent;
+                      return false;
+                    },
+                    child: ColoredBox(
+                      color: const Color(0xFFABCDEF),
+                      child: CustomScrollView(
+                        physics: const BouncingScrollPhysics(),
+                        controller: scrollController,
+                        slivers: <Widget>[
+                          SliverList(
+                            delegate: SliverChildBuilderDelegate(
+                              (_, int index) => children[index],
+                              childCount: children.length,
                             ),
-                          ],
-                        ),
+                          ),
+                        ],
                       ),
-                    );
-                  },
-                ),
+                    ),
+                  );
+                },
               );
             },
           ),

--- a/packages/flutter/test/widgets/utils.dart
+++ b/packages/flutter/test/widgets/utils.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 ///
 /// The returned color will be fully opaque,
 /// but the [Color.r], [Color.g], and [Color.b] channels
-/// will each be randomized between `00` and `FF`.
+/// will vary sequentially based on index, cycling every sixth integer.
 Color getTestColor(int index) {
   const colors = [
     Color(0xFFFF0000),

--- a/packages/flutter/test/widgets/utils.dart
+++ b/packages/flutter/test/widgets/utils.dart
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file defines basic widgets for use in tests for Widgets in `flutter/widgets`.
+
+import 'package:flutter/widgets.dart';
+
+/// Get a color for use in a widget test.
+///
+/// The returned color will be fully opaque,
+/// but the [Color.r], [Color.g], and [Color.b] channels
+/// will each be randomized between `00` and `FF`.
+Color getTestColor(int index) {
+  const colors = [
+    Color(0xFFFF0000),
+    Color(0xFF00FF00),
+    Color(0xFF0000FF),
+    Color(0xFFFFFF00),
+    Color(0xFFFF00FF),
+    Color(0xFF00FFFF),
+  ];
+
+  return colors[index % colors.length];
+}
+
+// TODO(justinmc): replace with `RawButton` or equivalent when available.
+/// A very basic button for use in widget tests.
+class TestButton extends StatelessWidget {
+  const TestButton({
+    required this.child,
+    this.focusNode,
+    this.autofocus = false,
+    this.onPressed,
+    super.key,
+  });
+
+  final bool autofocus;
+  final FocusNode? focusNode;
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: onPressed != null,
+      onTap: onPressed,
+      child: FocusableActionDetector(
+        enabled: onPressed != null,
+        focusNode: focusNode,
+        autofocus: autofocus,
+        child: GestureDetector(onTap: onPressed, child: child),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR removes the MaterialButtons and Divider from test/widgets/draggable_scrollable_sheet_test.dart
I also replaced some usages of WidgetsApp that did not use `WidgetsApp(home: home)` with MaterialApp.
These usages can be replaced once https://github.com/flutter/flutter/pull/180456 provides `TestWidgetsApp`.

Part of https://github.com/flutter/flutter/issues/177415
Part of https://github.com/flutter/flutter/issues/180501

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
