### PR TITLE
refactor: Standardize nullability of the EnumProperty type parameter on event diagnostic messages [proposal]

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2339,7 +2339,7 @@ class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
 ///
 ///  * [DiagnosticsProperty] which documents named parameters common to all
 ///    [DiagnosticsProperty].
-class EnumProperty<T extends Enum?> extends DiagnosticsProperty<T> {
+class EnumProperty<T extends Enum> extends DiagnosticsProperty<T> {
   /// Create a diagnostics property that displays an enum.
   ///
   /// The [level] argument must also not be null.

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -91,7 +91,7 @@ class DragStartDetails with Diagnosticable implements PositionedGestureDetails {
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
     properties.add(DiagnosticsProperty<Duration?>('sourceTimeStamp', sourceTimeStamp));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
   }
 }
 

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -134,7 +134,7 @@ class LongPressDownDetails with Diagnosticable implements PositionedGestureDetai
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
   }
 }
 

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -756,7 +756,7 @@ class SerialTapUpDetails with Diagnosticable implements PositionedGestureDetails
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(IntProperty('count', count));
   }
 }

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -50,7 +50,7 @@ class TapDownDetails with Diagnosticable implements PositionedGestureDetails {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
   }
 }
 

--- a/packages/flutter/lib/src/gestures/tap_and_drag.dart
+++ b/packages/flutter/lib/src/gestures/tap_and_drag.dart
@@ -109,7 +109,7 @@ class TapDragDownDetails with Diagnosticable implements PositionedGestureDetails
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(IntProperty('consecutiveTapCount', consecutiveTapCount));
   }
 }
@@ -162,7 +162,7 @@ class TapDragUpDetails with Diagnosticable implements PositionedGestureDetails {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(IntProperty('consecutiveTapCount', consecutiveTapCount));
   }
 }
@@ -223,7 +223,7 @@ class TapDragStartDetails with Diagnosticable implements PositionedGestureDetail
     properties.add(DiagnosticsProperty<Offset>('globalPosition', globalPosition));
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
     properties.add(DiagnosticsProperty<Duration?>('sourceTimeStamp', sourceTimeStamp));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(IntProperty('consecutiveTapCount', consecutiveTapCount));
   }
 }
@@ -336,7 +336,7 @@ class TapDragUpdateDetails with Diagnosticable implements PositionedGestureDetai
     properties.add(DiagnosticsProperty<Duration?>('sourceTimeStamp', sourceTimeStamp));
     properties.add(DiagnosticsProperty<Offset>('delta', delta));
     properties.add(DoubleProperty('primaryDelta', primaryDelta));
-    properties.add(EnumProperty<PointerDeviceKind?>('kind', kind));
+    properties.add(EnumProperty<PointerDeviceKind>('kind', kind));
     properties.add(DiagnosticsProperty<Offset>('offsetFromOrigin', offsetFromOrigin));
     properties.add(DiagnosticsProperty<Offset>('localOffsetFromOrigin', localOffsetFromOrigin));
     properties.add(IntProperty('consecutiveTapCount', consecutiveTapCount));

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -244,7 +244,7 @@ class PopupMenuThemeData with Diagnosticable {
         defaultValue: null,
       ),
     );
-    properties.add(EnumProperty<PopupMenuPosition?>('position', position, defaultValue: null));
+    properties.add(EnumProperty<PopupMenuPosition>('position', position, defaultValue: null));
     properties.add(ColorProperty('iconColor', iconColor, defaultValue: null));
     properties.add(DoubleProperty('iconSize', iconSize, defaultValue: null));
   }


### PR DESCRIPTION
On the `debugFillProperties` chain used to print debug representation of events, the `EnumProperty` extends the cornerstone `DiagnosticsProperty` with a type `T`. The type `T` is not meant to be nullable because the values are always supportive of nulls regardless of the value of `T` (i.e. `value` is of type `T?`). This can be seen on the vast majority of cases and children of `DiagnosticsProperty` which do not specify `Foo?`.

However `EnumProperty` was defined to support a nullable `T`, which cause some usages (but not most) to specify the null version of the enum (such as `EnumProperty<PointerDeviceKind?>`), which was not consistent even with many other usages. This makes it identical to the field definition, which _can_ be `null` and thus is defined as `PointerDeviceKind?`, but it is ultimately not necessary with how `DiagnosticsProperty` defines it.

This PR removes the permissibility of nullable `T` on `EnumProperty`, fixing the few existing violations which makes them standardized with all other usages of `EnumProperty` (and `DiagnosticsProperty` in general).

This should have absolutely no change in behaviour whatsoever, and this "debug to string" property is covered by the `debug_test.dart` and should be unchanged.

This was extracted from https://github.com/flutter/flutter/pull/176968 in an attempt to simplify it.

Note: this does not fix all other children or direct usages of `DiagnosticsProperty`, which there are a few. Those can be done as followups if desired.

Note: if the intent is to have the type of `T` to match the type of the field exactly (including nullability), I think it would make sense to then change the type of `value` to be just `T` - that way it "forces" the user to specify `Foo?` if the type is nullable `Foo?`. That is a good alternative as well, that if preferred, I can pivot to.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
