### PR TITLE
Remove material from single_child_scroll_view_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -248,7 +248,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/selection_container_test.dart',
     'packages/flutter/test/widgets/scrollable_semantics_test.dart',
     'packages/flutter/test/widgets/rotated_box_test.dart',
-    'packages/flutter/test/widgets/single_child_scroll_view_test.dart',
     'packages/flutter/test/widgets/pinned_header_sliver_test.dart',
     'packages/flutter/test/widgets/raw_radio_test.dart',
     'packages/flutter/test/widgets/syncing_test.dart',

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -53,6 +53,44 @@ void main() {
     expect(controller.position.pixels, 100.0);
   });
 
+  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests', (WidgetTester tester) async {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          key: scaffoldKey,
+          drawer: Container(),
+          body: Column(
+            children: <Widget>[
+              const TextField(),
+              Expanded(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                  child: Container(height: 1000),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.testTextInput.isVisible, isFalse);
+    final Finder finder = find.byType(TextField).first;
+    await tester.tap(finder);
+    expect(tester.testTextInput.isVisible, isTrue);
+
+    await tester.drag(find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
+    await tester.pumpAndSettle();
+
+    expect(tester.testTextInput.isVisible, isFalse);
+    scaffoldKey.currentState!.openDrawer();
+    await tester.pumpAndSettle();
+
+    expect(tester.testTextInput.isVisible, isFalse);
+  });
+
   testWidgets('Scaffold drawer callback test', (WidgetTester tester) async {
     var isDrawerOpen = false;
     var isEndDrawerOpen = false;

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/rendering_tester.dart' show TestClipPaintingContext;
@@ -1047,16 +1047,14 @@ void main() {
 
     Future<void> boilerplate(ScrollViewKeyboardDismissBehavior behavior) {
       return tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SingleChildScrollView(
-              padding: EdgeInsets.zero,
-              keyboardDismissBehavior: behavior,
-              child: Column(
-                children: focusNodes.map((FocusNode focusNode) {
-                  return SizedBox(height: 50, child: TextField(focusNode: focusNode));
-                }).toList(),
-              ),
+        TestWidgetsApp(
+          home: SingleChildScrollView(
+            padding: EdgeInsets.zero,
+            keyboardDismissBehavior: behavior,
+            child: Column(
+              children: focusNodes.map((FocusNode focusNode) {
+                return SizedBox(height: 50, child: TestTextField(focusNode: focusNode));
+              }).toList(),
             ),
           ),
         ),
@@ -1066,63 +1064,25 @@ void main() {
     // ScrollViewKeyboardDismissBehavior.onDrag dismiss keyboard on drag
     await boilerplate(ScrollViewKeyboardDismissBehavior.onDrag);
 
-    Finder finder = find.byType(TextField).first;
-    TextField textField = tester.widget(finder);
+    Finder finder = find.byType(EditableText).first;
+    EditableText textField = tester.widget(finder);
     await tester.showKeyboard(finder);
-    expect(textField.focusNode!.hasFocus, isTrue);
+    expect(textField.focusNode.hasFocus, isTrue);
 
     await tester.drag(finder, const Offset(0.0, -40.0));
     await tester.pumpAndSettle();
-    expect(textField.focusNode!.hasFocus, isFalse);
+    expect(textField.focusNode.hasFocus, isFalse);
 
     // ScrollViewKeyboardDismissBehavior.manual does no dismiss the keyboard
     await boilerplate(ScrollViewKeyboardDismissBehavior.manual);
 
-    finder = find.byType(TextField).first;
+    finder = find.byType(EditableText).first;
     textField = tester.widget(finder);
     await tester.showKeyboard(finder);
-    expect(textField.focusNode!.hasFocus, isTrue);
+    expect(textField.focusNode.hasFocus, isTrue);
 
     await tester.drag(finder, const Offset(0.0, -40.0));
     await tester.pumpAndSettle();
-    expect(textField.focusNode!.hasFocus, isTrue);
-  });
-
-  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests', (WidgetTester tester) async {
-    final scaffoldKey = GlobalKey<ScaffoldState>();
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          key: scaffoldKey,
-          drawer: Container(),
-          body: Column(
-            children: <Widget>[
-              const TextField(),
-              Expanded(
-                child: SingleChildScrollView(
-                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-                  child: Container(height: 1000),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-
-    expect(tester.testTextInput.isVisible, isFalse);
-    final Finder finder = find.byType(TextField).first;
-    await tester.tap(finder);
-    expect(tester.testTextInput.isVisible, isTrue);
-
-    await tester.drag(find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
-    await tester.pumpAndSettle();
-
-    expect(tester.testTextInput.isVisible, isFalse);
-    scaffoldKey.currentState!.openDrawer();
-    await tester.pumpAndSettle();
-
-    expect(tester.testTextInput.isVisible, isFalse);
+    expect(textField.focusNode.hasFocus, isTrue);
   });
 }


### PR DESCRIPTION
This PR removes Material from the single_child_scroll_view_test.dart and moves a Drawer test to scaffold_test.dart

Part of https://github.com/flutter/flutter/issues/177415
Depends on https://github.com/flutter/flutter/pull/180456
Depends on https://github.com/flutter/flutter/pull/180494

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
