### PR TITLE
fix description for semantics finders

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -567,8 +567,15 @@ class CommonFinders {
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder bySemanticsLabel(Pattern label, {bool skipOffstage = true}) {
+    final String description = switch (label) {
+      final RegExp regExp => 'a semantics label matching the pattern "${regExp.pattern}"',
+      final String labelString => 'a semantics label named "$labelString"',
+      _ => 'a semantics label matching "$label"',
+    };
+
     return _bySemanticsProperty(
       label,
+      description,
       (SemanticsNode? semantics) => semantics?.label,
       skipOffstage: skipOffstage,
     );
@@ -591,8 +598,15 @@ class CommonFinders {
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder bySemanticsIdentifier(Pattern identifier, {bool skipOffstage = true}) {
+    final String description = switch (identifier) {
+      final RegExp regExp => 'a semantics identifier matching the pattern "${regExp.pattern}"',
+      final String id => 'a semantics identifier named "$id"',
+      _ => 'a semantics identifier matching "$identifier"',
+    };
+
     return _bySemanticsProperty(
       identifier,
+      description,
       (SemanticsNode? semantics) => semantics?.identifier,
       skipOffstage: skipOffstage,
     );
@@ -600,6 +614,7 @@ class CommonFinders {
 
   Finder _bySemanticsProperty(
     Pattern pattern,
+    String description,
     String? Function(SemanticsNode?) propertyGetter, {
     bool skipOffstage = true,
   }) {
@@ -610,18 +625,23 @@ class CommonFinders {
         'this finder, and call dispose on its return value after.',
       );
     }
-    return byElementPredicate((Element element) {
-      // Multiple elements can have the same renderObject - we want the "owner"
-      // of the renderObject, i.e. the RenderObjectElement.
-      if (element is! RenderObjectElement) {
-        return false;
-      }
-      final String? propertyValue = propertyGetter(element.renderObject.debugSemantics);
-      if (propertyValue == null) {
-        return false;
-      }
-      return pattern is RegExp ? pattern.hasMatch(propertyValue) : pattern == propertyValue;
-    }, skipOffstage: skipOffstage);
+
+    return byElementPredicate(
+      (Element element) {
+        // Multiple elements can have the same renderObject - we want the "owner"
+        // of the renderObject, i.e. the RenderObjectElement.
+        if (element is! RenderObjectElement) {
+          return false;
+        }
+        final String? propertyValue = propertyGetter(element.renderObject.debugSemantics);
+        if (propertyValue == null) {
+          return false;
+        }
+        return pattern is RegExp ? pattern.hasMatch(propertyValue) : pattern == propertyValue;
+      },
+      description: description,
+      skipOffstage: skipOffstage,
+    );
   }
 }
 

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -359,6 +359,92 @@ void main() {
       expect(find.bySemanticsIdentifier(RegExp(r'^item-')), findsNWidgets(2));
       semanticsHandle.dispose();
     });
+
+    testWidgets(
+      'bySemanticsIdentifier contains given semantics identifier string in the error message',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(const Text('foo', textDirection: TextDirection.ltr));
+
+        late TestFailure failure;
+        try {
+          expect(find.bySemanticsIdentifier('custom-identifier'), findsOneWidget);
+        } on TestFailure catch (e) {
+          failure = e;
+        }
+
+        expect(failure, isNotNull);
+        expect(
+          failure.message,
+          contains(
+            'Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics identifier named "custom-identifier"',
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'bySemanticsIdentifier contains given semantics identifier RegExp in the error message',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(const Text('foo', textDirection: TextDirection.ltr));
+
+        late TestFailure failure;
+        try {
+          expect(find.bySemanticsIdentifier(RegExp(r'^item-')), findsOneWidget);
+        } on TestFailure catch (e) {
+          failure = e;
+        }
+
+        expect(failure, isNotNull);
+        expect(
+          failure.message,
+          contains(
+            'Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics identifier matching the pattern "^item-"',
+          ),
+        );
+      },
+    );
+
+    testWidgets('bySemanticsLabel contains given label string in the error message', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(const Text('foo', textDirection: TextDirection.ltr));
+
+      late TestFailure failure;
+      try {
+        expect(find.bySemanticsLabel('label'), findsOneWidget);
+      } on TestFailure catch (e) {
+        failure = e;
+      }
+
+      expect(failure, isNotNull);
+      expect(
+        failure.message,
+        contains(
+          'Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics label named "label"',
+        ),
+      );
+    });
+
+    testWidgets('bySemanticsLabel contains given label RegExp in the error message', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(const Text('foo', textDirection: TextDirection.ltr));
+
+      late TestFailure failure;
+      try {
+        expect(find.bySemanticsLabel(RegExp(r'^item-')), findsOneWidget);
+      } on TestFailure catch (e) {
+        failure = e;
+      }
+
+      expect(failure, isNotNull);
+      expect(
+        failure.message,
+        contains(
+          'Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics label matching the pattern "^item-"',
+        ),
+      );
+    });
   });
 
   group('byTooltip', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/181196

This PR fixes the description for the bySemanticsLabel/Identifier matchers, which was missing.

Note: The framework uses `byElementPredicate()` in a bunch of places in tests, but not all use the `description` field.
Should we add descriptions to those?

Example:

```dart
import 'package:flutter/material.dart';
import 'package:flutter_test/flutter_test.dart';

void main() {
  testWidgets('bySemanticsLabel', (tester) async {
    await tester.pumpWidget(const MaterialApp(home: Text('hello')));
    await tester.pumpAndSettle();
    expect(find.bySemanticsLabel('goodbye'), findsOneWidget);
  });

  testWidgets('bySemanticsLabel regex', (tester) async {
    await tester.pumpWidget(const MaterialApp(home: Text('hello')));
    await tester.pumpAndSettle();
    expect(find.bySemanticsLabel(RegExp('^foo')), findsOneWidget);
  });

  testWidgets('bySemanticsIdentifier', (tester) async {
    await tester.pumpWidget(const MaterialApp(home: Text('hello')));
    await tester.pumpAndSettle();
    expect(find.bySemanticsIdentifier('goodbye'), findsOneWidget);
  });

  testWidgets('bySemanticsIdentifier regex', (tester) async {
    await tester.pumpWidget(const MaterialApp(home: Text('hello')));
    await tester.pumpAndSettle();
    expect(find.bySemanticsIdentifier(RegExp('^foo')), findsOneWidget);
  });
}
```

now gives:

```dart
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Expected: exactly one matching candidate
  Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics label named "goodbye": []>
   Which: means none were found but one was expected

When the exception was thrown, this was the stack:
#4      main.<anonymous closure> (file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart:8:5)
<asynchronous suspension>
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1692:5)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)

This was caught by the test expectation on the following line:
  file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart line 8
The test description was:
  bySemanticsLabel
════════════════════════════════════════════════════════════════════════════════════════════════════
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Expected: exactly one matching candidate
  Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics label matching the pattern
"^foo": []>
   Which: means none were found but one was expected

When the exception was thrown, this was the stack:
#4      main.<anonymous closure> (file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart:14:5)
<asynchronous suspension>
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1692:5)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)

This was caught by the test expectation on the following line:
  file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart line 14
The test description was:
  bySemanticsLabel regex
════════════════════════════════════════════════════════════════════════════════════════════════════
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Expected: exactly one matching candidate
  Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics identifier named
"goodbye": []>
   Which: means none were found but one was expected

When the exception was thrown, this was the stack:
#4      main.<anonymous closure> (file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart:20:5)
<asynchronous suspension>
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1692:5)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)

This was caught by the test expectation on the following line:
  file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart line 20
The test description was:
  bySemanticsIdentifier
════════════════════════════════════════════════════════════════════════════════════════════════════
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Expected: exactly one matching candidate
  Actual: _ElementPredicateWidgetFinder:<Found 0 widgets with a semantics identifier matching the
pattern "^foo": []>
   Which: means none were found but one was expected

When the exception was thrown, this was the stack:
#4      main.<anonymous closure> (file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart:26:5)
<asynchronous suspension>
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
<asynchronous suspension>
#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1692:5)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)

This was caught by the test expectation on the following line:
  file:///Users/navaronbracke/Desktop/matchers_test/test/widget_test.dart line 26
The test description was:
  bySemanticsIdentifier regex
════════════════════════════════════════════════════════════════════════════════════════════════════

```

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
