### PR TITLE
[beta] Cherry pick https://github.com/flutter/flutter/pull/181074

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -173,7 +173,7 @@ enum DropdownMenuCloseBehavior {
 ///   The [DropdownMenu] uses a [TextField] as the "anchor".
 /// * [TextField], which is a text input widget that uses an [InputDecoration].
 /// * [DropdownMenuEntry], which is used to build the [MenuItemButton] in the [DropdownMenu] list.
-class DropdownMenu<T extends Object> extends StatefulWidget {
+class DropdownMenu<T> extends StatefulWidget {
   /// Creates a const [DropdownMenu].
   ///
   /// The leading and trailing icons in the text field can be customized by using
@@ -690,7 +690,7 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
 }
 
-class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
+class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   static const Map<ShortcutActivator, Intent> _editableShortcuts = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowLeft): ExtendSelectionByCharacterIntent(
       forward: false,

--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -28,7 +28,7 @@ import 'menu_style.dart';
 ///
 ///  * [DropdownMenu], which is the underlying text field without the [Form]
 ///    integration.
-class DropdownMenuFormField<T extends Object> extends FormField<T> {
+class DropdownMenuFormField<T> extends FormField<T> {
   /// Creates a [DropdownMenu] widget that is a [FormField].
   ///
   /// For a description of the `onSaved`, `validator`, or `autovalidateMode`
@@ -164,7 +164,7 @@ class DropdownMenuFormField<T extends Object> extends FormField<T> {
   FormFieldState<T> createState() => _DropdownMenuFormFieldState<T>();
 }
 
-class _DropdownMenuFormFieldState<T extends Object> extends FormFieldState<T> {
+class _DropdownMenuFormFieldState<T> extends FormFieldState<T> {
   DropdownMenuFormField<T> get _dropdownMenuFormField => widget as DropdownMenuFormField<T>;
 
   // The controller used to restore the selected item.

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -32,6 +32,14 @@ void main() {
     return find.widgetWithText(MenuItemButton, menuItem.label).last;
   }
 
+  Finder findMenuItemButton(String label) {
+    // For each menu items there are two MenuItemButton widgets.
+    // The last one is the real button item in the menu.
+    // The first one is not visible, it is part of _DropdownMenuBody
+    // which is used to compute the dropdown width.
+    return find.widgetWithText(MenuItemButton, label).last;
+  }
+
   testWidgets('Creates an underlying DropdownMenu', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -1393,5 +1401,48 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(DropdownMenuFormField<MenuItem>)), Size.zero);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/180121.
+  testWidgets('Allow null entry to clear selection', (WidgetTester tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    const selectNoneLabel = 'Select none';
+    final nullableMenuItems = <DropdownMenuEntry<String?>>[
+      const DropdownMenuEntry<String?>(value: null, label: selectNoneLabel),
+      const DropdownMenuEntry<String?>(value: 'a', label: 'A'),
+      const DropdownMenuEntry<String?>(value: 'b', label: 'B'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return DropdownMenuFormField<String?>(
+                controller: controller,
+                requestFocusOnTap: true,
+                enableFilter: true,
+                dropdownMenuEntries: nullableMenuItems,
+                onSelected: (_) {
+                  setState(() {});
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open the menu.
+    await tester.tap(find.byType(DropdownMenu<String?>));
+    await tester.pump();
+
+    // Select the 'None' item.
+    await tester.tap(findMenuItemButton(selectNoneLabel));
+    await tester.pumpAndSettle();
+
+    expect(controller.text, selectNoneLabel);
   });
 }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -5333,6 +5333,49 @@ void main() {
       shouldFocusPrevious: textInputAction == TextInputAction.previous,
     );
   }, variant: focusVariants);
+
+  // Regression test for https://github.com/flutter/flutter/issues/180121.
+  testWidgets('Allow null entry to clear selection', (WidgetTester tester) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    const selectNoneLabel = 'Select none';
+    final nullableMenuItems = <DropdownMenuEntry<String?>>[
+      const DropdownMenuEntry<String?>(value: null, label: selectNoneLabel),
+      const DropdownMenuEntry<String?>(value: 'a', label: 'A'),
+      const DropdownMenuEntry<String?>(value: 'b', label: 'B'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return DropdownMenu<String?>(
+                controller: controller,
+                requestFocusOnTap: true,
+                enableFilter: true,
+                dropdownMenuEntries: nullableMenuItems,
+                onSelected: (_) {
+                  setState(() {});
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Open the menu.
+    await tester.tap(find.byType(DropdownMenu<String?>));
+    await tester.pump();
+
+    // Select the 'None' item.
+    await tester.tap(findMenuItemButton(selectNoneLabel));
+    await tester.pumpAndSettle();
+
+    expect(controller.text, selectNoneLabel);
+  });
 }
 
 enum TestMenu {


### PR DESCRIPTION
This PR cherrypicks https://github.com/flutter/flutter/pull/181074 into beta, which is mostly a revert of https://github.com/flutter/flutter/pull/176711 (except that some docs are left unreverted and a few new tests are added.) This is needed to address a breakage as described in https://github.com/flutter/flutter/issues/180121.

**Impacted Users:** Apps that use `DropdownMenu` or `DropdownMenuFormField` for a nullable class, such as `DropdownMenu<int?>`.

**Impact Description:** Can not compile.

**Workaround:** Yes, through non-trivial changes. For example, the developer can replace  `DropdownMenu<int?>` with `DropdownMenu<Maybe<int>>`, as long as they import `Maybe` or create their own equivalence. 

**Risk:** Low. This PR is basically a revert.


**Test Coverage:** Yes. The widget has high test coverage.

**Validation Steps:** The PR compiles and tests pass.
