### PR TITLE
Remove unnecessary Material import from dialog_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -273,7 +273,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/cupertino/app_test.dart',
     'packages/flutter/test/cupertino/picker_test.dart',
     'packages/flutter/test/cupertino/text_field_test.dart',
-    'packages/flutter/test/cupertino/dialog_test.dart',
     'packages/flutter/test/cupertino/date_picker_test.dart',
     'packages/flutter/test/cupertino/switch_test.dart',
     'packages/flutter/test/cupertino/magnifier_test.dart',

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -12,7 +12,6 @@ import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1751,7 +1750,7 @@ void main() {
                     onPressed: () {
                       showCupertinoDialog<void>(
                         context: context,
-                        barrierColor: Colors.red,
+                        barrierColor: const Color(0xFFF44336),
                         builder: (BuildContext context) {
                           return CupertinoAlertDialog(
                             title: const Text('Title'),
@@ -1780,13 +1779,16 @@ void main() {
 
     await tester.tap(find.text('Custom BarrierColor'));
     await tester.pumpAndSettle();
-    expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, equals(Colors.red));
+    expect(
+      tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color,
+      equals(const Color(0xFFF44336)),
+    );
 
     await tester.tap(find.text('No'));
     await tester.pumpAndSettle();
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is ModalBarrier && widget.color == Colors.red,
+        (Widget widget) => widget is ModalBarrier && widget.color == const Color(0xFFF44336),
       ),
       findsNothing,
     );


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Replace Colors.red with hex value Color(0xFFF44336) to remove the Material import dependency from the Cupertino dialog test file. The test is Cupertino-specific and doesn't require Material.

Part of https://github.com/flutter/flutter/issues/177412

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md

[![talabat.com](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)
