### PR TITLE
feat: add `Image.fromTextureId()` for zero-copy image creation from platform textures

### DIFF
--- a/engine/src/flutter/common/graphics/texture.h
+++ b/engine/src/flutter/common/graphics/texture.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "flutter/display_list/dl_canvas.h"
+#include "flutter/display_list/image/dl_image.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 
@@ -57,6 +58,14 @@ class Texture : public ContextListener {
 
   // Called on raster thread.
   virtual void OnTextureUnregistered() = 0;
+
+  // Creates a DlImage snapshot from the texture's current content.
+  // Must be called on raster thread. Returns nullptr if unsupported.
+  // The returned image is independent of the texture - it captures the
+  // current content and will not update when the texture changes.
+  virtual sk_sp<DlImage> CreateDlImage(impeller::AiksContext* aiks_context) {
+    return nullptr;
+  }
 
   int64_t Id() { return id_; }
 

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -76,6 +76,8 @@ source_set("ui") {
     "painting/image_encoding_skia.h",
     "painting/image_filter.cc",
     "painting/image_filter.h",
+    "painting/image_from_texture.cc",
+    "painting/image_from_texture.h",
     "painting/image_generator.cc",
     "painting/image_generator.h",
     "painting/image_generator_apng.cc",

--- a/engine/src/flutter/lib/ui/dart_ui.cc
+++ b/engine/src/flutter/lib/ui/dart_ui.cc
@@ -24,6 +24,7 @@
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/painting/image_descriptor.h"
 #include "flutter/lib/ui/painting/image_filter.h"
+#include "flutter/lib/ui/painting/image_from_texture.h"
 #include "flutter/lib/ui/painting/image_shader.h"
 #include "flutter/lib/ui/painting/immutable_buffer.h"
 #include "flutter/lib/ui/painting/path.h"
@@ -125,7 +126,8 @@ typedef CanvasPath Path;
   V(DartRuntimeHooks::GetCallbackHandle)                           \
   V(DartRuntimeHooks::GetCallbackFromHandle)                       \
   V(DartPluginRegistrant_EnsureInitialized)                        \
-  V(Vertices::init)
+  V(Vertices::init)                                                \
+  V(CreateImageFromTextureId)
 
 // List of native instance methods used as @Native functions.
 // Items are tuples of ('class_name', 'method_name', 'parameter_count'), where:

--- a/engine/src/flutter/lib/ui/painting/image_from_texture.cc
+++ b/engine/src/flutter/lib/ui/painting/image_from_texture.cc
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/make_copyable.h"
+#include "flutter/lib/ui/painting/image.h"
+#include "flutter/lib/ui/ui_dart_state.h"
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_persistent_value.h"
+#include "third_party/tonic/logging/dart_invoke.h"
+
+namespace flutter {
+
+void CreateImageFromTextureId(int64_t texture_id, Dart_Handle callback_handle) {
+  if (!Dart_IsClosure(callback_handle)) {
+    Dart_ThrowException(tonic::ToDart("Callback must be a function"));
+    return;
+  }
+
+  auto* dart_state = UIDartState::Current();
+  if (!dart_state) {
+    Dart_ThrowException(tonic::ToDart("No UI dart state available"));
+    return;
+  }
+
+  auto snapshot_delegate = dart_state->GetSnapshotDelegate();
+  if (!snapshot_delegate) {
+    Dart_ThrowException(tonic::ToDart("No snapshot delegate available"));
+    return;
+  }
+
+  const auto& task_runners = dart_state->GetTaskRunners();
+  auto ui_runner = task_runners.GetUITaskRunner();
+  auto raster_runner = task_runners.GetRasterTaskRunner();
+
+  if (!ui_runner || !raster_runner) {
+    Dart_ThrowException(tonic::ToDart("Task runners not available"));
+    return;
+  }
+
+  // Store the callback so it persists across threads
+  auto persistent_callback =
+      std::make_unique<tonic::DartPersistentValue>(dart_state, callback_handle);
+
+  // Capture what we need for the raster thread
+  auto weak_dart_state = dart_state->GetWeakPtr();
+
+  raster_runner->PostTask(fml::MakeCopyable([texture_id, snapshot_delegate,
+                                             persistent_callback =
+                                                 std::move(persistent_callback),
+                                             ui_runner,
+                                             weak_dart_state]() mutable {
+    sk_sp<DlImage> dl_image = nullptr;
+
+    // Access the snapshot delegate on the raster thread
+    if (auto delegate = snapshot_delegate.get()) {
+      dl_image = delegate->CreateImageFromTexture(texture_id);
+    }
+
+    // Post result back to UI thread
+    ui_runner->PostTask(fml::MakeCopyable([dl_image = std::move(dl_image),
+                                           persistent_callback =
+                                               std::move(persistent_callback),
+                                           weak_dart_state]() mutable {
+      auto dart_state = weak_dart_state.lock();
+      if (!dart_state) {
+        // Isolate was terminated
+        return;
+      }
+
+      tonic::DartState::Scope scope(dart_state.get());
+
+      Dart_Handle callback = persistent_callback->Get();
+      if (Dart_IsNull(callback)) {
+        return;
+      }
+
+      if (dl_image && dl_image->isUIThreadSafe()) {
+        auto canvas_image = fml::MakeRefCounted<CanvasImage>();
+        canvas_image->set_image(std::move(dl_image));
+
+        tonic::DartInvoke(callback, {tonic::ToDart(canvas_image), Dart_Null()});
+      } else {
+        tonic::DartInvoke(
+            callback, {Dart_Null(),
+                       tonic::ToDart("Failed to create image from texture")});
+      }
+    }));
+  }));
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/lib/ui/painting/image_from_texture.h
+++ b/engine/src/flutter/lib/ui/painting/image_from_texture.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_IMAGE_FROM_TEXTURE_H_
+#define FLUTTER_LIB_UI_PAINTING_IMAGE_FROM_TEXTURE_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+
+namespace flutter {
+
+/// Creates a ui.Image from a registered texture's current content.
+///
+/// This is the native implementation of Image.fromTextureId() in Dart.
+/// It schedules work on the raster thread to create a DlImage from the
+/// texture, then wraps it as a CanvasImage and invokes the callback on
+/// the UI thread.
+///
+/// @param texture_id The ID of a registered texture.
+/// @param callback_handle A Dart closure to invoke with the result.
+void CreateImageFromTextureId(int64_t texture_id, Dart_Handle callback_handle);
+
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_PAINTING_IMAGE_FROM_TEXTURE_H_

--- a/engine/src/flutter/lib/ui/painting/testing/mocks.h
+++ b/engine/src/flutter/lib/ui/painting/testing/mocks.h
@@ -58,6 +58,7 @@ class MockSnapshotDelegate : public SnapshotDelegate {
               (const std::shared_ptr<impeller::RuntimeStage>&),
               (override));
   MOCK_METHOD(bool, MakeRenderContextCurrent, (), (override));
+  MOCK_METHOD(sk_sp<DlImage>, CreateImageFromTexture, (int64_t), (override));
 
   fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();

--- a/engine/src/flutter/lib/ui/snapshot_delegate.h
+++ b/engine/src/flutter/lib/ui/snapshot_delegate.h
@@ -102,6 +102,23 @@ class SnapshotDelegate {
   ///
   /// Impeller only.
   virtual bool MakeRenderContextCurrent() = 0;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Creates a DlImage from a registered texture's current content.
+  ///
+  ///             This enables zero-copy image creation from platform-decoded
+  ///             content. The returned image is independent of the texture -
+  ///             it captures the current content and will not update when the
+  ///             texture changes.
+  ///
+  ///             Must be called on the raster thread.
+  ///
+  /// @param[in]  texture_id  The ID of a registered texture.
+  ///
+  /// @return     A DlImage snapshot, or nullptr if the texture is not found
+  ///             or cannot be converted.
+  ///
+  virtual sk_sp<DlImage> CreateImageFromTexture(int64_t texture_id) = 0;
 };
 
 }  // namespace flutter

--- a/engine/src/flutter/shell/common/rasterizer.cc
+++ b/engine/src/flutter/shell/common/rasterizer.cc
@@ -476,6 +476,29 @@ bool Rasterizer::MakeRenderContextCurrent() {
   return snapshot_controller_->MakeRenderContextCurrent();
 }
 
+// |SnapshotDelegate|
+sk_sp<DlImage> Rasterizer::CreateImageFromTexture(int64_t texture_id) {
+  auto texture_registry = GetTextureRegistry();
+  if (!texture_registry) {
+    return nullptr;
+  }
+
+  auto texture = texture_registry->GetTexture(texture_id);
+  if (!texture) {
+    return nullptr;
+  }
+
+#if IMPELLER_SUPPORTS_RENDERING
+  auto aiks_context = GetAiksContext();
+  if (!aiks_context) {
+    return nullptr;
+  }
+  return texture->CreateDlImage(aiks_context.get());
+#else
+  return nullptr;
+#endif  // IMPELLER_SUPPORTS_RENDERING
+}
+
 fml::Milliseconds Rasterizer::GetFrameBudget() const {
   return delegate_.GetFrameBudget();
 };

--- a/engine/src/flutter/shell/common/rasterizer.h
+++ b/engine/src/flutter/shell/common/rasterizer.h
@@ -669,6 +669,9 @@ class Rasterizer final : public SnapshotDelegate,
   // |SnapshotDelegate|
   bool MakeRenderContextCurrent() override;
 
+  // |SnapshotDelegate|
+  sk_sp<DlImage> CreateImageFromTexture(int64_t texture_id) override;
+
   // |Stopwatch::Delegate|
   /// Time limit for a smooth frame.
   ///

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
@@ -62,22 +62,6 @@ FLUTTER_DARWIN_EXPORT
  * @param textureId The result that was previously returned from `registerTexture:`.
  */
 - (void)unregisterTexture:(int64_t)textureId;
-
-@optional
-/**
- * Creates a `ui.Image` snapshot from a registered texture's current content.
- *
- * The returned image is independent of the texture - it captures the current content
- * and will not update when the texture changes. This enables zero-copy image creation
- * from platform-decoded content.
- *
- * The completion handler is called on the platform thread.
- *
- * @param textureId The texture ID from `registerTexture:`.
- * @param completion Called with success (true) and the image dimensions, or failure (false).
- */
-- (void)createImageFromTexture:(int64_t)textureId
-                    completion:(void (^)(BOOL success, int width, int height))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
@@ -62,6 +62,22 @@ FLUTTER_DARWIN_EXPORT
  * @param textureId The result that was previously returned from `registerTexture:`.
  */
 - (void)unregisterTexture:(int64_t)textureId;
+
+@optional
+/**
+ * Creates a `ui.Image` snapshot from a registered texture's current content.
+ *
+ * The returned image is independent of the texture - it captures the current content
+ * and will not update when the texture changes. This enables zero-copy image creation
+ * from platform-decoded content.
+ *
+ * The completion handler is called on the platform thread.
+ *
+ * @param textureId The texture ID from `registerTexture:`.
+ * @param completion Called with success (true) and the image dimensions, or failure (false).
+ */
+- (void)createImageFromTexture:(int64_t)textureId
+                    completion:(void (^)(BOOL success, int width, int height))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
+++ b/engine/src/flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
@@ -62,6 +62,12 @@
 
 - (void)onTextureUnregistered;
 
+/// Creates a DlImage snapshot from the texture's current content.
+/// The returned image is independent of the texture - it captures the
+/// current content and will not update when the texture changes.
+/// Returns nullptr if no pixel buffer is available.
+- (sk_sp<flutter::DlImage>)createDlImageWithAiksContext:(nonnull impeller::AiksContext*)aiksContext;
+
 @property(nonatomic, readonly) int64_t textureID;
 
 @end

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -40,6 +40,9 @@ class IOSExternalTextureMetal final : public Texture {
   // |Texture|
   void OnTextureUnregistered() override;
 
+  // |Texture|
+  sk_sp<DlImage> CreateDlImage(impeller::AiksContext* aiks_context) override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureMetal);
 };
 

--- a/engine/src/flutter/shell/platform/darwin/ios/ios_external_texture_metal.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/ios_external_texture_metal.mm
@@ -42,4 +42,8 @@ void IOSExternalTextureMetal::OnTextureUnregistered() {
   [darwin_external_texture_metal_ onTextureUnregistered];
 }
 
+sk_sp<DlImage> IOSExternalTextureMetal::CreateDlImage(impeller::AiksContext* aiks_context) {
+  return [darwin_external_texture_metal_ createDlImageWithAiksContext:aiks_context];
+}
+
 }  // namespace flutter


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR allows creating ui.Image instances from external bitmaps, giving significant flexibility for creating bitmaps from platform APIs and custom image processing with optimal performance. The gap here is that the `ui.ImageDescriptor.raw` path effectively incurs three copies (platform GPU texture -> malloc buffer -> ImmutableBuffer -> ImageDescriptor.raw), while the texture API is a completely separate system from ui.Image. Importing a texture avoids this overhead while still benefitting from ui.Image ergonomics.

Besides performance, this also opens up a variety of applications, such as:
- Efficient progressive rendering (e.g. double buffering two textures, switching between them after each refinement scan)
- Extracting the current video frame as an image
- HDR using platform decoding APIs (this needs other future changes for color space handling and setting EDR for the CAMetalLayer)

The specific design choice of using the texture registry is because it:
1) Integrates nicely with existing engine code for `DlImage`
2) Abstracts engine details from the Dart API
3) Is a familiar interface for low-level platform usage

This PR only implements Impeller with Metal as a vertical slice of the implementation; I'm happy to complete Impeller support if we're aligned on the API and approach. I've attempted Skia support and had some threading issues with it, but am open to working on it as well if Skia is a requirement for the PR.

Notably, the current state of the PR doesn't take full ownership: it's relying on the underlying buffer's ref counts. My usage of it in testing has been to register the texture, pass it to this API in Dart and unregister it. I'm not sure if taking ownership would be preferred, or if this approach is perhaps more flexible.

Fixes #181134

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
