### PR TITLE
[CP-beta][ Tool ] Fix `flutter run -d all` crash (#180845)

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -128,12 +128,11 @@ class HotRunner extends ResidentRunner {
 
   final benchmarkData = <String, List<int>>{};
 
+  @visibleForTesting
+  String? get targetPlatformName => _targetPlatformName;
   String? _targetPlatformName;
-  TargetPlatform get _targetPlatform => _targetPlatformName != null
-      ? getTargetPlatformForName(_targetPlatformName!)
-      : throw ArgumentError(
-          'Access to the target platform needs a call to _calculateTargetPlatform first',
-        );
+  final _targetPlatforms = <TargetPlatform>{};
+
   String? _sdkName;
   bool? _emulator;
 
@@ -150,15 +149,22 @@ class HotRunner extends ResidentRunner {
     if (_targetPlatformName != null) {
       return;
     }
-
+    assert(_targetPlatforms.isEmpty);
     switch (flutterDevices.length) {
       case 1:
         final Device device = flutterDevices.first.device!;
-        _targetPlatformName = getNameForTargetPlatform(await device.targetPlatform);
+        final TargetPlatform targetPlatform = await device.targetPlatform;
+        _targetPlatformName = getNameForTargetPlatform(targetPlatform);
+        _targetPlatforms.add(targetPlatform);
         _sdkName = await device.sdkNameAndVersion;
         _emulator = await device.isLocalEmulator;
       case > 1:
         _targetPlatformName = 'multiple';
+        _targetPlatforms.addAll(
+          await Future.wait([
+            for (final flutterDevice in flutterDevices) flutterDevice.device!.targetPlatform,
+          ]),
+        );
         _sdkName = 'multiple';
         _emulator = false;
       default:
@@ -302,7 +308,7 @@ class HotRunner extends ResidentRunner {
     final initialUpdateDevFSsTimer = Stopwatch()..start();
     final UpdateFSReport devfsResult = await _updateDevFS(
       fullRestart: needsFullRestart,
-      targetPlatform: _targetPlatform,
+      targetPlatforms: _targetPlatforms,
     );
 
     _addBenchmarkData(
@@ -485,24 +491,26 @@ class HotRunner extends ResidentRunner {
 
   Future<UpdateFSReport> _updateDevFS({
     bool fullRestart = false,
-    required TargetPlatform targetPlatform,
+    required Set<TargetPlatform> targetPlatforms,
   }) async {
     final bool isFirstUpload = !assetBundle.wasBuiltOnce();
     final bool rebuildBundle = assetBundle.needsBuild();
     if (rebuildBundle) {
-      globals.printTrace('Updating assets');
-      final int result = await assetBundle.build(
-        flutterHookResult: await dartBuilder?.runHooks(
+      for (final targetPlatform in targetPlatforms) {
+        globals.printTrace('Updating assets for ${targetPlatform.osName}');
+        final int result = await assetBundle.build(
+          flutterHookResult: await dartBuilder?.runHooks(
+            targetPlatform: targetPlatform,
+            environment: environment,
+            logger: _logger,
+          ),
+          packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
+          flavor: debuggingOptions.buildInfo.flavor,
           targetPlatform: targetPlatform,
-          environment: environment,
-          logger: _logger,
-        ),
-        packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
-        flavor: debuggingOptions.buildInfo.flavor,
-        targetPlatform: targetPlatform,
-      );
-      if (result != 0) {
-        return UpdateFSReport();
+        );
+        if (result != 0) {
+          return UpdateFSReport();
+        }
       }
     }
 
@@ -612,7 +620,7 @@ class HotRunner extends ResidentRunner {
     final restartTimer = Stopwatch()..start();
     UpdateFSReport updatedDevFS;
     try {
-      updatedDevFS = await _updateDevFS(fullRestart: true, targetPlatform: _targetPlatform);
+      updatedDevFS = await _updateDevFS(fullRestart: true, targetPlatforms: _targetPlatforms);
     } finally {
       hotRunnerConfig!.updateDevFSComplete();
     }
@@ -1027,7 +1035,7 @@ class HotRunner extends ResidentRunner {
     final devFSTimer = Stopwatch()..start();
     UpdateFSReport updatedDevFS;
     try {
-      updatedDevFS = await _updateDevFS(targetPlatform: _targetPlatform);
+      updatedDevFS = await _updateDevFS(targetPlatforms: _targetPlatforms);
     } finally {
       hotRunnerConfig!.updateDevFSComplete();
     }


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/179857

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)?
Does it impact development (ex. flutter doctor crashes when Android Studio is installed),
or the shipping of production apps (the app crashes on launch).
This information is for domain experts and release engineers to understand the consequences of saying yes or no to the cherry pick.

`flutter run -d all` causes the tool to crash if multiple devices are available.

### Changelog Description:
Explain this cherry pick:
* In one line that is accessible to most Flutter developers.
* That describes the state prior to the fix.
* That includes which platforms are impacted.
See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples.

`flutter run -d all` causes the tool to crash if multiple devices are available.

### Workaround:
Is there a workaround for this issue?

No.

### Risk:
What is the risk level of this cherry-pick?

  - [X] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [X] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Run `flutter run -d all` with multiple non-web devices available and verify the application is deployed to all non-web devices.