### PR TITLE
Improve WillPopScope deprecation documentation with migration example

### DIFF
--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -12,8 +12,76 @@ import 'routes.dart';
 /// Registers a callback to veto attempts by the user to dismiss the enclosing
 /// [ModalRoute].
 ///
+/// {@tool snippet}
+/// **Migration example:**
+///
+/// Instead of:
+/// ```dart
+/// WillPopScope(
+///   onWillPop: () async {
+///     if (hasUnsavedChanges) {
+///       return await showDialog<bool>(
+///         context: context,
+///         builder: (context) => AlertDialog(
+///           title: const Text('Discard changes?'),
+///           actions: [
+///             TextButton(
+///               onPressed: () => Navigator.pop(context, false),
+///               child: const Text('Cancel'),
+///             ),
+///             TextButton(
+///               onPressed: () => Navigator.pop(context, true),
+///               child: const Text('Discard'),
+///             ),
+///           ],
+///         ),
+///       ) ?? false;
+///     }
+///     return true;
+///   },
+///   child: child,
+/// )
+/// ```
+///
+/// Use:
+/// ```dart
+/// PopScope(
+///   canPop: !hasUnsavedChanges,
+///   onPopInvokedWithResult: (bool didPop, dynamic result) async {
+///     if (!didPop && hasUnsavedChanges) {
+///       final bool? shouldPop = await showDialog<bool>(
+///         context: context,
+///         builder: (context) => AlertDialog(
+///           title: const Text('Discard changes?'),
+///           actions: [
+///             TextButton(
+///               onPressed: () => Navigator.pop(context, false),
+///               child: const Text('Cancel'),
+///             ),
+///             TextButton(
+///               onPressed: () => Navigator.pop(context, true),
+///               child: const Text('Discard'),
+///             ),
+///           ],
+///         ),
+///       );
+///       if (shouldPop == true && context.mounted) {
+///         Navigator.of(context).pop();
+///       }
+///     }
+///   },
+///   child: child,
+/// )
+/// ```
+///
+/// Note: [PopScope] uses [canPop] to prevent the pop in advance, and
+/// [onPopInvokedWithResult] is called after the pop attempt. If [canPop] is
+/// false, the pop is prevented and `didPop` will be false in the callback.
+/// {@end-tool}
+///
 /// See also:
 ///
+///  * [PopScope], the replacement widget that supports Android predictive back.
 ///  * [ModalRoute.addScopedWillPopCallback] and [ModalRoute.removeScopedWillPopCallback],
 ///    which this widget uses to register and unregister [onWillPop].
 ///  * [Form], which provides an `onWillPop` callback that enables the form


### PR DESCRIPTION
Add a detailed migration example showing how to migrate from WillPopScope to PopScope, including a complete code example demonstrating the before and after patterns.

This helps developers understand:
- How to replace onWillPop with canPop and onPopInvokedWithResult
- The key differences in the API design
- A practical example with unsaved changes dialog

Fixes: Improves developer experience when migrating deprecated code

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
