### PR TITLE
Make sure that an AnimatedAlign doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/widgets/animated_align_test.dart
+++ b/packages/flutter/test/widgets/animated_align_test.dart
@@ -146,4 +146,22 @@ void main() {
     final RenderBox box = tester.renderObject<RenderBox>(find.byType(SizedBox).last);
     expect(box.size, equals(const Size(100.0, 100)));
   });
+
+  testWidgets('AnimatedAlign does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox.shrink(
+            child: AnimatedAlign(
+              alignment: Alignment.bottomCenter,
+              duration: Duration(milliseconds: 50),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.byType(AnimatedAlign)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the AnimatedAlign widget.