### PR TITLE
Use SkPathBuilder with SkPathMeasure::getSegment

### DIFF
--- a/engine/src/flutter/lib/ui/painting/path_measure.cc
+++ b/engine/src/flutter/lib/ui/painting/path_measure.cc
@@ -87,13 +87,13 @@ void CanvasPathMeasure::getSegment(Dart_Handle path_handle,
           contour_index) >= measures_.size()) {
     CanvasPath::Create(path_handle);
   }
-  SkPath dst;
+  SkPathBuilder dst;
   bool success = measures_[contour_index]->getSegment(
       SafeNarrow(start_d), SafeNarrow(stop_d), &dst, start_with_move_to);
   if (!success) {
     CanvasPath::Create(path_handle);
   } else {
-    CanvasPath::CreateFrom(path_handle, dst);
+    CanvasPath::CreateFrom(path_handle, dst.detach());
   }
 }
 


### PR DESCRIPTION
Migrate calls from the now deprecated SkPathMeasure::getSegment which took SkPath to the new version of SkPathMeasure::getSegment which takes SkPathBuilder.