### PR TITLE
Skip HardwareKeyboard asserts until keyboard state is initialized

### DIFF
--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -702,6 +702,16 @@ class HardwareKeyboard {
     _keyboardStateInitialized = false;
     assert(_modifiedHandlers == null);
   }
+
+  /// Marks the keyboard state as initialized for testing purposes.
+  ///
+  /// This allows assertion checks in [_assertEventIsRegular] to work properly
+  /// in tests without needing to call [syncKeyboardState], which requires
+  /// an actual engine connection.
+  @visibleForTesting
+  void markStateInitializedForTesting() {
+    _keyboardStateInitialized = true;
+  }
 }
 
 /// The mode in which information of key messages is delivered.

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -416,6 +416,8 @@ class HardwareKeyboard {
   final Map<PhysicalKeyboardKey, LogicalKeyboardKey> _pressedKeys =
       <PhysicalKeyboardKey, LogicalKeyboardKey>{};
 
+  bool _keyboardStateInitialized = false;
+
   /// The set of [PhysicalKeyboardKey]s that are pressed.
   ///
   /// If called from a key event handler, the result will already include the effect
@@ -506,6 +508,9 @@ class HardwareKeyboard {
 
   void _assertEventIsRegular(KeyEvent event) {
     assert(() {
+      if (!_keyboardStateInitialized) {
+        return true;
+      }
       const common =
           'If this occurs in real application, please report this '
           'bug to Flutter. If this occurs in unit tests, please ensure that '
@@ -601,6 +606,7 @@ class HardwareKeyboard {
         _pressedKeys[physicalKey] = logicalKey;
       }
     }
+    _keyboardStateInitialized = true;
   }
 
   bool _dispatchKeyEvent(KeyEvent event) {
@@ -693,6 +699,7 @@ class HardwareKeyboard {
     _pressedKeys.clear();
     _lockModes.clear();
     _handlers.clear();
+    _keyboardStateInitialized = false;
     assert(_modifiedHandlers == null);
   }
 }

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -600,12 +600,12 @@ void main() {
   testWidgets(
     'Stray key events do not trigger assertion before keyboard state is initialized',
     (WidgetTester tester) async {
-      final HardwareKeyboard keyboard = HardwareKeyboard();
+      final keyboard = HardwareKeyboard();
       addTearDown(keyboard.clearState);
 
       // Before syncKeyboardState() is called, stray events should not trigger assertions.
       // Simulate a stray KeyUpEvent for a key that was never pressed.
-      final strayEvent = KeyUpEvent(
+      const strayEvent = KeyUpEvent(
         physicalKey: PhysicalKeyboardKey.keyA,
         logicalKey: LogicalKeyboardKey.keyA,
         timeStamp: Duration.zero,
@@ -618,15 +618,21 @@ void main() {
       // After syncKeyboardState() is called, assertions should be active.
       await keyboard.syncKeyboardState();
 
-      // Now simulate a proper key down event followed by key up.
-      final keyDownEvent = KeyDownEvent(
+      // Verify that stray events now trigger assertions after initialization.
+      expect(
+        () => keyboard.handleKeyEvent(strayEvent),
+        throwsAssertionError,
+      );
+
+      // Verify regular key event sequence still works.
+      const keyDownEvent = KeyDownEvent(
         physicalKey: PhysicalKeyboardKey.keyB,
         logicalKey: LogicalKeyboardKey.keyB,
         timeStamp: Duration.zero,
       );
       keyboard.handleKeyEvent(keyDownEvent);
 
-      final keyUpEvent = KeyUpEvent(
+      const keyUpEvent = KeyUpEvent(
         physicalKey: PhysicalKeyboardKey.keyB,
         logicalKey: LogicalKeyboardKey.keyB,
         timeStamp: Duration.zero,

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -596,6 +596,44 @@ void main() {
     expect(messagesStr, contains('KEYBOARD: Pressed state before processing the event:'));
     expect(messagesStr, contains('KEYBOARD: Pressed state after processing the event:'));
   });
+
+  testWidgets(
+    'Stray key events do not trigger assertion before keyboard state is initialized',
+    (WidgetTester tester) async {
+      final HardwareKeyboard keyboard = HardwareKeyboard();
+      addTearDown(keyboard.clearState);
+
+      // Before syncKeyboardState() is called, stray events should not trigger assertions.
+      // Simulate a stray KeyUpEvent for a key that was never pressed.
+      final strayEvent = KeyUpEvent(
+        physicalKey: PhysicalKeyboardKey.keyA,
+        logicalKey: LogicalKeyboardKey.keyA,
+        timeStamp: Duration.zero,
+      );
+
+      // This should not throw an assertion error because the keyboard state
+      // is not yet initialized.
+      keyboard.handleKeyEvent(strayEvent);
+
+      // After syncKeyboardState() is called, assertions should be active.
+      await keyboard.syncKeyboardState();
+
+      // Now simulate a proper key down event followed by key up.
+      final keyDownEvent = KeyDownEvent(
+        physicalKey: PhysicalKeyboardKey.keyB,
+        logicalKey: LogicalKeyboardKey.keyB,
+        timeStamp: Duration.zero,
+      );
+      keyboard.handleKeyEvent(keyDownEvent);
+
+      final keyUpEvent = KeyUpEvent(
+        physicalKey: PhysicalKeyboardKey.keyB,
+        logicalKey: LogicalKeyboardKey.keyB,
+        timeStamp: Duration.zero,
+      );
+      keyboard.handleKeyEvent(keyUpEvent);
+    },
+  );
 }
 
 Future<void> _runWhileOverridingOnError(

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -597,49 +597,45 @@ void main() {
     expect(messagesStr, contains('KEYBOARD: Pressed state after processing the event:'));
   });
 
-  testWidgets(
-    'Stray key events do not trigger assertion before keyboard state is initialized',
-    (WidgetTester tester) async {
-      final keyboard = HardwareKeyboard();
-      addTearDown(keyboard.clearState);
+  testWidgets('Stray key events do not trigger assertion before keyboard state is initialized', (
+    WidgetTester tester,
+  ) async {
+    final keyboard = HardwareKeyboard();
+    addTearDown(keyboard.clearState);
 
-      // Before syncKeyboardState() is called, stray events should not trigger assertions.
-      // Simulate a stray KeyUpEvent for a key that was never pressed.
-      const strayEvent = KeyUpEvent(
-        physicalKey: PhysicalKeyboardKey.keyA,
-        logicalKey: LogicalKeyboardKey.keyA,
-        timeStamp: Duration.zero,
-      );
+    // Before syncKeyboardState() is called, stray events should not trigger assertions.
+    // Simulate a stray KeyUpEvent for a key that was never pressed.
+    const strayEvent = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.keyA,
+      logicalKey: LogicalKeyboardKey.keyA,
+      timeStamp: Duration.zero,
+    );
 
-      // This should not throw an assertion error because the keyboard state
-      // is not yet initialized.
-      keyboard.handleKeyEvent(strayEvent);
+    // This should not throw an assertion error because the keyboard state
+    // is not yet initialized.
+    keyboard.handleKeyEvent(strayEvent);
 
-      // After syncKeyboardState() is called, assertions should be active.
-      await keyboard.syncKeyboardState();
+    // After syncKeyboardState() is called, assertions should be active.
+    await keyboard.syncKeyboardState();
 
-      // Verify that stray events now trigger assertions after initialization.
-      expect(
-        () => keyboard.handleKeyEvent(strayEvent),
-        throwsAssertionError,
-      );
+    // Verify that stray events now trigger assertions after initialization.
+    expect(() => keyboard.handleKeyEvent(strayEvent), throwsAssertionError);
 
-      // Verify regular key event sequence still works.
-      const keyDownEvent = KeyDownEvent(
-        physicalKey: PhysicalKeyboardKey.keyB,
-        logicalKey: LogicalKeyboardKey.keyB,
-        timeStamp: Duration.zero,
-      );
-      keyboard.handleKeyEvent(keyDownEvent);
+    // Verify regular key event sequence still works.
+    const keyDownEvent = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.keyB,
+      logicalKey: LogicalKeyboardKey.keyB,
+      timeStamp: Duration.zero,
+    );
+    keyboard.handleKeyEvent(keyDownEvent);
 
-      const keyUpEvent = KeyUpEvent(
-        physicalKey: PhysicalKeyboardKey.keyB,
-        logicalKey: LogicalKeyboardKey.keyB,
-        timeStamp: Duration.zero,
-      );
-      keyboard.handleKeyEvent(keyUpEvent);
-    },
-  );
+    const keyUpEvent = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.keyB,
+      logicalKey: LogicalKeyboardKey.keyB,
+      timeStamp: Duration.zero,
+    );
+    keyboard.handleKeyEvent(keyUpEvent);
+  });
 }
 
 Future<void> _runWhileOverridingOnError(

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1871,6 +1871,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     // ignore: invalid_use_of_visible_for_testing_member
     HardwareKeyboard.instance.clearState();
     // ignore: invalid_use_of_visible_for_testing_member
+    HardwareKeyboard.instance.markStateInitializedForTesting();
+    // ignore: invalid_use_of_visible_for_testing_member
     keyEventManager.clearState();
     // ignore: invalid_use_of_visible_for_testing_member
     RendererBinding.instance.initMouseTracker();


### PR DESCRIPTION
  Skip HardwareKeyboard asserts until keyboard state is initialized                                                                                                                     
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Added a _keyboardStateInitialized flag to HardwareKeyboard. The assertion in _assertEventIsRegular is now skipped until the keyboard state is initialized (after syncKeyboardState()  
  runs).                                                                                                                                                                                
                                                                                                                                                                                        
  Problem                                                                                                                                                                               
                                                                                                                                                                                        
  Key events received before the keyboard state is fully synchronized cause assertion failures:                                                                                         
  - "A KeyDownEvent is dispatched, but the state shows that the physical key is already pressed."                                                                                       
  - "A KeyUpEvent is dispatched, but the state shows that the physical key is not pressed."                                                                                             
                                                                                                                                                                                        
  This causes the app to stop accepting hardware keyboard input in debug mode.                                                                                                          
                                                                                                                                                                                        
  When It Occurs                                                                                                                                                                        
                                                                                                                                                                                        
  - During app startup when user presses keys before framework initialization completes                                                                                                 
  - After hot restart/hot reload while quickly interacting with the keyboard                                                                                                            
  - The engine's keyboard channel buffer (size 1) can deliver stale events to an uninitialized framework                                                                                
                                                                                                                                                                                        
  Affected Platforms                                                                                                                                                                    
                                                                                                                                                                                        
  - Linux                                                                                                                                                                               
  - macOS                                                                                                                                                                               
  - Android                                                                                                                                                                             
  - Any Flutter desktop/mobile application using hardware keyboard                                                                                                                      
                                                                                                                                                                                        
  Solution                                                                                                                                                                              
                                                                                                                                                                                        
  Skip keyboard state assertions until syncKeyboardState() completes, allowing early key events to pass through without triggering assertion failures while maintaining full validation 
  after initialization.                                                                                                                                                                 
                                                                                                                                                                                        
  Related Issues                                                                                                                                                                        
                                                                                                                                                                                        
  - Fixes #172153                                                                                                                                                                       
  - Fixes #125975                                                                                                                                                                       
  - Related to #87391  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
