### PR TITLE
Keep CupertinoSheetRoute transition from allowing blurs to go outside of the view

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -336,13 +336,13 @@ class CupertinoSheetTransition extends StatefulWidget {
             alignment: Alignment.topCenter,
             child: AnimatedBuilder(
               animation: radiusAnimation,
-              child: child,
+              child: ClipRect(child: contrastedChild),
               builder: (BuildContext context, Widget? child) {
                 return ClipRSuperellipse(
                   borderRadius: !secondaryAnimation.isDismissed
                       ? radiusAnimation.value
                       : BorderRadius.circular(0),
-                  child: contrastedChild,
+                  child: child,
                 );
               },
             ),
@@ -656,11 +656,13 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
     return MediaQuery.removePadding(
       context: context,
       removeTop: true,
-      child: ClipRSuperellipse(
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
-        child: CupertinoUserInterfaceLevel(
-          data: CupertinoUserInterfaceLevelData.elevated,
-          child: _CupertinoSheetScope(child: _sheetWithDragHandle(context)),
+      child: ClipRect(
+        child: ClipRSuperellipse(
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+          child: CupertinoUserInterfaceLevel(
+            data: CupertinoUserInterfaceLevelData.elevated,
+            child: _CupertinoSheetScope(child: _sheetWithDragHandle(context)),
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -226,6 +226,63 @@ void main() {
     expect(pageTwoYOffset, greaterThan(pageOneOffset.dy));
   });
 
+  testWidgets(
+    'A blur on the page does not go outside the rounded corner',
+    (WidgetTester tester) async {
+      final GlobalKey appKey = GlobalKey();
+      final GlobalKey scaffoldKey = GlobalKey();
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          key: appKey,
+          home: CupertinoPageScaffold(
+            key: scaffoldKey,
+            navigationBar: const CupertinoNavigationBar.large(
+              largeTitle: Text('Sheet Example'),
+              backgroundColor: Color(0x85F9F9F9),
+              transitionBetweenRoutes: false,
+              automaticBackgroundVisibility: false,
+            ),
+            child: SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
+                  Container(
+                    height: 500,
+                    color: CupertinoColors.activeOrange,
+                    child: const Center(child: Text('Entry A')),
+                  ),
+                  Container(
+                    height: 500,
+                    color: CupertinoColors.activeGreen,
+                    child: const Center(child: Text('Entry B')),
+                  ),
+                  Container(
+                    height: 500,
+                    color: CupertinoColors.activeBlue,
+                    child: const Center(child: Text('Entry C')),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      Navigator.of(scaffoldKey.currentContext!).push(
+        CupertinoSheetRoute<void>(
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(child: Text('Page 2'));
+          },
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Page 2'), findsOneWidget);
+      await expectLater(find.byKey(appKey), matchesGoldenFile('cupertinoSheetRoute.blur.png'));
+    },
+    variant: TargetPlatformVariant.mobile(),
+  );
+
   testWidgets('If a sheet covers another sheet, then the previous sheet moves slightly upwards', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+library;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Partially addresses #177420. Adds a ClipRRect around the sheet transition and delegated transition, which keeps the blur from bleeding to outside of the sheet on Android and iOS.

Before:

https://github.com/user-attachments/assets/94bed751-9121-4edc-a3e5-22a31fda32c0

After:

https://github.com/user-attachments/assets/d7c6720b-3077-4e6a-833d-d7b560c4f4e3



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
