### PR TITLE
flutter clean: add --xcode-clean option to control Xcode cleaning

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -194,6 +194,119 @@ void main() {
           XcodeProjectInterpreter: () => xcodeProjectInterpreter,
         },
       );
+
+      testUsingContext(
+        '$CleanCommand cleans all Xcode schemes with --xcode-clean=workspace',
+        () async {
+          setupProjectUnderTest(fs.currentDirectory, true);
+          xcodeProjectInterpreter.isInstalled = true;
+          xcodeProjectInterpreter.version = Version(1000, 0, 0);
+
+          final CommandRunner<void> runner = createTestCommandRunner(CleanCommand());
+          await runner.run(<String>['clean', '--xcode-clean=workspace']);
+
+          expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+            CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', false),
+            CleanWorkspaceCall('/ios/Runner.xcworkspace', 'custom-scheme', false),
+            CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', false),
+            CleanWorkspaceCall('/macos/Runner.xcworkspace', 'custom-scheme', false),
+          ]);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Xcode: () => xcode,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        },
+      );
+
+      testUsingContext(
+        '$CleanCommand cleans only application schemes with --xcode-clean=app',
+        () async {
+          setupProjectUnderTest(fs.currentDirectory, true);
+          xcodeProjectInterpreter.isInstalled = true;
+          xcodeProjectInterpreter.version = Version(1000, 0, 0);
+
+          final CommandRunner<void> runner = createTestCommandRunner(CleanCommand());
+          await runner.run(<String>['clean', '--xcode-clean=app']);
+
+          expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+            CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', false),
+            CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', false),
+          ]);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Xcode: () => xcode,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        },
+      );
+
+      testUsingContext(
+        '$CleanCommand skips Xcode cleaning with --xcode-clean=skip',
+        () async {
+          setupProjectUnderTest(fs.currentDirectory, true);
+          xcodeProjectInterpreter.isInstalled = true;
+          xcodeProjectInterpreter.version = Version(1000, 0, 0);
+
+          final CommandRunner<void> runner = createTestCommandRunner(CleanCommand());
+          await runner.run(<String>['clean', '--xcode-clean=skip']);
+
+          expect(xcodeProjectInterpreter.workspaces, isEmpty);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Xcode: () => xcode,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        },
+      );
+
+      testUsingContext(
+        '$CleanCommand throws when --scheme is used with --xcode-clean=skip',
+        () async {
+          setupProjectUnderTest(fs.currentDirectory, true);
+          xcodeProjectInterpreter.isInstalled = true;
+          xcodeProjectInterpreter.version = Version(1000, 0, 0);
+
+          final CommandRunner<void> runner = createTestCommandRunner(CleanCommand());
+
+          expect(
+            () => runner.run(<String>['clean', '--xcode-clean=skip', '--scheme=Runner']),
+            throwsToolExit(message: '--scheme cannot be used with --xcode-clean=skip.'),
+          );
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Xcode: () => xcode,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        },
+      );
+
+      testUsingContext(
+        '$CleanCommand prefers --scheme over --xcode-clean=app',
+        () async {
+          setupProjectUnderTest(fs.currentDirectory, true);
+          xcodeProjectInterpreter.isInstalled = true;
+          xcodeProjectInterpreter.version = Version(1000, 0, 0);
+
+          final CommandRunner<void> runner = createTestCommandRunner(CleanCommand());
+          await runner.run(<String>['clean', '--xcode-clean=app', '--scheme=custom-scheme']);
+
+          expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+            CleanWorkspaceCall('/ios/Runner.xcworkspace', 'custom-scheme', false),
+            CleanWorkspaceCall('/macos/Runner.xcworkspace', 'custom-scheme', false),
+          ]);
+        },
+        overrides: <Type, Generator>{
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Xcode: () => xcode,
+          XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        },
+      );
     });
 
     group('Windows', () {


### PR DESCRIPTION
This PR adds a new `--xcode-clean` option to `flutter clean` that allows controlling how Xcode workspaces are cleaned.

Large projects using Swift Package Manager can accumulate many Xcode schemes, which causes `flutter clean` to run `xcodebuild clean` serially for every scheme, significantly increasing execution time. This change allows users to limit Xcode cleaning to application-related schemes only, or skip Xcode workspace cleaning entirely when desired.

The default behavior remains unchanged: by default, all Xcode schemes continue to be cleaned to preserve existing workflows.

New options:
- `--xcode-clean=workspace` (default, current behavior): Clean all Xcode schemes.
- `--xcode-clean=app`: Clean only application schemes.
- `--xcode-clean=skip`: Skip Xcode workspace cleaning.

This provides a faster and more predictable cleanup experience for large SwiftPM-based workspaces while maintaining backward compatibility.

Fixes https://github.com/flutter/flutter/issues/173940, https://github.com/flutter/flutter/issues/180758

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] This PR is test-exempt.
- [x] All existing tests are passing.