### PR TITLE
Bring Linux coverage out of bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -384,8 +384,6 @@ targets:
       task_name: analyzer_benchmark
 
   - name: Linux coverage
-    # Because this only runs every 6 commits, it being flaky takes a long time to recover.
-    bringup: true
     presubmit: false
     recipe: flutter/coverage
     timeout: 90


### PR DESCRIPTION
Marked as bringup as of #174171. With the new dashboard level flake suppression, it will no longer take a long time to mark things as flaky. 
Also, this seems to be running on every commit now?