### PR TITLE
Remove use of SkDeserialProcs::fTypefaceProc

### DIFF
--- a/engine/src/flutter/shell/common/serialization_callbacks.cc
+++ b/engine/src/flutter/shell/common/serialization_callbacks.cc
@@ -21,9 +21,7 @@ SkSerialReturnType SerializeTypefaceWithData(SkTypeface* typeface, void* ctx) {
   return typeface->serialize(SkTypeface::SerializeBehavior::kDoIncludeData);
 }
 
-sk_sp<SkTypeface> DeserializeTypefaceWithoutData(const void* data,
-                                                 size_t length,
-                                                 void* ctx) {
+sk_sp<SkTypeface> DeserializeTypefaceWithoutData(SkStream&, void* ctx) {
   return nullptr;
 }
 

--- a/engine/src/flutter/shell/common/serialization_callbacks.h
+++ b/engine/src/flutter/shell/common/serialization_callbacks.h
@@ -8,6 +8,7 @@
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
+#include "third_party/skia/include/core/SkStream.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 
 namespace flutter {
@@ -15,9 +16,7 @@ namespace flutter {
 SkSerialReturnType SerializeTypefaceWithoutData(SkTypeface* typeface,
                                                 void* ctx);
 SkSerialReturnType SerializeTypefaceWithData(SkTypeface* typeface, void* ctx);
-sk_sp<SkTypeface> DeserializeTypefaceWithoutData(const void* data,
-                                                 size_t length,
-                                                 void* ctx);
+sk_sp<SkTypeface> DeserializeTypefaceWithoutData(SkStream&, void* ctx);
 
 // Serializes only the metadata of the image and not the underlying pixel data.
 SkSerialReturnType SerializeImageWithoutData(SkImage* image, void* ctx);

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/engine.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/engine.cc
@@ -893,7 +893,7 @@ void Engine::WarmupSkps(
           SkMemoryStream::MakeDirect(mapping->GetMapping(), mapping->GetSize());
       SkDeserialProcs procs = {0};
       procs.fImageProc = flutter::DeserializeImageWithoutData;
-      procs.fTypefaceProc = flutter::DeserializeTypefaceWithoutData;
+      procs.fTypefaceStreamProc = flutter::DeserializeTypefaceWithoutData;
       sk_sp<SkPicture> picture =
           SkPicture::MakeFromStream(stream.get(), &procs);
       if (!picture) {


### PR DESCRIPTION
SkDeserialProcs::fTypefaceProc took a void* and size_t, but the expectation was that the void* was a SkStream** and the size_t was always sizeof(SkStream*). Users should now use the less confusing replacement SkDeserialProcs::fTypefaceStreamProc which takes an SkStream&.