### PR TITLE
Reland "Fix capitalization of the path to FlutterWindowControllerTest.mm in the macOS platform build script"

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -239,10 +239,10 @@ executable("flutter_desktop_darwin_unittests") {
     "framework/Source/FlutterViewControllerTestUtils.mm",
     "framework/Source/FlutterViewEngineProviderTest.mm",
     "framework/Source/FlutterViewTest.mm",
+    "framework/Source/FlutterWindowControllerTest.mm",
     "framework/Source/KeyCodeMapTest.mm",
     "framework/Source/TestFlutterPlatformView.h",
     "framework/Source/TestFlutterPlatformView.mm",
-    "framework/source/FlutterWindowControllerTest.mm",
   ]
 
   deps = [

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowControllerTest.mm
@@ -23,14 +23,14 @@ class FlutterWindowControllerTest : public FlutterEngineTest {
 
     [GetFlutterEngine() runWithEntrypoint:@"testWindowController"];
 
-    bool signalled = false;
+    signalled_ = false;
 
     AddNativeCallback("SignalNativeTest", CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                         isolate_ = Isolate::Current();
-                        signalled = true;
+                        signalled_ = true;
                       }));
 
-    while (!signalled) {
+    while (!signalled_) {
       CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
     }
   }
@@ -51,6 +51,7 @@ class FlutterWindowControllerTest : public FlutterEngineTest {
   }
 
   std::optional<flutter::Isolate> isolate_;
+  bool signalled_;
 };
 
 class FlutterWindowControllerRetainTest : public ::testing::Test {};
@@ -144,7 +145,7 @@ TEST_F(FlutterWindowControllerTest, DestroyRegularWindow) {
   EXPECT_EQ(viewController, nil);
 }
 
-TEST_F(FlutterWindowControllerTest, InternalFlutter_Window_GetHandle) {
+TEST_F(FlutterWindowControllerTest, InternalFlutterWindowGetHandle) {
   FlutterWindowCreationRequest request{
       .has_size = true,
       .size = {.width = 800, .height = 600},


### PR DESCRIPTION
Also fixes clang-tidy warnings in that file.

Fixes https://github.com/flutter/flutter/issues/180963