### PR TITLE
[beta] Cherry pick https://github.com/flutter/flutter/pull/181269

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -230,7 +230,7 @@ class CupertinoSheetTransition extends StatefulWidget {
     required this.secondaryRouteAnimation,
     required this.child,
     required this.linearTransition,
-    required this.topGap,
+    this.topGap = _kTopGapRatio,
   });
 
   /// `primaryRouteAnimation` is a linear route animation from 0.0 to 1.0 when
@@ -252,9 +252,13 @@ class CupertinoSheetTransition extends StatefulWidget {
   /// The gap between the top of the screen and the top of the sheet as a ratio
   /// of the screen height.
   ///
+  ///{@template flutter.cupertino.CupertinoSheetTransition.topGap}
   /// This value should be between 0.0 and 0.9, where 0.0 means no gap (sheet
   /// extends to the top of the screen) and 0.9 means the sheet covers only the
   /// bottom 10% of the screen. A value of 0.08 represents 8% of the screen height.
+  ///
+  /// If not provided, defaults to a value of 0.08.
+  /// {@endtemplate}
   final double topGap;
 
   /// The primary delegated transition. Will slide a non [CupertinoSheetRoute] page down.
@@ -736,7 +740,9 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
   bool get enableDrag;
 
   /// The gap between the top of the screen and the top of the sheet as a ratio
-  /// of the screen height (0.0 to 1.0). Defaults to a value of 0.08.
+  /// of the screen height.
+  ///
+  /// {@macro flutter.cupertino.CupertinoSheetTransition.topGap}
   double get topGap;
 
   /// Whether a custom top gap has been set.

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -2018,7 +2018,6 @@ void main() {
       CupertinoSheetTransition(
         primaryRouteAnimation: animation,
         secondaryRouteAnimation: secondaryAnimation,
-        topGap: 0.08,
         linearTransition: false,
         child: const SizedBox(height: 100, width: 100),
       ),
@@ -2031,7 +2030,6 @@ void main() {
       CupertinoSheetTransition(
         primaryRouteAnimation: newAnimation,
         secondaryRouteAnimation: secondaryAnimation,
-        topGap: 0.08,
         linearTransition: false,
         child: const SizedBox(height: 100, width: 100),
       ),


### PR DESCRIPTION
This PR cherrypicks https://github.com/flutter/flutter/pull/181269 into beta. This is needed to address a breakage.

**Impacted Users:** Apps that directly use `CupertinoSheetTransition `.

**Impact Description:** Can not compile.

**Workaround:** Yes. They need to add `topGap: 0.08` to the constructor.

**Risk:** Low. This PR loosens the API, and reverts the behavior to that before https://github.com/flutter/flutter/pull/171348.

**Test Coverage:** Yes. The widget has high test coverage.

**Validation Steps:** The PR compiles and tests pass. `sheet_test.dart` contains constructors that do not specify `topGap` in the same way as existing apps.
