### PR TITLE
Marks linux_chrome_dev_mode to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2961,7 +2961,6 @@ targets:
       task_name: large_image_changer_perf_android
 
   - name: Linux_pixel_7pro linux_chrome_dev_mode
-    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
According to https://github.com/flutter/flutter/issues/173696#issuecomment-3522821072 this should no longer be flaking and should not be `bringup: true`.