### PR TITLE
Fix capitalization of the path to FlutterWindowControllerTest.mm in the macOS platform build script

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -239,10 +239,10 @@ executable("flutter_desktop_darwin_unittests") {
     "framework/Source/FlutterViewControllerTestUtils.mm",
     "framework/Source/FlutterViewEngineProviderTest.mm",
     "framework/Source/FlutterViewTest.mm",
+    "framework/Source/FlutterWindowControllerTest.mm",
     "framework/Source/KeyCodeMapTest.mm",
     "framework/Source/TestFlutterPlatformView.h",
     "framework/Source/TestFlutterPlatformView.mm",
-    "framework/source/FlutterWindowControllerTest.mm",
   ]
 
   deps = [


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/180963