### PR TITLE
Linux build hooks: Read compiler config from CMakeCache.txt

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/hook_runner_native.dart
@@ -43,7 +43,7 @@ class FlutterHookRunnerNative implements FlutterHookRunner {
       targetPlatform: targetPlatform,
       projectUri: environment.projectDir.uri,
       fileSystem: environment.fileSystem,
-      buildCodeAssets: false,
+      buildCodeAssets: null,
       buildDataAssets: true,
     );
 

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -59,7 +59,7 @@ class DartBuild extends Target {
       targetPlatform: targetPlatform,
       projectUri: projectUri,
       fileSystem: fileSystem,
-      buildCodeAssets: true,
+      buildCodeAssets: BuildCodeAssetsOptions(appBuildDirectory: environment.outputDir),
       buildDataAssets: true,
     );
     final File dartHookResultJsonFile = environment.buildDir.childFile(dartHookResultFilename);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -2,82 +2,92 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:code_assets/code_assets.dart';
 
 import '../../../base/common.dart';
 import '../../../base/file_system.dart';
-import '../../../base/io.dart';
 import '../../../globals.dart' as globals;
 
-/// Returns a [CCompilerConfig] matching a toolchain that would be used to compile the main app with
-/// CMake on Linux.
+/// Returns a [CCompilerConfig] suitable for compiling code assets for Linux apps.
 ///
-/// Flutter expects `clang++` to be on the path on Linux hosts, which this uses to search for the
-/// accompanying `clang`, `ar`, and `ld`.
+/// For app builds, [cmakeDirectory] must be given and point to the CMake build root for the app,
+/// e.g. `build/linux/x64/debug`. The compiler configuration is resolved by reading the
+/// `CMakeCache.txt` file in that directory to ensure we use the same compiler as the main app.
 ///
