### PR TITLE
No longer exiting the application when the RegularWindow is destroyed + resolving the window created promise after runWidget

### DIFF
--- a/dev/integration_tests/windowing_test/lib/main.dart
+++ b/dev/integration_tests/windowing_test/lib/main.dart
@@ -3,25 +3,15 @@
 // found in the LICENSE file.
 
 // ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: implementation_imports
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/_window.dart';
 import 'package:flutter_driver/driver_extension.dart';
-
-class _MainRegularWindowControllerDelegate
-    extends RegularWindowControllerDelegate {
-  @override
-  void onWindowDestroyed() {
-    super.onWindowDestroyed();
-
-    exit(0);
-  }
-}
 
 late final RegularWindowController controller;
 final ValueNotifier<DialogWindowController?> dialogController = ValueNotifier(
@@ -180,11 +170,11 @@ void main() {
   controller = RegularWindowController(
     preferredSize: Size(640, 480),
     title: 'Integration Test',
-    delegate: _MainRegularWindowControllerDelegate(),
+    delegate: RegularWindowControllerDelegate(),
   );
-  windowCreated.complete();
 
   runWidget(RegularWindow(controller: controller, child: MyApp()));
+  windowCreated.complete();
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
This potentially fixes https://github.com/flutter/flutter/issues/177715 by:

1. Relying on the test framework to close the app
2. Completing the `windowCreated` future following `runWidget` when everything is _actually_ ready to go

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

