### PR TITLE
[Impeller] Make dynamically created shader metadata for runtime effects consistent with metadata for built-in shaders

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -525,10 +525,11 @@ TEST_P(AiksTest, RuntimeEffectImageFilterRotated) {
 }
 
 TEST_P(AiksTest, RuntimeEffectVectorArray) {
+  constexpr float kDimension = 400.0f;
   struct FragUniforms {
     Vector2 iResolution;
     Vector4 iValues;
-  } frag_uniforms = {.iResolution = Vector2(400, 400),
+  } frag_uniforms = {.iResolution = Vector2(kDimension, kDimension),
                      .iValues = Vector4(0.25, 0.50, 0.75, 1.0)};
   auto uniform_data = std::make_shared<std::vector<uint8_t>>();
   uniform_data->resize(sizeof(FragUniforms));
@@ -541,7 +542,7 @@ TEST_P(AiksTest, RuntimeEffectVectorArray) {
   paint.setColorSource(effect.value());
 
   DisplayListBuilder builder;
-  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, kDimension, kDimension), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -524,5 +524,27 @@ TEST_P(AiksTest, RuntimeEffectImageFilterRotated) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_P(AiksTest, RuntimeEffectVectorArray) {
+  struct FragUniforms {
+    Vector2 iResolution;
+    Vector4 iValues;
+  } frag_uniforms = {.iResolution = Vector2(400, 400),
+                     .iValues = Vector4(0.25, 0.50, 0.75, 1.0)};
+  auto uniform_data = std::make_shared<std::vector<uint8_t>>();
+  uniform_data->resize(sizeof(FragUniforms));
+  memcpy(uniform_data->data(), &frag_uniforms, sizeof(FragUniforms));
+
+  DlPaint paint;
+  auto effect = MakeRuntimeEffect(this, "runtime_stage_vector_array.frag.iplr",
+                                  uniform_data);
+  ABSL_ASSERT_OK(effect);
+  paint.setColorSource(effect.value());
+
+  DisplayListBuilder builder;
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, 400, 400), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
@@ -85,13 +85,22 @@ static std::unique_ptr<ShaderMetadata> MakeShaderMetadata(
     const RuntimeUniformDescription& uniform) {
   std::unique_ptr<ShaderMetadata> metadata = std::make_unique<ShaderMetadata>();
   metadata->name = uniform.name;
+
+  // If the element is not an array, then the runtime stage flatbuffer will
+  // represent the unspecified array_elements as the default value of 0.
+  std::optional<size_t> array_elements;
+  if (uniform.array_elements.has_value() &&
+      uniform.array_elements.value() > 0) {
+    array_elements = uniform.array_elements;
+  }
+
+  size_t member_size = uniform.dimensions.rows * uniform.dimensions.cols *
+                       (uniform.bit_width / 8u);
   metadata->members.emplace_back(ShaderStructMemberMetadata{
-      .type = GetShaderType(uniform.type),  //
-      .size = uniform.dimensions.rows * uniform.dimensions.cols *
-              (uniform.bit_width / 8u),  //
-      .byte_length =
-          (uniform.bit_width / 8u) * uniform.array_elements.value_or(1),  //
-      .array_elements = uniform.array_elements                            //
+      .type = GetShaderType(uniform.type),                      //
+      .size = member_size,                                      //
+      .byte_length = member_size * array_elements.value_or(1),  //
+      .array_elements = array_elements                          //
   });
 
   return metadata;

--- a/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/runtime_effect_contents.cc
@@ -89,8 +89,7 @@ static std::unique_ptr<ShaderMetadata> MakeShaderMetadata(
   // If the element is not an array, then the runtime stage flatbuffer will
   // represent the unspecified array_elements as the default value of 0.
   std::optional<size_t> array_elements;
-  if (uniform.array_elements.has_value() &&
-      uniform.array_elements.value() > 0) {
+  if (uniform.array_elements.value_or(0) > 0) {
     array_elements = uniform.array_elements;
   }
 

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -99,6 +99,7 @@ impellerc("runtime_stages") {
     "uniforms_and_sampler_1.frag",
     "uniforms_and_sampler_2.frag",
     "runtime_stage_border.frag",
+    "runtime_stage_vector_array.frag",
   ]
   sl_file_extension = "iplr"
 

--- a/engine/src/flutter/impeller/fixtures/runtime_stage_vector_array.frag
+++ b/engine/src/flutter/impeller/fixtures/runtime_stage_vector_array.frag
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 iResolution;
+uniform vec4 iValues[1];
+
+out vec4 fragColor;
+
+void main() {
+  vec2 uv = FlutterFragCoord() / iResolution;
+  float value;
+  if (uv.y < .25) {
+    value = iValues[0].r;
+  } else if (uv.y < .5) {
+    value = iValues[0].g;
+  } else if (uv.y < .75) {
+    value = iValues[0].b;
+  } else {
+    value = iValues[0].a;
+  }
+  vec3 color = vec3(value);
+  fragColor = vec4(color, 1);
+}

--- a/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -34,7 +34,7 @@ TEST(BufferBindingsGLESTest, BindUniformData) {
                                              .offset = 0,
                                              .size = sizeof(float),
                                              .byte_length = sizeof(float),
-                                             .array_elements = 0}}};
+                                             .array_elements = std::nullopt}}};
   std::shared_ptr<ReactorGLES> reactor;
   std::shared_ptr<Allocation> backing_store = std::make_shared<Allocation>();
   ASSERT_TRUE(backing_store->Truncate(Bytes{sizeof(float)}));


### PR DESCRIPTION
* Set byte_length to the total byte length of all array elements
* The runtime stage flatbuffer will represent an unspecified array_elements value as the default value of zero.  Convert that to an empty std::optional in the metadata.

Fixes https://github.com/flutter/flutter/issues/180068