### PR TITLE
Remove divider from widgets tests

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -145,7 +145,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/app_test.dart',
     'packages/flutter/test/widgets/widget_inspector_test.dart',
     'packages/flutter/test/widgets/radio_group_test.dart',
-    'packages/flutter/test/widgets/list_view_test.dart',
     'packages/flutter/test/widgets/sliver_resizing_header_test.dart',
     'packages/flutter/test/widgets/navigator_replacement_test.dart',
     'packages/flutter/test/widgets/implicit_animations_test.dart',

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
@@ -112,7 +112,7 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/100451
-  testWidgets('ListView.separator respects findChildIndexCallback', (WidgetTester tester) async {
+  testWidgets('ListView.separated respects findChildIndexCallback', (WidgetTester tester) async {
     var finderCalled = false;
     var itemCount = 7;
     late StateSetter stateSetter;
@@ -131,7 +131,7 @@ void main() {
                 finderCalled = true;
                 return null;
               },
-              separatorBuilder: (BuildContext _, int _) => const Divider(),
+              separatorBuilder: (BuildContext _, int _) => const SizedBox(),
             );
           },
         ),
@@ -162,7 +162,7 @@ void main() {
         child: ListView(
           itemExtent: 200.0,
           children: List<Widget>.generate(20, (int i) {
-            return ColoredBox(color: Colors.green, child: Text('$i'));
+            return ColoredBox(color: const Color(0xFF00FF00), child: Text('$i'));
           }),
         ),
       ),
@@ -961,7 +961,7 @@ void main() {
         child: ListView.separated(
           itemCount: 10,
           itemBuilder: (BuildContext _, int _) => Container(height: 2000.0),
-          separatorBuilder: (BuildContext _, int _) => const Divider(),
+          separatorBuilder: (BuildContext _, int _) => const SizedBox(),
           clipBehavior: Clip.antiAlias,
         ),
       ),

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -332,7 +332,7 @@ void main() {
           padding: EdgeInsets.zero,
           keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           itemCount: focusNodes.length,
-          separatorBuilder: (BuildContext context, int index) => const Divider(),
+          separatorBuilder: (BuildContext context, int index) => const SizedBox(),
           itemBuilder: (BuildContext context, int index) {
             return Container(
               height: 50,
@@ -670,7 +670,7 @@ void main() {
         child: ListView.separated(
           padding: EdgeInsets.zero,
           itemCount: focusNodes.length,
-          separatorBuilder: (BuildContext context, int index) => const Divider(),
+          separatorBuilder: (BuildContext context, int index) => const SizedBox(),
           itemBuilder: (BuildContext context, int index) {
             return Container(
               height: 50,
@@ -1441,6 +1441,13 @@ void main() {
   testWidgets('separatorBuilder must return something', (WidgetTester tester) async {
     const listOfValues = <String>['ALPHA', 'BETA', 'GAMMA', 'DELTA'];
 
+    Widget buildDivider() {
+      return Padding(
+        padding: const EdgeInsets.all(4),
+        child: Container(color: const Color(0xFF000000), height: 4, width: double.infinity),
+      );
+    }
+
     Widget buildFrame(Widget firstSeparator) {
       return MaterialApp(
         home: Material(
@@ -1449,11 +1456,7 @@ void main() {
               return Text(listOfValues[index]);
             },
             separatorBuilder: (BuildContext context, int index) {
-              if (index == 0) {
-                return firstSeparator;
-              } else {
-                return const Divider();
-              }
+              return index == 0 ? firstSeparator : buildDivider();
             },
             itemCount: listOfValues.length,
           ),
@@ -1461,8 +1464,8 @@ void main() {
       );
     }
 
-    // A separatorBuilder that always returns a Divider is fine
-    await tester.pumpWidget(buildFrame(const Divider()));
+    // A separatorBuilder that always returns a divider is fine
+    await tester.pumpWidget(buildFrame(buildDivider()));
     expect(tester.takeException(), isNull);
   });
 
@@ -1513,7 +1516,7 @@ void main() {
               if (index == 0 && throwOnFirstSeparator) {
                 throw Exception('separatorBuilder fail');
               }
-              return const Divider();
+              return const SizedBox();
             },
             itemCount: listOfValues.length,
           ),
@@ -1831,7 +1834,7 @@ void main() {
             itemBuilder: (BuildContext context, int index) {
               return ItemWidget(key: ValueKey<String>(itemList[index]), value: itemList[index]);
             },
-            separatorBuilder: (BuildContext context, int index) => const Divider(),
+            separatorBuilder: (BuildContext context, int index) => const SizedBox(),
           ),
         ),
       );
@@ -1880,7 +1883,7 @@ void main() {
                 itemBuilder: (BuildContext context, int index) {
                   return ItemWidget(key: ValueKey<String>(itemList[index]), value: itemList[index]);
                 },
-                separatorBuilder: (BuildContext context, int index) => const Divider(),
+                separatorBuilder: (BuildContext context, int index) => const SizedBox(),
               ),
             ],
           ),


### PR DESCRIPTION
This PR removes `Divider` usages from `test/widgets/scroll_view_test.dart` and `test/widgets/list_view_test.dart`.
Usages of `Divider()` still exist under `examples/api` and in code samples under `lib/widgets`, though.

Part of https://github.com/flutter/flutter/issues/177415
Part of https://github.com/flutter/flutter/issues/180501

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
