### PR TITLE
update GLFW to latest and use EGL context creation on linux

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -250,7 +250,7 @@ deps = {
    Var('llvm_git') + '/llvm-project/libc' + '@' + '5af39a19a1ad51ce93972cdab206dcd3ff9b6afa',
 
   'engine/src/flutter/third_party/glfw':
-   Var('flutter_git') + '/third_party/glfw' + '@' + 'dd8a678a66f1967372e5a5e3deac41ebf65ee127',
+   Var('flutter_git') + '/third_party/glfw' + '@' + '9352d8fe93cd443be18157abe81f16500549aec0',
 
   'engine/src/flutter/third_party/shaderc':
    Var('chromium_git') + '/external/github.com/google/shaderc' + '@' + '37e25539ce199ecaf19fb7f7d27818716d36686d',

--- a/engine/src/flutter/build/secondary/flutter/third_party/glfw/BUILD.gn
+++ b/engine/src/flutter/build/secondary/flutter/third_party/glfw/BUILD.gn
@@ -80,7 +80,7 @@ source_set("glfw") {
 
     defines = [
       "_GLFW_X11",
-      "_GLFW_HAS_XF86VM",
+      "_DEFAULT_SOURCE"
     ]
 
     libs = [

--- a/engine/src/flutter/build/secondary/flutter/third_party/glfw/BUILD.gn
+++ b/engine/src/flutter/build/secondary/flutter/third_party/glfw/BUILD.gn
@@ -113,8 +113,10 @@ source_set("glfw") {
     ]
 
     frameworks = [
-      "CoreVideo.framework",
       "IOKit.framework",
+      "Cocoa.framework",
+      "CoreFoundation.framework",
+      "QuartzCore.framework"
     ]
   }
 

--- a/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -79,6 +79,11 @@ PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
   FML_CHECK(use_angle_) << "Must use Angle on macOS for OpenGL ES.";
   ::glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
 #endif  // FML_OS_MACOSX
+#if FML_OS_LINUX
+  // Use EGL even on X11 then the client can select the GLES implementation
+  // by defining __EGL_VENDOR_LIBRARY_FILENAMES
+  ::glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+#endif
   ::glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);


### PR DESCRIPTION
Updates the GLFW dependency to master and uses the EGL context creation API on Linux. This allows Linux users to select an OpenGL implementation when running the impeller playground tests by defining `__EGL_VENDOR_LIBRARY_FILENAMES`.

For example, running
```
$ impeller_unittests --gtest_filter=Play/AiksTest.ToImageFromImage/OpenGLES
```
gives,  in `description_gles.cc` ,
```
gl_version_string_ // OpenGL ES 3.2 NVIDIA 590.48.01
```

Then running

```
$ __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json impeller_unittests --gtest_filter=Play/AiksTest.ToImageFromImage/OpenGLES
```

```
gl_version_string_ // OpenGL ES 3.2 Mesa 25.3.3-arch1.3
```

Fixes #181258

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
