### PR TITLE
Revert #176711

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -173,7 +173,7 @@ enum DropdownMenuCloseBehavior {
 ///   The [DropdownMenu] uses a [TextField] as the "anchor".
 /// * [TextField], which is a text input widget that uses an [InputDecoration].
 /// * [DropdownMenuEntry], which is used to build the [MenuItemButton] in the [DropdownMenu] list.
-class DropdownMenu<T extends Object> extends StatefulWidget {
+class DropdownMenu<T> extends StatefulWidget {
   /// Creates a const [DropdownMenu].
   ///
   /// The leading and trailing icons in the text field can be customized by using
@@ -448,12 +448,7 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
 
   /// The callback is called when a selection is made.
   ///
-  /// The callback receives the selected entry's value of type `T` when the user
-  /// chooses an item. It may also be invoked with `null` to indicate that the
-  /// selection was cleared / that no item was chosen.
-  ///
-  /// Defaults to null. If this callback itself is null, the widget still updates
-  /// the text field with the selected label.
+  /// Defaults to null. If null, only the text field is updated.
   final ValueChanged<T?>? onSelected;
 
   /// Defines the keyboard focus for this widget.
@@ -690,7 +685,7 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
 }
 
-class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
+class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   static const Map<ShortcutActivator, Intent> _editableShortcuts = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowLeft): ExtendSelectionByCharacterIntent(
       forward: false,

--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -28,7 +28,7 @@ import 'menu_style.dart';
 ///
 ///  * [DropdownMenu], which is the underlying text field without the [Form]
 ///    integration.
-class DropdownMenuFormField<T extends Object> extends FormField<T> {
+class DropdownMenuFormField<T> extends FormField<T> {
   /// Creates a [DropdownMenu] widget that is a [FormField].
   ///
   /// For a description of the `onSaved`, `validator`, or `autovalidateMode`
@@ -140,12 +140,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
 
   /// The callback is called when a selection is made.
   ///
-  /// The callback receives the selected entry's value of type `T` when the user
-  /// chooses an item. It may also be invoked with `null` to indicate that the
-  /// selection was cleared / that no item was chosen.
-  ///
-  /// Defaults to null. If this callback itself is null, the widget still updates
-  /// the text field with the selected label.
+  /// Defaults to null. If null, only the text field is updated.
   final ValueChanged<T?>? onSelected;
 
   /// Controls the text being edited.
@@ -164,7 +159,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
   FormFieldState<T> createState() => _DropdownMenuFormFieldState<T>();
 }
 
-class _DropdownMenuFormFieldState<T extends Object> extends FormFieldState<T> {
+class _DropdownMenuFormFieldState<T> extends FormFieldState<T> {
   DropdownMenuFormField<T> get _dropdownMenuFormField => widget as DropdownMenuFormField<T>;
 
   // The controller used to restore the selected item.


### PR DESCRIPTION
As discussed under https://github.com/flutter/flutter/pull/176711 and https://github.com/flutter/flutter/issues/180121, the PR was a hard break. After discussing with @LongCatIsLooong , we've agreed to revert this PR for now and seek better approaches or more justification in the future.



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
