### PR TITLE
Fixes macOS App.framework not being codesigned or find framework

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -286,15 +286,15 @@ class Context {
     final xcodeFrameworksDir =
         '${environment['TARGET_BUILD_DIR']}/${environment['FRAMEWORKS_FOLDER_PATH']}';
     runSync('mkdir', <String>['-p', '--', xcodeFrameworksDir]);
-    runRsync('${environment['BUILT_PRODUCTS_DIR']}/App.framework', xcodeFrameworksDir);
 
     final String? expandedCodeSignIdentity = environment['EXPANDED_CODE_SIGN_IDENTITY'];
-
     final bool codesign =
         platform == TargetPlatform.macos &&
         expandedCodeSignIdentity != null &&
         expandedCodeSignIdentity.isNotEmpty &&
         environment['CODE_SIGNING_REQUIRED'] != 'NO';
+
+    _embedAppFramework(xcodeFrameworksDir, codesign ? expandedCodeSignIdentity : null);
 
     var shouldEmbedFlutterFramework = true;
     if (_usingFlutterFrameworkSwiftPackage()) {
@@ -332,7 +332,6 @@ class Context {
           );
 
           if (codesign) {
-            _codesignFramework(expandedCodeSignIdentity, '$xcodeFrameworksDir/App.framework/App');
             _codesignFramework(
               expandedCodeSignIdentity,
               '$xcodeFrameworksDir/FlutterMacOS.framework/FlutterMacOS',
@@ -350,6 +349,13 @@ class Context {
 
     if (platform == TargetPlatform.ios) {
       addVmServiceBonjourService();
+    }
+  }
+
+  void _embedAppFramework(String xcodeFrameworksDir, String? expandedCodeSignIdentity) {
+    runRsync('${environment['BUILT_PRODUCTS_DIR']}/App.framework', xcodeFrameworksDir);
+    if (expandedCodeSignIdentity != null) {
+      _codesignFramework(expandedCodeSignIdentity, '$xcodeFrameworksDir/App.framework/App');
     }
   }
 

--- a/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_package_manager.dart
@@ -261,6 +261,7 @@ class SwiftPackageManager {
       fileSystem: _fileSystem,
       platform: platform,
       project: project,
+      createIfNotFound: true,
     );
   }
 
@@ -270,6 +271,7 @@ class SwiftPackageManager {
     required FileSystem fileSystem,
     required FlutterDarwinPlatform platform,
     required XcodeBasedProject project,
+    bool createIfNotFound = false,
   }) {
     final String frameworkName = platform.binaryName;
     final Link frameworkLink = fileSystem.link(
@@ -279,7 +281,7 @@ class SwiftPackageManager {
     );
     if (frameworkLink.existsSync()) {
       frameworkLink.updateSync('./${buildMode.uppercaseName}/$frameworkName.xcframework');
-    } else {
+    } else if (createIfNotFound) {
       frameworkLink.createSync(
         './${buildMode.uppercaseName}/$frameworkName.xcframework',
         recursive: true,

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -483,7 +483,7 @@ let package = Package(
         });
 
         group('updateFlutterFrameworkSymlink', () {
-          testWithoutContext('create link if does not exists', () {
+          testWithoutContext('does not create link', () {
             final fs = MemoryFileSystem();
             final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
             final Link frameworkSymlink = project.flutterFrameworkSwiftPackageDirectory.childLink(
@@ -495,6 +495,23 @@ let package = Package(
               fileSystem: fs,
               platform: platform,
               project: project,
+            );
+            expect(frameworkSymlink.existsSync(), isFalse);
+          });
+
+          testWithoutContext('creates link when createIfNotFound is true', () {
+            final fs = MemoryFileSystem();
+            final project = FakeXcodeProject(platform: platform.name, fileSystem: fs);
+            final Link frameworkSymlink = project.flutterFrameworkSwiftPackageDirectory.childLink(
+              '${platform.binaryName}.xcframework',
+            );
+            expect(frameworkSymlink.existsSync(), isFalse);
+            SwiftPackageManager.updateFlutterFrameworkSymlink(
+              buildMode: BuildMode.profile,
+              fileSystem: fs,
+              platform: platform,
+              project: project,
+              createIfNotFound: true,
             );
             expect(frameworkSymlink.targetSync(), './Profile/${platform.binaryName}.xcframework');
           });

--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -993,6 +993,20 @@ void main() {
           ),
           FakeCommand(
             command: <String>[
+              'codesign',
+              '--force',
+              '--verbose',
+              '--sign',
+              codesignIdentity,
+              '--',
+              targetBuildDir
+                  .childDirectory(frameworksFolderPath)
+                  .childFile('App.framework/App')
+                  .path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
               'rsync',
               '-8',
               '-av',
@@ -1007,20 +1021,7 @@ void main() {
               '${targetBuildDir.childDirectory(frameworksFolderPath).path}/',
             ],
           ),
-          FakeCommand(
-            command: <String>[
-              'codesign',
-              '--force',
-              '--verbose',
-              '--sign',
-              codesignIdentity,
-              '--',
-              targetBuildDir
-                  .childDirectory(frameworksFolderPath)
-                  .childFile('App.framework/App')
-                  .path,
-            ],
-          ),
+
           FakeCommand(
             command: <String>[
               'codesign',
@@ -1472,6 +1473,7 @@ void main() {
           final File infoPlist = memoryFileSystem.file('${buildDir.path}/$infoPlistPath');
           infoPlist.createSync(recursive: true);
           const buildMode = 'Debug';
+          const codesignIdentity = '12312313';
           final testContext = TestContext(
             <String>['embed_and_thin', 'macos'],
             <String, String>{
@@ -1486,6 +1488,7 @@ void main() {
               'FRAMEWORKS_FOLDER_PATH': frameworksFolderPath,
               'FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH': flutterSwiftPackageDir.path,
               'SDKROOT': 'macosx',
+              'EXPANDED_CODE_SIGN_IDENTITY': codesignIdentity,
             },
             commands: <FakeCommand>[
               FakeCommand(
@@ -1510,6 +1513,20 @@ void main() {
               ),
               FakeCommand(
                 command: <String>[
+                  'codesign',
+                  '--force',
+                  '--verbose',
+                  '--sign',
+                  codesignIdentity,
+                  '--',
+                  targetBuildDir
+                      .childDirectory(frameworksFolderPath)
+                      .childFile('App.framework/App')
+                      .path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
                   'rsync',
                   '-8',
                   '-av',
@@ -1522,6 +1539,20 @@ void main() {
                   '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'codesign',
+                  '--force',
+                  '--verbose',
+                  '--sign',
+                  codesignIdentity,
+                  '--',
+                  targetBuildDir
+                      .childDirectory(frameworksFolderPath)
+                      .childFile('$ffiPackageName.framework/$ffiPackageName')
+                      .path,
                 ],
               ),
             ],
@@ -1970,6 +2001,20 @@ void main() {
           ),
           FakeCommand(
             command: <String>[
+              'codesign',
+              '--force',
+              '--verbose',
+              '--sign',
+              codesignIdentity,
+              '--',
+              targetBuildDir
+                  .childDirectory(frameworksFolderPath)
+                  .childFile('App.framework/App')
+                  .path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
               'rsync',
               '-8',
               '-av',
@@ -1984,20 +2029,7 @@ void main() {
               '${targetBuildDir.childDirectory(frameworksFolderPath).path}/',
             ],
           ),
-          FakeCommand(
-            command: <String>[
-              'codesign',
-              '--force',
-              '--verbose',
-              '--sign',
-              codesignIdentity,
-              '--',
-              targetBuildDir
-                  .childDirectory(frameworksFolderPath)
-                  .childFile('App.framework/App')
-                  .path,
-            ],
-          ),
+
           FakeCommand(
             command: <String>[
               'codesign',


### PR DESCRIPTION
When SwiftPM is enabled, it doesn't embed/codesign the Flutter framework via Flutter tooling since it's now handled by Xcode. There was a bug in this, though, which prevented the App.framework from being codesigned. This PR fixes that.

Fixes https://github.com/flutter/flutter/issues/181056.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
