### PR TITLE
Fix PopScope blocking maybePop from sibling widgets

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -2006,7 +2006,7 @@ class _NavigationBarStaticComponents {
       leadingContent = CupertinoButton(
         padding: EdgeInsets.zero,
         onPressed: () {
-          route.navigator!.maybePop();
+          route.navigator!.maybePop(null, context);
         },
         child: Text(CupertinoLocalizations.of(context).cancelButtonLabel),
       );

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2669,6 +2669,31 @@ void main() {
     expect(find.text('dialog1'), findsOneWidget);
   });
 
+  testWidgets('can be dismissed with escape when PopScope is inside dialog', (
+    WidgetTester tester,
+  ) async {
+    // Regression test: PopScope inside a dialog should not block dismissing
+    // the dialog via escape key, because the PopScope is not an ancestor of
+    // the dismiss action.
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('home')));
+
+    showDialog<void>(
+      context: tester.element(find.text('home')),
+      builder: (BuildContext context) =>
+          const PopScope<void>(canPop: false, child: Text('dialog with PopScope')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('dialog with PopScope'), findsOneWidget);
+
+    // Escape should still dismiss the dialog because PopScope is inside the
+    // dialog, not an ancestor of the barrier/dismiss action.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.text('dialog with PopScope'), findsNothing);
+    expect(find.text('home'), findsOneWidget);
+  });
+
   testWidgets('ModalRoute.of works for void routes', (WidgetTester tester) async {
     final navigatorKey = GlobalKey<NavigatorState>();
     await tester.pumpWidget(MaterialApp(navigatorKey: navigatorKey, home: const Text('home')));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/181304

`PopScope` (and `NavigatorPopHandler`) registers with `ModalRoute` and blocks **all** `maybePop()` calls on that route, regardless of widget tree position. This means a `PopScope` in the body blocks a `BackButton` in the `AppBar`, even though they're siblings, not ancestors.

```
Scaffold
├── AppBar
│   └── BackButton  ← blocked by PopScope (incorrectly)
└── body
    └── PopScope(canPop: false)
```

This change makes `popDisposition` ancestor-aware: only `PopScope` instances that are ancestors of the `maybePop()` caller will block the pop.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md