### PR TITLE
Surface struct member information from impellerc

### DIFF
--- a/engine/src/flutter/impeller/compiler/reflector.cc
+++ b/engine/src/flutter/impeller/compiler/reflector.cc
@@ -397,6 +397,7 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
         compiler_->get_decoration(ubo.id, spv::Decoration::DecorationBinding);
     auto members = ReadStructMembers(ubo.type_id);
     std::vector<uint8_t> struct_layout;
+    std::vector<StructElement> struct_elements;
     size_t float_count = 0;
 
     for (size_t i = 0; i < members.size(); i += 1) {
@@ -413,6 +414,11 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
           break;
         }
         case StructMember::UnderlyingType::kFloat: {
+          StructElement element_desc{};
+          element_desc.name = member.name;
+          element_desc.byte_size =
+              member.size * member.array_elements.value_or(1);
+          struct_elements.push_back(element_desc);
           if (member.array_elements > 1) {
             // For each array element member, insert 1 layout property per byte
             // and 0 layout property per byte of padding
@@ -447,6 +453,7 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
         .binding = binding,
         .type = spirv_cross::SPIRType::Struct,
         .struct_layout = std::move(struct_layout),
+        .struct_elements = std::move(struct_elements),
         .struct_float_count = float_count,
     });
   }

--- a/engine/src/flutter/impeller/compiler/runtime_stage_data.cc
+++ b/engine/src/flutter/impeller/compiler/runtime_stage_data.cc
@@ -194,6 +194,7 @@ static const char* kUniformRowsKey = "rows";
 static const char* kUniformColumnsKey = "columns";
 static const char* kUniformBitWidthKey = "bit_width";
 static const char* kUniformArrayElementsKey = "array_elements";
