### PR TITLE
enable enhanced debugging for GLES playground

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -256,6 +256,7 @@ void(glDepthRange)(GLdouble n, GLdouble f);
 
 #define FOR_EACH_IMPELLER_EXT_PROC(PROC)    \
   PROC(DebugMessageControlKHR);             \
+  PROC(DebugMessageCallbackKHR);            \
   PROC(DiscardFramebufferEXT);              \
   PROC(FramebufferTexture2DMultisampleEXT); \
   PROC(PushDebugGroupKHR);                  \


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Enables improved OpenGLES debug support in the playground tests if [KHR_DEBUG](https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt)  is available. Only activated on unoptimized builds (where `NDEBUG` is not defined)

Example: 

Before:
```
[FATAL:flutter/impeller/renderer/backend/gles/proc_table_gles.h(44)] Fatal GL Error GL_INVALID_ENUM(1280) encountered on call to glBindBuffer
```

After:
```
[ERROR:flutter/impeller/playground/backend/gles/playground_impl_gles.cc(146)] GL Error: GL_INVALID_ENUM error generated. Invalid buffer target enum.
[FATAL:flutter/impeller/renderer/backend/gles/proc_table_gles.h(44)] Fatal GL Error GL_INVALID_ENUM(1280) encountered on call to glBindBuffer
```


Closes #179329

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
