### PR TITLE
add stacktrace support when requested for host builds

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -615,7 +615,7 @@ def to_gn_args(args):
   # Determine whether backtace support should be compiled in.
   if args.backtrace:
     gn_args['enable_backtrace'] = (
-        args.target_os in ['linux', 'mac', 'win'] or
+        is_host_build(args) or args.target_os in ['linux', 'mac', 'win'] or
         args.target_os == 'ios' and runtime_mode == 'debug'
     )
   else:


### PR DESCRIPTION
Adds support for backtraces when requested in host builds

### Before:

```
Note: Google Test filter = Play/RendererTest.BabysFirstTriangle/OpenGLES
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Play/RendererTest
[ RUN      ] Play/RendererTest.BabysFirstTriangle/OpenGLES
...
Segmentation fault         (core dumped) __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json ./out/host_debug_unopt/exe.unstripped/impeller_unittests --enable_playground --gtest_filter='Play/RendererTest.BabysFirstTriangle/OpenGLES'
```

### After:
```
Note: Google Test filter = Play/RendererTest.BabysFirstTriangle/OpenGLES
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Play/RendererTest
[ RUN      ] Play/RendererTest.BabysFirstTriangle/OpenGLES
...
[symbolize_elf.inc : 379] RAW: Unable to get high fd: rc=0, limit=1024
[ERROR:flutter/fml/backtrace.cc(108)] Caught signal SIGSEGV during program execution.
Frame 0: 0x55831f19fbc4 impeller::DeviceBufferGLES::GetBufferData()
Frame 1: 0x55831f186cd3 impeller::BufferBindingsGLES::BindUniformBufferV2()
Frame 2: 0x55831f186b66 impeller::BufferBindingsGLES::BindUniformBufferV3()
Frame 3: 0x55831f1861da impeller::BufferBindingsGLES::BindUniformBuffer()
Frame 4: 0x55831f185fea impeller::BufferBindingsGLES::BindUniformData()
Frame 5: 0x55831f1cb112 impeller::EncodeCommandsInReactor()
...
Segmentation fault         (core dumped) __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json ./out/host_debug_unopt/exe.unstripped/impeller_unittests --enable_playground --gtest_filter='Play/RendererTest.BabysFirstTriangle/OpenGLES'
```

Fixes #181156

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.