### PR TITLE
chore: swiftshader mirrored + llvm16

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,6 @@
 vars = {
   'android_git': 'https://android.googlesource.com',
   'chromium_git': 'https://chromium.googlesource.com',
-  'swiftshader_git': 'https://swiftshader.googlesource.com',
   'dart_git': 'https://dart.googlesource.com',
   'flutter_git': 'https://flutter.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
@@ -186,7 +185,6 @@ vars = {
   "upstream_shelf": "https://github.com/dart-lang/shelf.git",
   "upstream_skia": "https://skia.googlesource.com/skia.git",
   "upstream_sqlite": "https://github.com/sqlite/sqlite.git",
-  "upstream_SwiftShader": "https://swiftshader.googlesource.com/SwiftShader.git",
   "upstream_tar": "https://github.com/simolus3/tar.git",
   "upstream_test": "https://github.com/dart-lang/test.git",
   "upstream_usage": "https://github.com/dart-lang/usage.git",
@@ -224,7 +222,6 @@ allowed_hosts = [
   'flutter.googlesource.com',
   'llvm.googlesource.com',
   'skia.googlesource.com',
-  'swiftshader.googlesource.com',
 ]
 
 deps = {
@@ -544,7 +541,7 @@ deps = {
    Var('flutter_git') + '/third_party/pyyaml.git' + '@' + '03c67afd452cdff45b41bfe65e19a2fb5b80a0e8',
 
   'engine/src/flutter/third_party/swiftshader':
-  Var('swiftshader_git') + '/SwiftShader.git' + '@' + '794b0cfce1d828d187637e6d932bae484fbe0976',
+  Var('flutter_git') + '/third_party/swiftshader.git' + '@' + '1be9f83618f8ba258431c0c13d7a083eb193df11',
 
   'engine/src/flutter/third_party/angle':
   Var('flutter_git') + '/third_party/angle' + '@' + 'cc08479fbcc181697fa837069ce1103c58c15528',

--- a/engine/src/flutter/sky/packages/sky_engine/LICENSE
+++ b/engine/src/flutter/sky/packages/sky_engine/LICENSE
@@ -15939,12 +15939,6 @@ Copyright 2014-2022 The Khronos Group Inc.
 
 SPDX-License-Identifier: Apache-2.0
 --------------------------------------------------------------------------------
-swiftshader
-
-Copyright 2014-2025 The Khronos Group Inc.
-
-SPDX-License-Identifier: Apache-2.0
---------------------------------------------------------------------------------
 vulkan
 vulkan-headers
 


### PR DESCRIPTION
Updates SwiftShader to our own mirror and applied patches for llvm16: 

New head commit: 1be9f83618f8ba258431c0c13d7a083eb193df11

https://flutter.googlesource.com/third_party/swiftshader/+/refs/heads/flutter-a7c547b55

```
llvm16 + riscv on flutter

Reapply "Default to use llvm16" +

---
LLVM: Fix missing MCExternalSymbolizer on ARM64

This adds MCExternalSymbolizer.cpp and MCSymbolizer.cpp back to the build files by removing them from the ignore list in generate_build_files.py.
It also fixes two Windows-specific bugs in generate_build_files.py that caused it to output thousands of extra files and CRLF line endings on Windows.
This reverts commit 5b0479bd2d15058aaa9eb490e364f920ff824a8c.

---
LLVM: Fix MSVC 14.44 build error in CFG.h
Add default constructor to SuccIterator to satisfy std::default_initializable required by MSVC's C++20/C++23 std::reverse_iterator.
```


Must land before #178712