### PR TITLE
Add route for 'tmp' to Flutter runner

### DIFF
--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -27,6 +27,7 @@ using component_testing::ParentRef;
 using component_testing::Protocol;
 using component_testing::RealmRoot;
 using component_testing::Route;
+using component_testing::Storage;
 
 using fuchsia_test_utils::CheckViewExistsInSnapshot;
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -104,10 +104,9 @@ void PortableUITest::SetUpRealmBase() {
       .targets = {ParentRef(), kFlutterJitRunnerRef}});
 
   // Route "tmp" to Flutter runner
-  realm_builder_.AddRoute(Route{
-      .capabilities = {Storage{"tmp"}},
-      .source = ParentRef(),
-      .targets = {kFlutterJitRunnerRef}});
+  realm_builder_.AddRoute(Route{.capabilities = {Storage{"tmp"}},
+                                .source = ParentRef(),
+                                .targets = {kFlutterJitRunnerRef}});
 }
 
 void PortableUITest::ProcessViewGeometryResponse(

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -101,6 +101,12 @@ void PortableUITest::SetUpRealmBase() {
                        Protocol{kPointerInjectorRegistryName}},
       .source = kTestUIStackRef,
       .targets = {ParentRef(), kFlutterJitRunnerRef}});
+
+  // Route "tmp" to Flutter runner
+  realm_builder_.AddRoute(Route{
+      .capabilities = {Storage{"tmp"}},
+      .source = ParentRef(),
+      .targets = {kFlutterJitRunnerRef});
 }
 
 void PortableUITest::ProcessViewGeometryResponse(

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -107,7 +107,7 @@ void PortableUITest::SetUpRealmBase() {
   realm_builder_.AddRoute(Route{
       .capabilities = {Storage{"tmp"}},
       .source = ParentRef(),
-      .targets = {kFlutterJitRunnerRef});
+      .targets = {kFlutterJitRunnerRef}});
 }
 
 void PortableUITest::ProcessViewGeometryResponse(

--- a/engine/src/flutter/testing/fuchsia/test_suites.yaml
+++ b/engine/src/flutter/testing/fuchsia/test_suites.yaml
@@ -99,8 +99,7 @@
     - oot_flutter_jit_runner-0.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/touch-input-view/touch-input-view.far
     - gen/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/embedding-flutter-view/embedding-flutter-view.far
-  variant: disabed
-  disabled: FlutterEmbedTapTest(s) are flaky, https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20linux_fuchsia_tests
+  variant: debug_x64
 - test_command: test run fuchsia-pkg://fuchsia.com/txt_tests#meta/txt_tests.cm -- --gtest_filter=-ParagraphTest.*
   package: txt_tests-0.far
   variant: debug


### PR DESCRIPTION
The flaky test shows test realm miss "tmp" route to Flutter runner

Bug: b/468371588

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
