### PR TITLE
Add WidgetStatesController support to ExpansionTile

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -152,6 +152,7 @@ class ExpansionTile extends StatefulWidget {
     this.enabled = true,
     this.expansionAnimationStyle,
     this.internalAddSemanticForOnTap = false,
+    this.statesController,
   }) : assert(
          expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
          'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -484,6 +485,40 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
+  /// {@tool snippet}
+  /// This example listens for hover and press states on an [ExpansionTile].
+  ///
+  /// ```dart
+  /// class ExpansionTileStatesExample extends StatelessWidget {
+  ///   ExpansionTileStatesExample({super.key});
+  ///
+  ///   final WidgetStatesController controller = WidgetStatesController();
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     controller.addListener(() {
+  ///       if (controller.value.contains(WidgetState.hovered)) {
+  ///         debugPrint('Tile is hovered');
+  ///       }
+  ///     });
+  ///
+  ///     return MaterialApp(
+  ///       home: Scaffold(
+  ///         body: ExpansionTile(
+  ///           title: const Text('Settings'),
+  ///           statesController: controller,
+  ///         ),
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// If null, the backing [ListTile] will create and manage its own
+  /// [WidgetStatesController].
+  final WidgetStatesController? statesController;
+
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }
@@ -626,6 +661,7 @@ class _ExpansionTileState extends State<ExpansionTile> {
             : null,
         minTileHeight: widget.minTileHeight,
         internalAddSemanticForOnTap: widget.internalAddSemanticForOnTap,
+        statesController: widget.statesController,
       ),
     );
 

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -485,6 +485,12 @@ class ExpansionTile extends StatefulWidget {
   // the default value to true.
   final bool internalAddSemanticForOnTap;
 
+  /// The controller that notifies when the widget's [WidgetState]s change.
+  ///
+  /// This allows listening to and controlling states such as
+  /// [WidgetState.hovered], [WidgetState.focused], [WidgetState.pressed],
+  /// and [WidgetState.disabled] for the tile's header.
+  ///
   /// {@tool snippet}
   /// This example listens for hover and press states on an [ExpansionTile].
   ///

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -491,36 +491,6 @@ class ExpansionTile extends StatefulWidget {
   /// [WidgetState.hovered], [WidgetState.focused], [WidgetState.pressed],
   /// and [WidgetState.disabled] for the tile's header.
   ///
-  /// {@tool snippet}
-  /// This example listens for hover and press states on an [ExpansionTile].
-  ///
-  /// ```dart
-  /// class ExpansionTileStatesExample extends StatelessWidget {
-  ///   ExpansionTileStatesExample({super.key});
-  ///
-  ///   final WidgetStatesController controller = WidgetStatesController();
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     controller.addListener(() {
-  ///       if (controller.value.contains(WidgetState.hovered)) {
-  ///         debugPrint('Tile is hovered');
-  ///       }
-  ///     });
-  ///
-  ///     return MaterialApp(
-  ///       home: Scaffold(
-  ///         body: ExpansionTile(
-  ///           title: const Text('Settings'),
-  ///           statesController: controller,
-  ///         ),
-  ///       ),
-  ///     );
-  ///   }
-  /// }
-  /// ```
-  /// {@end-tool}
-  ///
   /// If null, the backing [ListTile] will create and manage its own
   /// [WidgetStatesController].
   final WidgetStatesController? statesController;

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2158,4 +2158,36 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}),
     );
   });
+
+  testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
+  final controller = WidgetStatesController();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          title: const Text('Tile'),
+          statesController: controller,
+        ),
+      ),
+    ),
+  );
+
+  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+  expect(listTile.statesController, controller);
+});
+
+testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      home: Material(
+        child: ExpansionTile(title: Text('Tile')),
+      ),
+    ),
+  );
+
+  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+  expect(listTile.statesController, isNull);
+});
+
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2160,22 +2160,7 @@ void main() {
   });
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
-    final controller = WidgetStatesController();
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: ExpansionTile(title: const Text('Tile'), statesController: controller),
-        ),
-      ),
-    );
-
-    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
-    expect(listTile.statesController, controller);
-  });
-
-  testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
-    final controller = WidgetStatesController();
+    final WidgetStatesController controller = WidgetStatesController();
     addTearDown(() async {
       controller.dispose();
       await tester.pumpWidget(const SizedBox.shrink());
@@ -2191,5 +2176,18 @@ void main() {
 
     final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
     expect(listTile.statesController, controller);
+  });
+
+  testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: ExpansionTile(title: Text('Tile'))),
+      ),
+    );
+
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+    expect(listTile.statesController, isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2174,14 +2174,19 @@ void main() {
     expect(listTile.statesController, controller);
   });
 
-  testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
+  testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
+    final controller = WidgetStatesController();
+    addTearDown(controller.dispose);
+
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Material(child: ExpansionTile(title: Text('Tile'))),
+      MaterialApp(
+        home: Material(
+          child: ExpansionTile(title: const Text('Tile'), statesController: controller),
+        ),
       ),
     );
 
     final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
-    expect(listTile.statesController, isNull);
+    expect(listTile.statesController, controller);
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2176,7 +2176,10 @@ void main() {
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
     final controller = WidgetStatesController();
-    addTearDown(controller.dispose);
+    addTearDown(() async {
+      controller.dispose();
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
 
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2160,34 +2160,28 @@ void main() {
   });
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
-  final controller = WidgetStatesController();
+    final controller = WidgetStatesController();
 
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Material(
-        child: ExpansionTile(
-          title: const Text('Tile'),
-          statesController: controller,
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ExpansionTile(title: const Text('Tile'), statesController: controller),
         ),
       ),
-    ),
-  );
+    );
 
-  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
-  expect(listTile.statesController, controller);
-});
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+    expect(listTile.statesController, controller);
+  });
 
-testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
-  await tester.pumpWidget(
-    const MaterialApp(
-      home: Material(
-        child: ExpansionTile(title: Text('Tile')),
+  testWidgets('ExpansionTile forwards null statesController to ListTile', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(child: ExpansionTile(title: Text('Tile'))),
       ),
-    ),
-  );
+    );
 
-  final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
-  expect(listTile.statesController, isNull);
-});
-
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
+    expect(listTile.statesController, isNull);
+  });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2161,10 +2161,7 @@ void main() {
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
     final WidgetStatesController controller = WidgetStatesController();
-    addTearDown(() async {
-      controller.dispose();
-      await tester.pumpWidget(const SizedBox.shrink());
-    });
+    addTearDown(controller.dispose);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -2187,7 +2184,5 @@ void main() {
 
     final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile));
     expect(listTile.statesController, isNull);
-
-    await tester.pumpWidget(const SizedBox.shrink());
   });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -2160,7 +2160,7 @@ void main() {
   });
 
   testWidgets('ExpansionTile forwards statesController to ListTile', (tester) async {
-    final WidgetStatesController controller = WidgetStatesController();
+    final controller = WidgetStatesController();
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(


### PR DESCRIPTION
This PR adds support for providing a `WidgetStatesController` to `ExpansionTile`
and forwards it to the backing `ListTile`. This allows callers to observe and
control hovered, pressed, and focused states of the tile header.

The change includes updated documentation with a snippet example and adds
test coverage for both provided and null `statesController` cases.

Fixes #180161

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I read and followed the Flutter Style Guide, including Features we expect every widget to implement.
- [x] I signed the CLA.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [ ] I followed the breaking change policy and added Data Driven Fixes where supported.
- [ ] All existing and new tests are passing.
