### PR TITLE
[ Tool ] Fix `update-packages` failing due to mismatched dependencies between flutter_tools and the framework

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -277,7 +277,7 @@ void main() {
         ..createSync(recursive: true)
         ..writeAsStringSync(kNonWorkspacePubspecYaml);
       Cache.flutterRoot = flutterSdk.absolute.path;
-      pub = _FakePub();
+      pub = _FakePub(flutterTools: flutterTools);
       processManager = FakeProcessManager.empty();
     });
 
@@ -302,6 +302,17 @@ void main() {
     testUsingContext(
       '--force-upgrade updates packages',
       () async {
+        //
+        expect(
+          Pubspec.parse(kFlutterToolsPubspecYaml).dependencies['test_api'],
+          HostedDependency(version: VersionConstraint.parse('0.7.4')),
+        );
+
+        expect(
+          Pubspec.parse(kFlutterWorkspacePubspecYaml).dependencies['test_api'],
+          HostedDependency(version: VersionConstraint.parse('0.7.4')),
+        );
+
         final command = UpdatePackagesCommand(verboseHelp: false);
         await createTestCommandRunner(command).run(<String>['update-packages', '--force-upgrade']);
         expect(
@@ -309,6 +320,9 @@ void main() {
           (Pubspec.parse(kFlutterWorkspacePubspecYaml)
                 ..dependencies['typed_data'] = HostedDependency(
                   version: VersionConstraint.parse('^1.1.1'),
+                )
+                ..dependencies['test_api'] = HostedDependency(
+                  version: VersionConstraint.parse('0.7.5'),
                 ))
               .dependencies,
         );
@@ -317,6 +331,20 @@ void main() {
           (Pubspec.parse(kFlutterToolsPubspecYaml)
                 ..dependencies['unified_analytics'] = HostedDependency(
                   version: VersionConstraint.parse('8.0.10'),
+                )
+                ..dependencies['test_api'] = HostedDependency(
+                  version: VersionConstraint.parse('0.7.5'),
+                ))
+              .dependencies,
+        );
+        expect(
+          pub.pubspecs[flutterSdk.absolute.path]!.first.dependencies,
+          (Pubspec.parse(kFlutterWorkspacePubspecYaml)
+                ..dependencies['typed_data'] = HostedDependency(
+                  version: VersionConstraint.parse('^1.1.1'),
+                )
+                ..dependencies['test_api'] = HostedDependency(
+                  version: VersionConstraint.parse('0.7.5'),
                 ))
               .dependencies,
         );
@@ -433,7 +461,9 @@ void main() {
 }
 
 class _FakePub extends Fake implements Pub {
-  _FakePub();
+  _FakePub({required this.flutterTools});
+
+  final Directory flutterTools;
 
   Map<String, List<Pubspec>> pubspecs = <String, List<Pubspec>>{};
 
@@ -490,12 +520,20 @@ class _FakePub extends Fake implements Pub {
   }
 
   Pubspec _upgrade(List<String> arguments, {required FlutterProject project}) {
-    final String pubspec = project.pubspecFile.readAsStringSync();
-    project.pubspecFile.writeAsStringSync(
-      pubspec
-          .replaceFirst('typed_data: ^1.1.6', 'typed_data: ^1.1.1')
-          .replaceFirst('unified_analytics: ^8.0.5', 'unified_analytics: ^8.0.10'),
-    );
+    final String pubspec = project.pubspecFile
+        .readAsStringSync()
+        .replaceFirst('typed_data: ^1.1.6', 'typed_data: ^1.1.1')
+        .replaceFirst('unified_analytics: ^8.0.5', 'unified_analytics: ^8.0.10')
+        .replaceFirst(
+          'test_api: ^0.7.4',
+          // Set test_api to a newer version for flutter_tools to verify that the version in the
+          // updated flutter_tools pubspec is pinned to the same version as the framework.
+          //
+          // Regression test for https://github.com/flutter/flutter/issues/180503.
+          project.directory == flutterTools ? 'test_api: ^10.0.0' : 'test_api: ^0.7.5',
+        );
+    project.pubspecFile.writeAsStringSync(pubspec);
+
     final upgradedPubspec = Pubspec.parse(project.pubspecFile.readAsStringSync());
     for (final MapEntry<String, Dependency>(key: packageName, value: dependency) in [
       ...upgradedPubspec.dependencies.entries,

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -338,17 +338,6 @@ void main() {
               .dependencies,
         );
         expect(
-          pub.pubspecs[flutterSdk.absolute.path]!.first.dependencies,
-          (Pubspec.parse(kFlutterWorkspacePubspecYaml)
-                ..dependencies['typed_data'] = HostedDependency(
-                  version: VersionConstraint.parse('^1.1.1'),
-                )
-                ..dependencies['test_api'] = HostedDependency(
-                  version: VersionConstraint.parse('0.7.5'),
-                ))
-              .dependencies,
-        );
-        expect(
           pub.pubspecs[widgetPreviewScaffold.absolute.path]!.first.dependencies,
           (Pubspec.parse(kWidgetTestPubspecYaml)
                 ..dependencies['unified_analytics'] = HostedDependency(


### PR DESCRIPTION
Since the `widget_preview_scaffold` project depends on both the Flutter SDK and `flutter_tools`, `flutter_tools` must use the same version pins as the Flutter SDK. This change ensures that any packages used by both the Flutter SDK and `flutter_tools` use the same pinned version.

Fixes https://github.com/flutter/flutter/issues/180503