### PR TITLE
test: Improve DropdownMenuFormField tests

### DIFF
--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -24,20 +24,16 @@ void main() {
     menuEntries.add(entry);
   }
 
-  Finder findMenuItem(MenuItem menuItem) {
-    // For each menu item there are two MenuItemButton widgets.
-    // The last one is the real button item in the menu.
-    // The first one is not visible, it is part of _DropdownMenuBody
-    // which is used to compute the dropdown width.
-    return find.widgetWithText(MenuItemButton, menuItem.label).last;
-  }
-
   Finder findMenuItemButton(String label) {
     // For each menu items there are two MenuItemButton widgets.
     // The last one is the real button item in the menu.
     // The first one is not visible, it is part of _DropdownMenuBody
     // which is used to compute the dropdown width.
     return find.widgetWithText(MenuItemButton, label).last;
+  }
+
+  Finder findMenuItem(MenuItem menuItem) {
+    return findMenuItemButton(menuItem.label);
   }
 
   testWidgets('Creates an underlying DropdownMenu', (WidgetTester tester) async {
@@ -884,7 +880,7 @@ void main() {
     expect(dropdownMenu.restorationId, restorationId);
   });
 
-  testWidgets('Field state is correcly updated', (WidgetTester tester) async {
+  testWidgets('Field state is correctly updated', (WidgetTester tester) async {
     final fieldKey = GlobalKey<FormFieldState<MenuItem>>();
 
     await tester.pumpWidget(
@@ -1366,7 +1362,7 @@ void main() {
     expect(onSelectedCallCount, 1);
   });
 
-  testWidgets('onSelect is called exactly once when reseted', (WidgetTester tester) async {
+  testWidgets('onSelect is called exactly once when reset', (WidgetTester tester) async {
     var onSelectedCallCount = 0;
     final fieldKey = GlobalKey<FormFieldState<MenuItem>>();
     await tester.pumpWidget(
@@ -1436,7 +1432,7 @@ void main() {
     );
 
     // Open the menu.
-    await tester.tap(find.byType(DropdownMenu<String?>));
+    await tester.tap(find.byType(DropdownMenuFormField<String?>));
     await tester.pump();
 
     // Select the 'None' item.


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/pull/181367#discussion_r2719670803

The test was still valid as `DropdownMenuFormField` includes `DropdownMenu` and therefore could select the desired MenuItemButton.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
