### PR TITLE
Marks drive_perf_debug_warning to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2625,7 +2625,6 @@ targets:
       task_name: devtools_profile_start_test
 
   - name: Linux_pixel_7pro drive_perf_debug_warning
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/174111
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Infra issue has resolved https://github.com/flutter/flutter/issues/174111, and the test has been passing for [50 consecutive runs](https://data.corp.google.com/sites/dash_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Linux_pixel_7pro%20drive_perf_debug_warning%22).
