### PR TITLE
Marks firebase_release_smoke_test to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -705,7 +705,6 @@ targets:
       - DEPS
 
   - name: Linux firebase_release_smoke_test
-    bringup: true # https://github.com/flutter/flutter/issues/176042
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:


### PR DESCRIPTION
Tests have not failed for [50 consecutive runs](https://data.corp.google.com/sites/dash_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Linux%20firebase_release_smoke_test%22).

Fixes https://github.com/flutter/flutter/issues/176042