-/// If [throwIfNotFound] is false, this is allowed to fail (in which case `null`) is returned. This
-/// is used for `flutter test` setups, where no main app is compiled and we thus don't want a
-/// `clang` toolchain to be a requirement.
-Future<CCompilerConfig?> cCompilerConfigLinux({required bool throwIfNotFound}) async {
-  const kClangPlusPlusBinary = 'clang++';
-  // NOTE: these binaries sometimes have different names depending on the installation;
-  // thus, we check for a few possible options (in order of preference).
-  const kClangBinaryOptions = ['clang'];
-  const kArBinaryOptions = ['llvm-ar', 'ar'];
-  const kLdBinaryOptions = ['ld.lld', 'ld'];
-
-  final ProcessResult whichResult = await globals.processManager.run(<String>[
-    'which',
-    kClangPlusPlusBinary,
-  ]);
-  if (whichResult.exitCode != 0) {
-    if (throwIfNotFound) {
-      throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
-    } else {
-      return null;
-    }
-  }
-  File clangPpFile = globals.fs.file((whichResult.stdout as String).trim());
-  clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
-
-  final Directory clangDir = clangPpFile.parent;
-  Uri? findExecutable({required List<String> possibleExecutableNames, required Directory path}) {
-    final Uri? found = _findExecutableIfExists(
-      possibleExecutableNames: possibleExecutableNames,
-      path: path,
-    );
-
-    if (found == null && throwIfNotFound) {
-      throwToolExit('Failed to find any of $possibleExecutableNames in $path');
-    }
-
-    return found;
-  }
-
-  final Uri? linker = findExecutable(path: clangDir, possibleExecutableNames: kLdBinaryOptions);
-  final Uri? compiler = findExecutable(
-    path: clangDir,
-    possibleExecutableNames: kClangBinaryOptions,
-  );
-  final Uri? archiver = findExecutable(path: clangDir, possibleExecutableNames: kArBinaryOptions);
-
-  if (linker == null || compiler == null || archiver == null) {
-    assert(!throwIfNotFound); // otherwise, findExecutable would have thrown
+/// Flutter also builds code assets for widget tests. Since there is no app build in that context,
+/// [cmakeDirectory] should be set to null for those builds.
+Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async {
+  if (cmakeDirectory == null) {
+    // No CMake reference (e.g. for a widget test). Hooks can resolve to any
+    // compiler.
     return null;
   }
-  return CCompilerConfig(linker: linker, compiler: compiler, archiver: archiver);
+
+  // For app builds, use the same compiler as the native/GTK parts of the app.
+  final File cmakeCacheTxt = cmakeDirectory.childFile('CMakeCache.txt');
+  if (!cmakeCacheTxt.existsSync()) {
+    throwToolExit(
+      'Could not read compiler configurations for build hooks, expected ${cmakeCacheTxt.path} to exist.',
+    );
+  }
+
+  const archiverVariable = 'CMAKE_AR';
+  const compilerVariable = 'CMAKE_CXX_COMPILER';
+  const linkerVariable = 'CMAKE_LINKER';
+
+  String? archiver;
+  String? cxxCompiler;
+  String? linker;
+
+  final String cmakeCacheContents = await cmakeCacheTxt.readAsString();
+  for (final String line in const LineSplitter().convert(cmakeCacheContents)) {
+    final RegExpMatch? match = _cmakeCacheEntry.firstMatch(line);
+    if (match != null) {
+      final String variable = match.group(1)!;
+      final String value = match.group(2)!;
+
+      switch (variable) {
+        case archiverVariable:
+          archiver = value;
+        case compilerVariable:
+          cxxCompiler = value;
+        case linkerVariable:
+          linker = value;
+      }
+    }
+  }
+
+  Uri requireTool(String? found, String variableName) {
+    if (found == null) {
+      throwToolExit('Expected ${cmakeCacheTxt.path} to contain an entry for $variableName');
+    }
+
+    final File file = globals.fs.file(found);
+    if (!file.existsSync()) {
+      throwToolExit(
+        'Expected ${file.path} (read from $variableName in ${cmakeCacheTxt.path}) to exist.',
+      );
+    }
+
+    return file.uri;
+  }
+
+  // Find clang next to the clang++ we use in CMake
+  File clangPpFile = globals.fs.file(requireTool(cxxCompiler, compilerVariable));
+  clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
+  final File clangFile = clangPpFile.parent.childFile('clang');
+  if (!clangFile.existsSync()) {
+    throwToolExit('Expected to find clang next to ${clangPpFile.path}');
+  }
+
+  return CCompilerConfig(
+    compiler: clangFile.uri,
+    linker: requireTool(linker, linkerVariable),
+    archiver: requireTool(archiver, linkerVariable),
+  );
 }
 
-/// Searches for an executable with a name in [possibleExecutableNames]
-/// at [path] and returns the first one it finds, if one is found.
-/// Otherwise, returns `null`.
-Uri? _findExecutableIfExists({
-  required List<String> possibleExecutableNames,
-  required Directory path,
-}) {
-  return possibleExecutableNames
-      .map((execName) => path.childFile(execName))
-      .where((file) => file.existsSync())
-      .map((file) => file.uri)
-      .firstOrNull;
-}
+// Format: `VARIABLE_NAME:TYPE=value`;
+final RegExp _cmakeCacheEntry = RegExp(r'^(\w+):\w+=(.*)$');

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:code_assets/code_assets.dart';
 
 import '../../../base/common.dart';
 import '../../../base/file_system.dart';
+import '../../../convert.dart';
 import '../../../globals.dart' as globals;
 
 /// Returns a [CCompilerConfig] suitable for compiling code assets for Linux apps.
@@ -85,7 +84,7 @@ Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async
   return CCompilerConfig(
     compiler: clangFile.uri,
     linker: requireTool(linker, linkerVariable),
-    archiver: requireTool(archiver, linkerVariable),
+    archiver: requireTool(archiver, archiverVariable),
   );
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -33,6 +33,9 @@ Future<CCompilerConfig?> cCompilerConfigLinux({Directory? cmakeDirectory}) async
   }
 
   const archiverVariable = 'CMAKE_AR';
+  // Flutter CMake projects use `LANGUAGES CXX`, so we can't read a configured C
+  // compiler directly. We read the C++ compiler and infer the C compiler from
+  // there.
   const compilerVariable = 'CMAKE_CXX_COMPILER';
   const linkerVariable = 'CMAKE_LINKER';
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -85,28 +85,13 @@ Future<DartHooksResult> runFlutterSpecificHooks({
     targetPlatform == TargetPlatform.tester,
   );
 
-  // When building for Linux, we need access to the native build directory to
-  // read compiler options from CMakeLists.txt that are then forwarded to build
-  // hooks.
-  Directory? nativeBuildDirectory;
-  if (buildCodeAssets?.appBuildDirectory case final appBuildDirectory?) {
-    if (targetPlatform
-        case TargetPlatform.linux_x64 ||
-            TargetPlatform.linux_arm64 ||
-            TargetPlatform.linux_riscv64) {
-      nativeBuildDirectory = appBuildDirectory
-          .childDirectory('linux')
-          .childDirectory(targetPlatform.simpleName)
-          .childDirectory(buildMode.cliName);
-    }
-  }
-
   final List<AssetBuildTarget> targets = AssetBuildTarget.targetsFor(
     targetPlatform: targetPlatform,
+    buildMode: buildMode,
     environmentDefines: environmentDefines,
     fileSystem: fileSystem,
     supportedAssetTypes: supportedAssetTypes,
-    nativeBuildDirectory: nativeBuildDirectory,
+    buildDirectory: buildCodeAssets?.appBuildDirectory,
   );
 
   if (supportedAssetTypes.contains(SupportedAssetTypes.codeAssets)) {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -44,6 +44,21 @@ class FlutterCodeAsset {
 /// support more asset types in the future.
 enum SupportedAssetTypes { codeAssets, dataAssets }
 
+/// Hook options specific to building code assets.
+final class BuildCodeAssetsOptions {
+  const BuildCodeAssetsOptions({required this.appBuildDirectory});
+
+  /// The build directory of the main app build, e.g. `/path/to/app/build`.
+  ///
+  /// Depending on the target platform, we may try to lookup compiler options
+  /// based on files in this directory to align code assets toolchains with the
+  /// main app build.
+  ///
+  /// Null for hook invocations not associated with an app build (e.g. widget
+  /// tests).
+  final Directory? appBuildDirectory;
+}
+
 /// Invokes the build of all transitive Dart package hooks and prepares assets
 /// to be included in the native build.
 Future<DartHooksResult> runFlutterSpecificHooks({
@@ -52,7 +67,7 @@ Future<DartHooksResult> runFlutterSpecificHooks({
   required TargetPlatform targetPlatform,
   required Uri projectUri,
   required FileSystem fileSystem,
-  required bool buildCodeAssets,
+  required BuildCodeAssetsOptions? buildCodeAssets,
   required bool buildDataAssets,
 }) async {
   if (!await _hookRunRequired(buildRunner)) {
@@ -60,14 +75,38 @@ Future<DartHooksResult> runFlutterSpecificHooks({
   }
 
   final supportedAssetTypes = <SupportedAssetTypes>[
-    if (featureFlags.isNativeAssetsEnabled && buildCodeAssets) SupportedAssetTypes.codeAssets,
+    if (featureFlags.isNativeAssetsEnabled && buildCodeAssets != null)
+      SupportedAssetTypes.codeAssets,
     if (featureFlags.isDartDataAssetsEnabled && buildDataAssets) SupportedAssetTypes.dataAssets,
   ];
+
+  final BuildMode buildMode = _getBuildMode(
+    environmentDefines,
+    targetPlatform == TargetPlatform.tester,
+  );
+
+  // When building for Linux, we need access to the native build directory to
+  // read compiler options from CMakeLists.txt that are then forwarded to build
+  // hooks.
+  Directory? nativeBuildDirectory;
+  if (buildCodeAssets?.appBuildDirectory case final appBuildDirectory?) {
+    if (targetPlatform
+        case TargetPlatform.linux_x64 ||
+            TargetPlatform.linux_arm64 ||
+            TargetPlatform.linux_riscv64) {
+      nativeBuildDirectory = appBuildDirectory
+          .childDirectory('linux')
+          .childDirectory(targetPlatform.simpleName)
+          .childDirectory(buildMode.cliName);
+    }
+  }
+
   final List<AssetBuildTarget> targets = AssetBuildTarget.targetsFor(
     targetPlatform: targetPlatform,
     environmentDefines: environmentDefines,
     fileSystem: fileSystem,
     supportedAssetTypes: supportedAssetTypes,
+    nativeBuildDirectory: nativeBuildDirectory,
   );
 
   // This is ugly, but sadly necessary as fetching the cCompilerConfig is async,
@@ -76,10 +115,6 @@ Future<DartHooksResult> runFlutterSpecificHooks({
     await buildRunner.setCCompilerConfig(target);
   }
 
-  final BuildMode buildMode = _getBuildMode(
-    environmentDefines,
-    targetPlatform == TargetPlatform.tester,
-  );
   final bool linkingEnabled = _nativeAssetsLinkingEnabled(buildMode);
 
   return _runDartHooks(

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -109,10 +109,12 @@ Future<DartHooksResult> runFlutterSpecificHooks({
     nativeBuildDirectory: nativeBuildDirectory,
   );
 
-  // This is ugly, but sadly necessary as fetching the cCompilerConfig is async,
-  // while using it in native_assets_builder is not.
-  for (final CodeAssetTarget target in targets.whereType<CodeAssetTarget>()) {
-    await buildRunner.setCCompilerConfig(target);
+  if (supportedAssetTypes.contains(SupportedAssetTypes.codeAssets)) {
+    // This is ugly, but sadly necessary as fetching the cCompilerConfig is async,
+    // while using it in native_assets_builder is not.
+    for (final CodeAssetTarget target in targets.whereType<CodeAssetTarget>()) {
+      await buildRunner.setCCompilerConfig(target);
+    }
   }
 
   final bool linkingEnabled = _nativeAssetsLinkingEnabled(buildMode);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -4,7 +4,7 @@
 
 import 'package:code_assets/code_assets.dart';
 import 'package:data_assets/data_assets.dart';
-import 'package:file/file.dart' show FileSystem;
+import 'package:file/file.dart' show Directory, FileSystem;
 import 'package:hooks/hooks.dart';
 
 import '../../base/common.dart' show throwToolExit;
@@ -56,21 +56,25 @@ sealed class AssetBuildTarget {
   ///
   /// It needs access to other parameters such as the [fileSystem] or
   /// [environmentDefines] to retrieve options for some of the targets.
+  ///
+  /// When building for Linux, [nativeBuildDirectory] should point to the CMake
+  /// build (e.g. `build/linux/x64/release/`).
   static List<AssetBuildTarget> targetsFor({
     required TargetPlatform targetPlatform,
     required Map<String, String> environmentDefines,
     required FileSystem fileSystem,
     required List<SupportedAssetTypes> supportedAssetTypes,
+    required Directory? nativeBuildDirectory,
   }) {
     switch (targetPlatform) {
       case TargetPlatform.windows_x64:
         return _windowsTarget(supportedAssetTypes, Architecture.x64);
       case TargetPlatform.linux_x64:
-        return _linuxTarget(supportedAssetTypes, Architecture.x64);
+        return _linuxTarget(supportedAssetTypes, Architecture.x64, nativeBuildDirectory);
       case TargetPlatform.linux_arm64:
-        return _linuxTarget(supportedAssetTypes, Architecture.arm64);
+        return _linuxTarget(supportedAssetTypes, Architecture.arm64, nativeBuildDirectory);
       case TargetPlatform.linux_riscv64:
-        return _linuxTarget(supportedAssetTypes, Architecture.riscv64);
+        return _linuxTarget(supportedAssetTypes, Architecture.riscv64, nativeBuildDirectory);
       case TargetPlatform.windows_arm64:
         return _windowsTarget(supportedAssetTypes, Architecture.arm64);
       case TargetPlatform.darwin:
@@ -96,9 +100,14 @@ sealed class AssetBuildTarget {
   static List<AssetBuildTarget> _linuxTarget(
     List<SupportedAssetTypes> supportedAssetTypes,
     Architecture architecture,
+    Directory? nativeBuildDirectory,
   ) {
     return <AssetBuildTarget>[
-      LinuxAssetTarget(architecture: architecture, supportedAssetTypes: supportedAssetTypes),
+      LinuxAssetTarget(
+        architecture: architecture,
+        supportedAssetTypes: supportedAssetTypes,
+        cmakeBuildDirectory: nativeBuildDirectory,
+      ),
     ];
   }
 
@@ -243,12 +252,26 @@ class WindowsAssetTarget extends CodeAssetTarget {
 }
 
 final class LinuxAssetTarget extends CodeAssetTarget {
-  LinuxAssetTarget({required super.supportedAssetTypes, required super.architecture})
-    : super(os: OS.linux);
+  LinuxAssetTarget({
+    required super.supportedAssetTypes,
+    required super.architecture,
+    required this.cmakeBuildDirectory,
+  }) : super(os: OS.linux);
+
+  /// Null if this target is used for widget tests where we run code assets
+  /// without an app to build.
+  final Directory? cmakeBuildDirectory;
 
   @override
-  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async =>
-      cCompilerConfigSync = await cCompilerConfigLinux(throwIfNotFound: mustMatchAppBuild);
+  Future<void> setCCompilerConfig({bool mustMatchAppBuild = true}) async {
+    if (cmakeBuildDirectory == null && mustMatchAppBuild) {
+      throw StateError('Missing CMake build directory on LinuxAssetTarget');
+    }
+
+    cCompilerConfigSync = await cCompilerConfigLinux(
+      cmakeDirectory: mustMatchAppBuild ? cmakeBuildDirectory! : null,
+    );
+  }
 
   @override
   List<ProtocolExtension> get extensions => <ProtocolExtension>[
@@ -358,6 +381,7 @@ final class FlutterTesterAssetTarget extends CodeAssetTarget {
       OS.linux => LinuxAssetTarget(
         supportedAssetTypes: supportedAssetTypes,
         architecture: architecture,
+        cmakeBuildDirectory: null,
       ),
       OS.windows => WindowsAssetTarget(
         supportedAssetTypes: supportedAssetTypes,

--- a/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/targets.dart
@@ -11,6 +11,7 @@ import '../../base/common.dart' show throwToolExit;
 import '../../build_info.dart'
     show
         AndroidArch,
+        BuildMode,
         DarwinArch,
         EnvironmentType,
         TargetPlatform,
@@ -57,24 +58,26 @@ sealed class AssetBuildTarget {
   /// It needs access to other parameters such as the [fileSystem] or
   /// [environmentDefines] to retrieve options for some of the targets.
   ///
-  /// When building for Linux, [nativeBuildDirectory] should point to the CMake
-  /// build (e.g. `build/linux/x64/release/`).
+  /// When building for Linux, [buildDirectory] should point to the build
+  /// directory of the app (e.g. `build/`). It is used to infer configured
+  /// compilers by reading `CMakeCache.txt`.
   static List<AssetBuildTarget> targetsFor({
     required TargetPlatform targetPlatform,
+    required BuildMode buildMode,
     required Map<String, String> environmentDefines,
     required FileSystem fileSystem,
     required List<SupportedAssetTypes> supportedAssetTypes,
-    required Directory? nativeBuildDirectory,
+    required Directory? buildDirectory,
   }) {
     switch (targetPlatform) {
       case TargetPlatform.windows_x64:
         return _windowsTarget(supportedAssetTypes, Architecture.x64);
       case TargetPlatform.linux_x64:
-        return _linuxTarget(supportedAssetTypes, Architecture.x64, nativeBuildDirectory);
+        return _linuxTarget(supportedAssetTypes, Architecture.x64, buildMode, buildDirectory);
       case TargetPlatform.linux_arm64:
-        return _linuxTarget(supportedAssetTypes, Architecture.arm64, nativeBuildDirectory);
+        return _linuxTarget(supportedAssetTypes, Architecture.arm64, buildMode, buildDirectory);
       case TargetPlatform.linux_riscv64:
-        return _linuxTarget(supportedAssetTypes, Architecture.riscv64, nativeBuildDirectory);
+        return _linuxTarget(supportedAssetTypes, Architecture.riscv64, buildMode, buildDirectory);
       case TargetPlatform.windows_arm64:
         return _windowsTarget(supportedAssetTypes, Architecture.arm64);
       case TargetPlatform.darwin:
@@ -100,13 +103,22 @@ sealed class AssetBuildTarget {
   static List<AssetBuildTarget> _linuxTarget(
     List<SupportedAssetTypes> supportedAssetTypes,
     Architecture architecture,
-    Directory? nativeBuildDirectory,
+    BuildMode buildMode,
+    Directory? buildDirectory,
   ) {
+    Directory? cmakeBuildDirectory;
+    if (buildDirectory != null) {
+      cmakeBuildDirectory = buildDirectory
+          .childDirectory('linux')
+          .childDirectory(architecture.name)
+          .childDirectory(buildMode.cliName);
+    }
+
     return <AssetBuildTarget>[
       LinuxAssetTarget(
         architecture: architecture,
         supportedAssetTypes: supportedAssetTypes,
-        cmakeBuildDirectory: nativeBuildDirectory,
+        cmakeBuildDirectory: cmakeBuildDirectory,
       ),
     ];
   }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -77,7 +77,10 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
     targetPlatform: TargetPlatform.tester,
     projectUri: projectUri,
     fileSystem: globals.fs,
-    buildCodeAssets: true,
+    buildCodeAssets: const BuildCodeAssetsOptions(
+      // We're in tests, so there is no app build directory
+      appBuildDirectory: null,
+    ),
     buildDataAssets: true,
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -91,7 +91,7 @@ void main() {
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
-          buildCodeAssets: true,
+          buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
           buildDataAssets: true,
         );
         await installCodeAssets(
@@ -135,7 +135,7 @@ void main() {
         projectUri: projectUri,
         fileSystem: fileSystem,
         buildRunner: _BuildRunnerWithoutNdk(),
-        buildCodeAssets: true,
+        buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
         buildDataAssets: true,
       );
       expect(
@@ -162,7 +162,7 @@ void main() {
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: _BuildRunnerWithoutNdk(packagesWithNativeAssetsResult: <String>['bar']),
-          buildCodeAssets: true,
+          buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
           buildDataAssets: true,
         ),
         isA<DartHooksResult>(),

--- a/packages/flutter_tools/test/general.shard/isolated/data_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/data_assets_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/build_info.dart' show BuildMode, TargetPlatfor
 import 'package:flutter_tools/src/build_system/build_system.dart' show Environment;
 import 'package:flutter_tools/src/features.dart' show FeatureFlags;
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart'
-    show runFlutterSpecificHooks;
+    show BuildCodeAssetsOptions, runFlutterSpecificHooks;
 
 import '../../src/common.dart' show expect, returnsNormally, setUp, throwsToolExit;
 import '../../src/context.dart'
@@ -64,7 +64,7 @@ void main() {
           buildRunner: FakeFlutterNativeAssetsBuildRunner(
             packagesWithNativeAssetsResult: <String>['bar'],
           ),
-          buildCodeAssets: true,
+          buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
           buildDataAssets: true,
         ),
         throwsToolExit(
@@ -101,7 +101,7 @@ void main() {
             environmentDefines: <String, String>{kBuildMode: buildMode.cliName},
             targetPlatform: TargetPlatform.linux_x64,
             projectUri: projectUri,
-            buildCodeAssets: true,
+            buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
             buildDataAssets: true,
             fileSystem: fileSystem,
             buildRunner: FakeFlutterNativeAssetsBuildRunner(

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -261,7 +261,7 @@ void main() {
           projectUri: projectUri,
           fileSystem: fileSystem,
           buildRunner: buildRunner,
-          buildCodeAssets: true,
+          buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
           buildDataAssets: true,
         );
         await installCodeAssets(

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -342,7 +342,9 @@ void main() {
             projectUri: projectUri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
-            buildCodeAssets: true,
+            buildCodeAssets: BuildCodeAssetsOptions(
+              appBuildDirectory: fileSystem.directory(projectUri),
+            ),
             buildDataAssets: true,
           );
           final Uri nativeAssetsFileUri = flutterTester

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -101,7 +101,7 @@ void main() {
             projectUri: projectUri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
-            buildCodeAssets: true,
+            buildCodeAssets: const BuildCodeAssetsOptions(appBuildDirectory: null),
             buildDataAssets: true,
           );
           final expectedDirectory = flutterTester ? code_assets.OS.current.toString() : 'windows';


### PR DESCRIPTION
When running native assets as part of an app build, the Flutter tool tries to infer clang, archiver and linker executables from `PATH`. That logic doesn't handle builds where clang is used with a GNU linker.

To fix this, this PR changes the logic to read `CMakeCache.txt` from the Linux build directory, which contains all tools to be used in the build.
While Windows also uses CMake, we don't need to adopt this for Windows since MSVC is the only supported toolchain for that target anyway.

Closes https://github.com/flutter/flutter/issues/180770. cc @dcharkes 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
