### PR TITLE
[Material] modernize Typography._withPlatform with Dart 3 switch expression

### DIFF
--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -215,27 +215,16 @@ class Typography with Diagnosticable {
     TextTheme tall,
   ) {
     assert(platform != null || (black != null && white != null));
-    switch (platform) {
-      case TargetPlatform.iOS:
-        black ??= blackCupertino;
-        white ??= whiteCupertino;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        black ??= blackMountainView;
-        white ??= whiteMountainView;
-      case TargetPlatform.windows:
-        black ??= blackRedmond;
-        white ??= whiteRedmond;
-      case TargetPlatform.macOS:
-        black ??= blackRedwoodCity;
-        white ??= whiteRedwoodCity;
-      case TargetPlatform.linux:
-        black ??= blackHelsinki;
-        white ??= whiteHelsinki;
-      case null:
-        break;
-    }
-    return Typography._(black!, white!, englishLike, dense, tall);
+    final (TextTheme blackResolved, TextTheme whiteResolved) = switch (platform) {
+      TargetPlatform.iOS => (black ?? blackCupertino, white ?? whiteCupertino),
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia => (black ?? blackMountainView, white ?? whiteMountainView),
+      TargetPlatform.windows => (black ?? blackRedmond, white ?? whiteRedmond),
+      TargetPlatform.macOS => (black ?? blackRedwoodCity, white ?? whiteRedwoodCity),
+      TargetPlatform.linux => (black ?? blackHelsinki, white ?? whiteHelsinki),
+      null => (black!, white!),
+    };
+    return Typography._(blackResolved, whiteResolved, englishLike, dense, tall);
   }
 
   const Typography._(this.black, this.white, this.englishLike, this.dense, this.tall);


### PR DESCRIPTION
Continuing the effort to clean up some of the older switch statements, I've moved over to `typography.dart`

I found that `Typography._withPlatform` was using a standard switch block to handle platform-specific theme assignments. Since both `black` and `white` themes are resolved based on the same platform variable, I've refactored this into a single switch expression using a Record. This allowed me to group Android and Fuchsia together using the new logical OR pattern, which feels much cleaner.

The logic and the existing fallbacks haven't changed at all—the `assert` at the start already guarantees we have the required themes if the platform is null, so I've handled that case directly in the expression.

I've run the local tests in `typography_test.dart` and everything is passing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA]. (I will sign it once the bot prompts me)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md