### PR TITLE
Use null-aware elements in cupertino/nav_bar.dart

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -2674,25 +2674,23 @@ class _NavigationBarTransition extends StatelessWidget {
     );
 
     final children = <Widget>[
-      if (componentsTransition.bottomNavBarBackground != null)
-        componentsTransition.bottomNavBarBackground!,
-      if (componentsTransition.bottomBackChevron != null) componentsTransition.bottomBackChevron!,
-      if (componentsTransition.bottomBackLabel != null) componentsTransition.bottomBackLabel!,
-      if (componentsTransition.bottomLeading != null) componentsTransition.bottomLeading!,
-      if (componentsTransition.bottomMiddle != null) componentsTransition.bottomMiddle!,
-      if (componentsTransition.bottomLargeTitle != null) componentsTransition.bottomLargeTitle!,
-      if (componentsTransition.bottomTrailing != null) componentsTransition.bottomTrailing!,
-      if (componentsTransition.bottomNavBarBottom != null) componentsTransition.bottomNavBarBottom!,
+      ?componentsTransition.bottomNavBarBackground,
+      ?componentsTransition.bottomBackChevron,
+      ?componentsTransition.bottomBackLabel,
+      ?componentsTransition.bottomLeading,
+      ?componentsTransition.bottomMiddle,
+      ?componentsTransition.bottomLargeTitle,
+      ?componentsTransition.bottomTrailing,
+      ?componentsTransition.bottomNavBarBottom,
       // Draw top components on top of the bottom components.
-      if (componentsTransition.topNavBarBackground != null)
-        componentsTransition.topNavBarBackground!,
-      if (componentsTransition.topLeading != null) componentsTransition.topLeading!,
-      if (componentsTransition.topBackChevron != null) componentsTransition.topBackChevron!,
-      if (componentsTransition.topBackLabel != null) componentsTransition.topBackLabel!,
-      if (componentsTransition.topMiddle != null) componentsTransition.topMiddle!,
-      if (componentsTransition.topLargeTitle != null) componentsTransition.topLargeTitle!,
-      if (componentsTransition.topTrailing != null) componentsTransition.topTrailing!,
-      if (componentsTransition.topNavBarBottom != null) componentsTransition.topNavBarBottom!,
+      ?componentsTransition.topNavBarBackground,
+      ?componentsTransition.topLeading,
+      ?componentsTransition.topBackChevron,
+      ?componentsTransition.topBackLabel,
+      ?componentsTransition.topMiddle,
+      ?componentsTransition.topLargeTitle,
+      ?componentsTransition.topTrailing,
+      ?componentsTransition.topNavBarBottom,
     ];
 
     // The text scaling is disabled to avoid odd transitions between pages.


### PR DESCRIPTION
## Description

Adopts null-aware element syntax (`?x`) in `cupertino/nav_bar.dart`, replacing 16 instances of the verbose `if (x != null) x!` pattern in the `_NavigationBarTransition` widget's children list.

Fixes https://github.com/flutter/flutter/issues/172188

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md

[![talabat.com contributions](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)