+static const char* kUniformStructElementsKey = "struct_elements";
 
 static std::string RuntimeStageBackendToString(RuntimeStageBackend backend) {
   switch (backend) {
@@ -336,6 +337,13 @@ std::unique_ptr<fb::RuntimeStageT> RuntimeStageData::CreateStageFlatbuffer(
       desc->struct_layout.push_back(static_cast<fb::StructByteType>(byte_type));
     }
     desc->struct_float_count = uniform.struct_float_count;
+
+    for (const auto& element : uniform.struct_elements) {
+      auto a = fb::StructElementT{};
+      a.name = element.name;
+      a.byte_size = element.byte_size;
+      desc->struct_elements.push_back(std::make_unique<fb::StructElementT>(a));
+    }
 
     runtime_stage->uniforms.emplace_back(std::move(desc));
   }

--- a/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
+++ b/engine/src/flutter/impeller/compiler/shader_bundle_unittests.cc
@@ -146,6 +146,7 @@ TEST(ShaderBundleTest, GenerateShaderBundleFlatbufferProducesCorrectResult) {
 
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   const auto& shaders = bundle->shaders;
+
   const auto* vertex = FindByName(shaders, "UnlitVertex");
   const auto* fragment = FindByName(shaders, "UnlitFragment");
   ASSERT_NE(vertex, nullptr);

--- a/engine/src/flutter/impeller/compiler/types.h
+++ b/engine/src/flutter/impeller/compiler/types.h
@@ -46,6 +46,11 @@ enum class SourceLanguage {
   kHLSL,
 };
 
+struct StructElement {
+  std::string name;
+  size_t byte_size;
+};
+
 struct UniformDescription {
   std::string name;
   size_t location = 0u;
@@ -56,6 +61,7 @@ struct UniformDescription {
   size_t bit_width = 0u;
   std::optional<size_t> array_elements = std::nullopt;
   std::vector<uint8_t> struct_layout = {};
+  std::vector<StructElement> struct_elements = {};
   size_t struct_float_count = 0u;
 };
 

--- a/engine/src/flutter/impeller/core/runtime_types.h
+++ b/engine/src/flutter/impeller/core/runtime_types.h
@@ -38,6 +38,11 @@ struct RuntimeUniformDimensions {
   size_t cols = 0;
 };
 
+struct StructElement {
+  std::string name;
+  size_t byte_size;
+};
+
 struct RuntimeUniformDescription {
   std::string name;
   size_t location = 0u;
@@ -48,6 +53,7 @@ struct RuntimeUniformDescription {
   size_t bit_width = 0u;
   std::optional<size_t> array_elements;
   std::vector<uint8_t> struct_layout = {};
+  std::vector<StructElement> struct_elements = {};
   size_t struct_float_count = 0u;
 
   /// @brief  Computes the total number of bytes that this uniform requires.

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -88,6 +88,7 @@ impellerc("runtime_stages") {
   mnemonic = "IMPELLERC_IPLR"
   shaders = [
     "ink_sparkle.frag",
+    "all_supported_uniforms.frag",
     "runtime_stage_example.frag",
     "runtime_stage_filter_example.frag",
     "interop_runtime_stage_cs.frag",

--- a/engine/src/flutter/impeller/fixtures/all_supported_uniforms.frag
+++ b/engine/src/flutter/impeller/fixtures/all_supported_uniforms.frag
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+out vec4 fragColor;
+
+uniform float uFloat;
+
+uniform vec2 uVec2;
+uniform vec3 uVec3;
+uniform vec4 uVec4;
+
+uniform mat2 uMat2;
+uniform mat3 uMat3;
+uniform mat4 uMat4;
+
+const int ARRAY_SIZE = 2;
+uniform float uFloatArray[ARRAY_SIZE];
+
+uniform vec2 uVec2Array[ARRAY_SIZE];
+uniform vec3 uVec3Array[ARRAY_SIZE];
+uniform vec4 uVec4Array[ARRAY_SIZE];
+
+uniform mat2 uMat2Array[ARRAY_SIZE];
+uniform mat3 uMat3Array[ARRAY_SIZE];
+uniform mat4 uMat4Array[ARRAY_SIZE];
+
+bool checkAllNonZero() {
+  if (uFloat == 0.0)
+    return false;
+
+  if (uVec2.x == 0.0 || uVec2.y == 0.0)
+    return false;
+  if (uVec3.x == 0.0 || uVec3.y == 0.0 || uVec3.z == 0.0)
+    return false;
+  if (uVec4.x == 0.0 || uVec4.y == 0.0 || uVec4.z == 0.0 || uVec4.w == 0.0)
+    return false;
+
+  if (uMat2[0].x == 0.0 || uMat2[0].y == 0.0 || uMat2[1].x == 0.0 ||
+      uMat2[1].y == 0.0)
+    return false;
+  if (uMat3[0].x == 0.0 || uMat3[0].y == 0.0 || uMat3[0].z == 0.0 ||
+      uMat3[1].x == 0.0 || uMat3[1].y == 0.0 || uMat3[1].z == 0.0 ||
+      uMat3[2].x == 0.0 || uMat3[2].y == 0.0 || uMat3[2].z == 0.0)
+    return false;
+  if (uMat4[0].x == 0.0 || uMat4[0].y == 0.0 || uMat4[0].z == 0.0 ||
+      uMat4[0].w == 0.0 || uMat4[1].x == 0.0 || uMat4[1].y == 0.0 ||
+      uMat4[1].z == 0.0 || uMat4[1].w == 0.0 || uMat4[2].x == 0.0 ||
+      uMat4[2].y == 0.0 || uMat4[2].z == 0.0 || uMat4[2].w == 0.0 ||
+      uMat4[3].x == 0.0 || uMat4[3].y == 0.0 || uMat4[3].z == 0.0 ||
+      uMat4[3].w == 0.0)
+    return false;
+
+  for (int i = 0; i < ARRAY_SIZE; ++i) {
+    if (uFloatArray[i] == 0.0)
+      return false;
+
+    if (uVec2Array[i].x == 0.0 || uVec2Array[i].y == 0.0)
+      return false;
+    if (uVec3Array[i].x == 0.0 || uVec3Array[i].y == 0.0 ||
+        uVec3Array[i].z == 0.0)
+      return false;
+    if (uVec4Array[i].x == 0.0 || uVec4Array[i].y == 0.0 ||
+        uVec4Array[i].z == 0.0 || uVec4Array[i].w == 0.0)
+      return false;
+
+    if (uMat2Array[i][0].x == 0.0 || uMat2Array[i][0].y == 0.0 ||
+        uMat2Array[i][1].x == 0.0 || uMat2Array[i][1].y == 0.0)
+      return false;
+    if (uMat3Array[i][0].x == 0.0 || uMat3Array[i][0].y == 0.0 ||
+        uMat3Array[i][0].z == 0.0 || uMat3Array[i][1].x == 0.0 ||
+        uMat3Array[i][1].y == 0.0 || uMat3Array[i][1].z == 0.0 ||
+        uMat3Array[i][2].x == 0.0 || uMat3Array[i][2].y == 0.0 ||
+        uMat3Array[i][2].z == 0.0)
+      return false;
+    if (uMat4Array[i][0].x == 0.0 || uMat4Array[i][0].y == 0.0 ||
+        uMat4Array[i][0].z == 0.0 || uMat4Array[i][0].w == 0.0 ||
+        uMat4Array[i][1].x == 0.0 || uMat4Array[i][1].y == 0.0 ||
+        uMat4Array[i][1].z == 0.0 || uMat4Array[i][1].w == 0.0 ||
+        uMat4Array[i][2].x == 0.0 || uMat4Array[i][2].y == 0.0 ||
+        uMat4Array[i][2].z == 0.0 || uMat4Array[i][2].w == 0.0 ||
+        uMat4Array[i][3].x == 0.0 || uMat4Array[i][3].y == 0.0 ||
+        uMat4Array[i][3].z == 0.0 || uMat4Array[i][3].w == 0.0)
+      return false;
+  }
+
+  return true;
+}
+
+void main() {
+  if (checkAllNonZero()) {
+    fragColor = vec4(0.0, 1.0, 0.0, 1.0);
+  } else {
+    fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  }
+}

--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage.cc
@@ -86,6 +86,14 @@ absl::StatusOr<RuntimeStage> RuntimeStage::Create(
           desc.struct_layout.push_back(static_cast<uint8_t>(byte_type));
         }
       }
+      if (i->struct_elements()) {
+        for (const auto& elem : *i->struct_elements()) {
+          StructElement e;
+          e.name = elem->name()->str();
+          e.byte_size = elem->byte_size();
+          desc.struct_elements.push_back(e);
+        }
+      }
       desc.struct_float_count = i->struct_float_count();
       stage.uniforms_.push_back(std::move(desc));
     }

--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage_types.fbs
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage_types.fbs
@@ -34,6 +34,11 @@ enum StructByteType:uint8 {
   kFloat = 1,
 }
 
+table StructElement {
+  name: string;
+  byte_size: uint64;
+}
+
 table UniformDescription {
   name: string;
   location: uint64;
@@ -44,6 +49,7 @@ table UniformDescription {
   columns: uint64;
   array_elements: uint64;
   struct_layout: [StructByteType];
+  struct_elements: [StructElement];
   struct_float_count: uint64;
 }
 

--- a/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/engine/src/flutter/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <cstddef>
 #include <future>
 
 #include "flutter/fml/make_copyable.h"
@@ -73,7 +74,8 @@ TEST_P(RuntimeStageTest, CanRejectInvalidBlob) {
 
 TEST_P(RuntimeStageTest, CanReadUniforms) {
   const std::shared_ptr<fml::Mapping> fixture =
-      flutter::testing::OpenFixtureAsMapping("ink_sparkle.frag.iplr");
+      flutter::testing::OpenFixtureAsMapping(
+          "all_supported_uniforms.frag.iplr");
   ASSERT_TRUE(fixture);
   ASSERT_GT(fixture->GetSize(), 0u);
   auto stages = RuntimeStage::DecodeRuntimeStages(fixture);
@@ -86,73 +88,83 @@ TEST_P(RuntimeStageTest, CanReadUniforms) {
     case PlaygroundBackend::kMetal:
       [[fallthrough]];
     case PlaygroundBackend::kOpenGLES: {
-      ASSERT_EQ(stage->GetUniforms().size(), 17u);
+      ASSERT_EQ(stage->GetUniforms().size(), 14u);
       {
-        auto uni = stage->GetUniform("u_color");
+        // uFloat
+        auto uni = stage->GetUniform("uFloat");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 4u);
+        EXPECT_EQ(uni->dimensions.rows, 1u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 0u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_alpha");
+        // uVec2
+        auto uni = stage->GetUniform("uVec2");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 1u);
+        EXPECT_EQ(uni->dimensions.rows, 2u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 1u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_sparkle_color");
+        // uVec3
+        auto uni = stage->GetUniform("uVec3");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 4u);
+        EXPECT_EQ(uni->dimensions.rows, 3u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 2u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_sparkle_alpha");
+        // uVec4
+        auto uni = stage->GetUniform("uVec4");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 1u);
+        EXPECT_EQ(uni->dimensions.rows, 4u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 3u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_blur");
+        // uMat2
+        auto uni = stage->GetUniform("uMat2");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 1u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
+        EXPECT_EQ(uni->dimensions.rows, 2u);
+        EXPECT_EQ(uni->dimensions.cols, 2u);
         EXPECT_EQ(uni->location, 4u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_radius_scale");
+        // uMat3
+        auto uni = stage->GetUniform("uMat3");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 1u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
+        EXPECT_EQ(uni->dimensions.rows, 3u);
+        EXPECT_EQ(uni->dimensions.cols, 3u);
+        EXPECT_EQ(uni->location, 5u);
+        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
+      }
+      {
+        // uMat4
+        auto uni = stage->GetUniform("uMat4");
+        ASSERT_NE(uni, nullptr);
+        EXPECT_EQ(uni->dimensions.rows, 4u);
+        EXPECT_EQ(uni->dimensions.cols, 4u);
         EXPECT_EQ(uni->location, 6u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_max_radius");
+        // uFloatArray
+        auto uni = stage->GetUniform("uFloatArray");
         ASSERT_NE(uni, nullptr);
         EXPECT_EQ(uni->dimensions.rows, 1u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 7u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
+        // Note: Assuming 'array_size' is not part of the reflection struct
       }
       {
-        auto uni = stage->GetUniform("u_resolution_scale");
-        ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
-        EXPECT_EQ(uni->location, 8u);
-        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
-      }
-      {
-        auto uni = stage->GetUniform("u_noise_scale");
+        // uVec2Array
+        auto uni = stage->GetUniform("uVec2Array");
         ASSERT_NE(uni, nullptr);
         EXPECT_EQ(uni->dimensions.rows, 2u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
@@ -160,88 +172,132 @@ TEST_P(RuntimeStageTest, CanReadUniforms) {
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_noise_phase");
+        // uVec3Array
+        auto uni = stage->GetUniform("uVec3Array");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 1u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
-        EXPECT_EQ(uni->location, 10u);
-        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
-      }
-
-      {
-        auto uni = stage->GetUniform("u_circle1");
-        ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
+        EXPECT_EQ(uni->dimensions.rows, 3u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 11u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_circle2");
+        // uVec4Array
+        auto uni = stage->GetUniform("uVec4Array");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
-        EXPECT_EQ(uni->location, 12u);
-        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
-      }
-      {
-        auto uni = stage->GetUniform("u_circle3");
-        ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
+        EXPECT_EQ(uni->dimensions.rows, 4u);
         EXPECT_EQ(uni->dimensions.cols, 1u);
         EXPECT_EQ(uni->location, 13u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_rotation1");
+        // uMat2Array
+        auto uni = stage->GetUniform("uMat2Array");
         ASSERT_NE(uni, nullptr);
         EXPECT_EQ(uni->dimensions.rows, 2u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
-        EXPECT_EQ(uni->location, 14u);
-        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
-      }
-      {
-        auto uni = stage->GetUniform("u_rotation2");
-        ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
+        EXPECT_EQ(uni->dimensions.cols, 2u);
         EXPECT_EQ(uni->location, 15u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       {
-        auto uni = stage->GetUniform("u_rotation3");
+        // uMat3Array
+        auto uni = stage->GetUniform("uMat3Array");
         ASSERT_NE(uni, nullptr);
-        EXPECT_EQ(uni->dimensions.rows, 2u);
-        EXPECT_EQ(uni->dimensions.cols, 1u);
-        EXPECT_EQ(uni->location, 16u);
+        EXPECT_EQ(uni->dimensions.rows, 3u);
+        EXPECT_EQ(uni->dimensions.cols, 3u);
+        EXPECT_EQ(uni->location, 17u);
+        EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
+      }
+      {
+        // uMat4Array
+        auto uni = stage->GetUniform("uMat4Array");
+        ASSERT_NE(uni, nullptr);
+        EXPECT_EQ(uni->dimensions.rows, 4u);
+        EXPECT_EQ(uni->dimensions.cols, 4u);
+        EXPECT_EQ(uni->location, 19u);
         EXPECT_EQ(uni->type, RuntimeUniformType::kFloat);
       }
       break;
     }
     case PlaygroundBackend::kVulkan: {
       EXPECT_EQ(stage->GetUniforms().size(), 1u);
-      auto uni = stage->GetUniform(RuntimeStage::kVulkanUBOName);
+      const RuntimeUniformDescription* uni =
+          stage->GetUniform(RuntimeStage::kVulkanUBOName);
       ASSERT_TRUE(uni);
       EXPECT_EQ(uni->type, RuntimeUniformType::kStruct);
-      EXPECT_EQ(uni->struct_float_count, 32u);
+      EXPECT_EQ(uni->struct_float_count, 39u);
 
-      // There are 36 4 byte chunks in the UBO: 32 for the 32 floats, and 4 for
-      // padding. Initialize a vector as if they'll all be floats, then manually
-      // set the few padding bytes. If the shader changes, the padding locations
-      // will change as well. For example, if `u_alpha` was moved to the end,
-      // three bytes of padding could potentially be dropped - or if some of the
-      // scalar floats were changed to vec2 or vec4s, or if any vec3s are
-      // introduced.
-      // This means 36 * 4 = 144 bytes total.
-
-      EXPECT_EQ(uni->GetSize(), 144u);
+      EXPECT_EQ(uni->GetSize(), 640u);
       std::vector<uint8_t> layout(uni->GetSize() / sizeof(float), 1);
-      layout[5] = 0;
-      layout[6] = 0;
+      // uFloat and uVec2 are packed into a vec4 with 1 byte of padding between.
+      layout[1] = 0;
+      // uVec3 is packed as a vec4 with 1 byte of padding.
       layout[7] = 0;
-      layout[23] = 0;
+      // uMat2 is packed as two vec4s, with the last 4 bytes being all padding
+      layout[16] = 0;
+      layout[17] = 0;
+      layout[18] = 0;
+      layout[19] = 0;
+      // uMat3 is packed as 3 vec4s, with the last 3 bytes being padding
+      layout[29] = 0;
+      layout[30] = 0;
+      layout[31] = 0;
+      // uFloatArray is packed as 2 vec4s, with the last 3 bytes of each
+      // being padding.
+      layout[49] = 0;
+      layout[50] = 0;
+      layout[51] = 0;
+      layout[53] = 0;
+      layout[54] = 0;
+      layout[55] = 0;
+      // uVec2Array is packed as 2 vec4s, with 2 bytes of padding at the end of
+      // each.
+      layout[58] = 0;
+      layout[59] = 0;
+      layout[62] = 0;
+      layout[63] = 0;
+      // uVec3Array is packed as 2 vec4s, with the last byte of each as padding.
+      layout[67] = 0;
+      layout[71] = 0;
+      // uVec4Array has no padding.
+      // uMat2Array[2] is packed as 4 vec4s, with the second and last being all
+      // padding.
+      layout[84] = 0;
+      layout[85] = 0;
+      layout[86] = 0;
+      layout[87] = 0;
+      layout[92] = 0;
+      layout[93] = 0;
+      layout[94] = 0;
+      layout[95] = 0;
+      // uMat3Array[2] is packed as 6 vec4s, with the last 3 bytes of the 3rd
+      // and 6th being padding.
+      layout[105] = 0;
+      layout[106] = 0;
+      layout[107] = 0;
+      layout[117] = 0;
+      layout[118] = 0;
+      layout[119] = 0;
+      // uMat4Array[2] is packed as 8 vec4s with no padding.
+      layout[152] = 0;
+      layout[153] = 0;
+      layout[154] = 0;
+      layout[155] = 0;
+      layout[156] = 0;
+      layout[157] = 0;
+      layout[158] = 0;
+      layout[159] = 0;
 
       EXPECT_THAT(uni->struct_layout, ::testing::ElementsAreArray(layout));
+
+      std::vector<std::pair<std::string, unsigned int>> expected_uniforms = {
+          {"uFloat", 4},      {"uVec2", 8},       {"uVec3", 12},
+          {"uVec4", 16},      {"uMat2", 16},      {"uMat3", 36},
+          {"uMat4", 64},      {"uFloatArray", 8}, {"uVec2Array", 16},
+          {"uVec3Array", 24}, {"uVec4Array", 32}, {"uMat2Array", 32},
+          {"uMat3Array", 72}, {"uMat4Array", 128}};
+
+      ASSERT_EQ(uni->struct_elements.size(), expected_uniforms.size());
+
       break;
     }
   }


### PR DESCRIPTION
This PR adds struct member information to the runtime flatbuffer format. This will allow dart code to introspect structs at runtime.

Also modifies the runtime_stage tests to verify formats for all supported uniform types.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
