### PR TITLE
Make sure that an AnimatedPadding doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/animated_padding_test.dart
+++ b/packages/flutter/test/widgets/animated_padding_test.dart
@@ -100,4 +100,24 @@ void main() {
     expect(tester.getSize(find.byKey(target)), const Size(800.0, 600.0));
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 0.0));
   });
+
+  testWidgets('AnimatedPadding does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(
+            child: AnimatedPadding(
+              duration: const Duration(milliseconds: 200),
+              padding: const EdgeInsets.all(1),
+              child: const Text('X'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.byType(AnimatedPadding)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the AnimatedPadding widget.