### PR TITLE
refactor: Centralize copying of drag events when handling scrollbar scrolling

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -177,15 +177,15 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   // on the scrollbar thumb and then drags the scrollbar without releasing.
 
   @override
-  void handleThumbPressStart(Offset localPosition) {
-    super.handleThumbPressStart(localPosition);
+  void handleThumbPressStart(DragStartDetails details) {
+    super.handleThumbPressStart(details);
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
       return;
     }
     _pressStartAxisPosition = switch (direction) {
-      Axis.vertical => localPosition.dy,
-      Axis.horizontal => localPosition.dx,
+      Axis.vertical => details.localPosition.dy,
+      Axis.horizontal => details.localPosition.dx,
     };
   }
 
@@ -199,16 +199,16 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   }
 
   @override
-  void handleThumbPressEnd(Offset localPosition, Velocity velocity) {
+  void handleThumbPressEnd(DragEndDetails details) {
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
       return;
     }
     _thicknessAnimationController.reverse();
-    super.handleThumbPressEnd(localPosition, velocity);
+    super.handleThumbPressEnd(details);
     final (double axisPosition, double axisVelocity) = switch (direction) {
-      Axis.horizontal => (localPosition.dx, velocity.pixelsPerSecond.dx),
-      Axis.vertical => (localPosition.dy, velocity.pixelsPerSecond.dy),
+      Axis.horizontal => (details.localPosition.dx, details.velocity.pixelsPerSecond.dx),
+      Axis.vertical => (details.localPosition.dy, details.velocity.pixelsPerSecond.dy),
     };
     if (axisPosition != _pressStartAxisPosition && axisVelocity.abs() < 10) {
       HapticFeedback.mediumImpact();

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -93,6 +93,22 @@ class DragStartDetails with Diagnosticable implements PositionedGestureDetails {
     properties.add(DiagnosticsProperty<Duration?>('sourceTimeStamp', sourceTimeStamp));
     properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
   }
+
+  /// Creates a copy of this event but replacing the provided fields, while
+  /// maintaining the others.
+  DragStartDetails copyWith({
+    Offset? globalPosition,
+    Offset? localPosition,
+    Duration? sourceTimeStamp,
+    PointerDeviceKind? kind,
+  }) {
+    return DragStartDetails(
+      globalPosition: globalPosition ?? this.globalPosition,
+      localPosition: localPosition ?? this.localPosition,
+      sourceTimeStamp: sourceTimeStamp ?? this.sourceTimeStamp,
+      kind: kind ?? this.kind,
+    );
+  }
 }
 
 /// {@template flutter.gestures.dragdetails.GestureDragStartCallback}
@@ -181,6 +197,26 @@ class DragUpdateDetails with Diagnosticable implements PositionedGestureDetails 
     properties.add(DiagnosticsProperty<Offset>('delta', delta));
     properties.add(DoubleProperty('primaryDelta', primaryDelta));
   }
+
+  /// Creates a copy of this event but replacing the provided fields, while
+  /// maintaining the others.
+  DragUpdateDetails copyWith({
+    Offset? globalPosition,
+    Offset? localPosition,
+    Duration? sourceTimeStamp,
+    Offset? delta,
+    double? primaryDelta,
+    PointerDeviceKind? kind,
+  }) {
+    return DragUpdateDetails(
+      globalPosition: globalPosition ?? this.globalPosition,
+      localPosition: localPosition ?? this.localPosition,
+      sourceTimeStamp: sourceTimeStamp ?? this.sourceTimeStamp,
+      delta: delta ?? this.delta,
+      primaryDelta: primaryDelta ?? this.primaryDelta,
+      kind: kind ?? this.kind,
+    );
+  }
 }
 
 /// {@template flutter.gestures.dragdetails.GestureDragUpdateCallback}
@@ -252,5 +288,21 @@ class DragEndDetails with Diagnosticable implements PositionedGestureDetails {
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
     properties.add(DiagnosticsProperty<Velocity>('velocity', velocity));
     properties.add(DoubleProperty('primaryVelocity', primaryVelocity));
+  }
+
+  /// Creates a copy of this event but replacing the provided fields, while
+  /// maintaining the others.
+  DragEndDetails copyWith({
+    Offset? globalPosition,
+    Offset? localPosition,
+    Velocity? velocity,
+    double? primaryVelocity,
+  }) {
+    return DragEndDetails(
+      globalPosition: globalPosition ?? this.globalPosition,
+      localPosition: localPosition ?? this.localPosition,
+      velocity: velocity ?? this.velocity,
+      primaryVelocity: primaryVelocity ?? this.primaryVelocity,
+    );
   }
 }

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -363,16 +363,16 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   }
 
   @override
-  void handleThumbPressStart(Offset localPosition) {
-    super.handleThumbPressStart(localPosition);
+  void handleThumbPressStart(DragStartDetails details) {
+    super.handleThumbPressStart(details);
     setState(() {
       _dragIsActive = true;
     });
   }
 
   @override
-  void handleThumbPressEnd(Offset localPosition, Velocity velocity) {
-    super.handleThumbPressEnd(localPosition, velocity);
+  void handleThumbPressEnd(DragEndDetails details) {
+    super.handleThumbPressEnd(details);
     setState(() {
       _dragIsActive = false;
     });


### PR DESCRIPTION
This PR changes the signatures of `handleThumbPressStart`, `handleThumbPressUpdate`, and `handleThumbPressEnd`, related to scrollbar handling, to take in a copy of the original event with the `localPosition` added inside, instead of separate fields.

This centralizes the copying of these events by the generic platform code (while still allowing some of them to re-copy based on implementation details), ensures that additional fields are propagated (such as `kind` when it exists, `buttons` when it is eventually added, and others) and simplifies the method signature significantly, future proofing it to future additions.

This was extracted from https://github.com/flutter/flutter/pull/176968 in an attempt to simplify it, and it will make it possible to add the missing `buttons` property to these events more easily.

This also adds a `copyWith` method to these events in an attempt to ensure that the copies have all non-specified fields propagated by centralizing the "exhaustiveness" of the copy into the event class itself; that way if a new field is added in the future it can be trivially added to the `copyWith` method and not require figuring out all "copiers" out there (specially if it has a default value which could go un-noticed elsewhere).

Note: this is a public signature change but only if people are creating their own custom scrollbar implementations (?) without using either the material or cupertino ones; and on top of that should be very trivial to fix. But please advise if there are concerns.

Note: this has no test changes because it is a refactor which should have zero change in behaviour; the existing tests passing is proof of it working. So I am disregarding this bot, but please advise if I am mistaken.

Note: this PR assumes that the `renderBox.localToGlobal(localPosition)` computation that was previously done was essentially the _reverse_ of the global -> local computation, so essentially the flow was `global --(global to local)--> local --(local to global)--> global` (the second step being there just because we didn't provide the original global to the method). So this is saving a computation step and should not change the behaviour. I will let the tests be the judge of this assumption but please let me know if there are concerns.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
