### PR TITLE
Marks Mac_mokey microbenchmarks to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4813,7 +4813,6 @@ targets:
 
   # mac mokey benchmark
   - name: Mac_mokey microbenchmarks
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/174101
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
The issue https://github.com/flutter/flutter/issues/174101 has been closed, and the test has been passing for [50 consecutive runs](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac_mokey%20microbenchmarks%22).
This test can be marked as unflaky.

https://github.com/flutter/flutter/pull/175488 should have been landed.