### PR TITLE
[ Tool ] Cleanup `ResidentCompiler` initialization logic

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -61,6 +61,50 @@ class BuildInfo {
        dartDefines = dartDefines ?? const <String>[],
        dartExperiments = dartExperiments ?? const <String>[];
 
+  BuildInfo copyWith({
+    String? fileSystemScheme,
+    List<String>? fileSystemRoots,
+    List<String>? extraFrontEndOptions,
+    String? packageConfigPath,
+    PackageConfig? packageConfig,
+    String? initializeFromDill,
+    List<String>? dartDefines,
+    bool? includeUnsupportedPlatformLibraryStubs,
+  }) {
+    return BuildInfo(
+      mode,
+      flavor,
+      trackWidgetCreation: trackWidgetCreation,
+      frontendServerStarterPath: frontendServerStarterPath,
+      extraFrontEndOptions: extraFrontEndOptions ?? this.extraFrontEndOptions,
+      extraGenSnapshotOptions: extraGenSnapshotOptions,
+      fileSystemRoots: fileSystemRoots ?? this.fileSystemRoots,
+      androidProjectArgs: androidProjectArgs,
+      androidGradleProjectCacheDir: androidGradleProjectCacheDir,
+      fileSystemScheme: fileSystemScheme ?? this.fileSystemScheme,
+      buildNumber: buildNumber,
+      buildName: buildName,
+      splitDebugInfoPath: splitDebugInfoPath,
+      dartObfuscation: dartObfuscation,
+      dartDefines: dartDefines ?? this.dartDefines,
+      dartExperiments: dartExperiments,
+      performanceMeasurementFile: performanceMeasurementFile,
+      packageConfigPath: packageConfigPath ?? this.packageConfigPath,
+      codeSizeDirectory: codeSizeDirectory,
+      androidGradleDaemon: androidGradleDaemon,
+      androidSkipBuildDependencyValidation: androidSkipBuildDependencyValidation,
+      packageConfig: packageConfig ?? this.packageConfig,
+      initializeFromDill: initializeFromDill ?? this.initializeFromDill,
+      assumeInitializeFromDillUpToDate: assumeInitializeFromDillUpToDate,
+      buildNativeAssets: buildNativeAssets,
+      useLocalCanvasKit: useLocalCanvasKit,
+      includeUnsupportedPlatformLibraryStubs:
+          includeUnsupportedPlatformLibraryStubs ?? this.includeUnsupportedPlatformLibraryStubs,
+      webEnableHotReload: webEnableHotReload,
+      treeShakeIcons: treeShakeIcons,
+    );
+  }
+
   final BuildMode mode;
 
   /// Whether the build should subset icon fonts.

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -25,9 +25,9 @@ String getDefaultApplicationKernelPath({required bool trackWidgetCreation}) {
 String getDefaultCachedKernelPath({
   required bool trackWidgetCreation,
   required List<String> dartDefines,
+  required Config config,
+  required FileSystem fileSystem,
   List<String> extraFrontEndOptions = const <String>[],
-  FileSystem? fileSystem,
-  Config? config,
 }) {
   final buffer = StringBuffer();
   final List<String> cacheFrontEndOptions = extraFrontEndOptions.toList()
@@ -41,10 +41,7 @@ String getDefaultCachedKernelPath({
     buildPrefix = '${hex.encode(digest.bytes)}.';
   }
   return getKernelPathForTransformerOptions(
-    (fileSystem ?? globals.fs).path.join(
-      getBuildDirectory(config ?? globals.config, fileSystem ?? globals.fs),
-      '${buildPrefix}cache.dill',
-    ),
+    fileSystem.path.join(getBuildDirectory(config, fileSystem), '${buildPrefix}cache.dill'),
     trackWidgetCreation: trackWidgetCreation,
   );
 }

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -357,7 +357,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
     final FlutterDevice flutterDevice = await FlutterDevice.create(
       device,
       target: targetFile,
-      targetModel: TargetModel(stringArg('target-model')!),
+      targetModelOverride: TargetModel(stringArg('target-model')!),
       buildInfo: buildInfo,
       userIdentifier: userIdentifier,
       platform: _platform,

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -848,16 +848,10 @@ class RunCommand extends RunCommandBase {
       }
     }
 
-    List<String>? expFlags;
-    if (argParser.options.containsKey(FlutterOptions.kEnableExperiment) &&
-        stringsArg(FlutterOptions.kEnableExperiment).isNotEmpty) {
-      expFlags = stringsArg(FlutterOptions.kEnableExperiment);
-    }
     final flutterDevices = <FlutterDevice>[
       for (final Device device in devices!)
         await FlutterDevice.create(
           device,
-          experimentalFlags: expFlags,
           target: targetFile,
           buildInfo: buildInfo,
           userIdentifier: userIdentifier,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -532,6 +532,7 @@ abstract interface class ResidentCompiler {
     String? librariesSpec;
     TargetModel targetModel = targetModelOverride ?? .flutter;
 
+    // Configure the compiler to target the DDC runtime.
     if (targetPlatform case .web_javascript) {
       sdkRoot = artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
       targetModel = .dartdevc;
@@ -933,45 +934,43 @@ class DefaultResidentCompiler implements ResidentCompiler {
 
     final command = <String>[
       ...commandToStartFrontendServer,
-      ...<String>[
-        '--sdk-root',
-        sdkRoot,
-        '--incremental',
-        if (testCompilation) '--no-print-incremental-dependencies',
-        '--target=$targetModel',
-        // TODO(annagrin): remove once this becomes the default behavior
-        // in the frontend_server.
-        // https://github.com/flutter/flutter/issues/59902
-        '--experimental-emit-debug-metadata',
-        for (final Object dartDefine in dartDefines) '-D$dartDefine',
-        if (outputPath != null) ...<String>['--output-dill', outputPath],
-        // If we have a platform dill, we don't need to pass the libraries spec,
-        // since the information is embedded in the .dill file.
-        if (librariesSpec != null && platformDill == null) ...<String>[
-          '--libraries-spec',
-          librariesSpec!,
-        ],
-        if (packagesPath != null) ...<String>['--packages', packagesPath!],
-        ...buildModeOptions(buildMode, dartDefines),
-        if (trackWidgetCreation) '--track-widget-creation',
-        if (includeUnsupportedPlatformLibraryStubs) '--include-unsupported-platform-library-stubs',
-        for (final String root in fileSystemRoots) ...<String>['--filesystem-root', root],
-        if (fileSystemScheme != null) ...<String>['--filesystem-scheme', fileSystemScheme!],
-        if (initializeFromDill != null) ...<String>['--initialize-from-dill', initializeFromDill!],
-        if (assumeInitializeFromDillUpToDate) '--assume-initialize-from-dill-up-to-date',
-        if (additionalSourceUri != null) ...<String>[
-          '--source',
-          additionalSourceUri,
-          '--source',
-          'package:flutter/src/dart_plugin_registrant.dart',
-          '-Dflutter.dart_plugin_registrant=$additionalSourceUri',
-        ],
-        if (nativeAssetsUri != null) ...<String>['--native-assets', nativeAssetsUri],
-        if (platformDill != null) ...<String>['--platform', platformDill!],
-        // See: https://github.com/flutter/flutter/issues/103994
-        '--verbosity=error',
-        ...?_filterExtraFrontEndOptions(extraFrontEndOptions),
+      '--sdk-root',
+      sdkRoot,
+      '--incremental',
+      if (testCompilation) '--no-print-incremental-dependencies',
+      '--target=$targetModel',
+      // TODO(annagrin): remove once this becomes the default behavior
+      // in the frontend_server.
+      // https://github.com/flutter/flutter/issues/59902
+      '--experimental-emit-debug-metadata',
+      for (final Object dartDefine in dartDefines) '-D$dartDefine',
+      if (outputPath != null) ...<String>['--output-dill', outputPath],
+      // If we have a platform dill, we don't need to pass the libraries spec,
+      // since the information is embedded in the .dill file.
+      if (librariesSpec != null && platformDill == null) ...<String>[
+        '--libraries-spec',
+        librariesSpec!,
       ],
+      if (packagesPath != null) ...<String>['--packages', packagesPath!],
+      ...buildModeOptions(buildMode, dartDefines),
+      if (trackWidgetCreation) '--track-widget-creation',
+      if (includeUnsupportedPlatformLibraryStubs) '--include-unsupported-platform-library-stubs',
+      for (final String root in fileSystemRoots) ...<String>['--filesystem-root', root],
+      if (fileSystemScheme != null) ...<String>['--filesystem-scheme', fileSystemScheme!],
+      if (initializeFromDill != null) ...<String>['--initialize-from-dill', initializeFromDill!],
+      if (assumeInitializeFromDillUpToDate) '--assume-initialize-from-dill-up-to-date',
+      if (additionalSourceUri != null) ...<String>[
+        '--source',
+        additionalSourceUri,
+        '--source',
+        'package:flutter/src/dart_plugin_registrant.dart',
+        '-Dflutter.dart_plugin_registrant=$additionalSourceUri',
+      ],
+      if (nativeAssetsUri != null) ...<String>['--native-assets', nativeAssetsUri],
+      if (platformDill != null) ...<String>['--platform', platformDill!],
+      // See: https://github.com/flutter/flutter/issues/103994
+      '--verbosity=error',
+      ...?_filterExtraFrontEndOptions(extraFrontEndOptions),
     ];
     _logger.printTrace(command.join(' '));
     _server = await _processManager.start(command);

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -564,9 +564,10 @@ abstract interface class ResidentCompiler {
           ...<String>['--dartdevc-canary', '--dartdevc-module-format=ddc'],
         ],
       );
-    } else if (targetPlatform case .fuchsia_arm64 || .fuchsia_x64) {
-      targetModel = .flutterRunner;
     } else {
+      if (targetPlatform case .fuchsia_arm64 || .fuchsia_x64) {
+        targetModel = .flutterRunner;
+      }
       buildInfo = buildInfo.copyWith(
         extraFrontEndOptions: [
           ...buildInfo.extraFrontEndOptions,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -12,6 +12,7 @@ import 'package:usage/uuid/uuid.dart';
 
 import 'artifacts.dart';
 import 'base/common.dart';
+import 'base/config.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/logger.dart';
@@ -19,6 +20,7 @@ import 'base/platform.dart';
 import 'base/process.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
+import 'bundle.dart';
 import 'convert.dart';
 
 /// Opt-in changes to the dart compilers.
@@ -507,32 +509,88 @@ class _RejectRequest extends _CompilationRequest {
 ///
 /// The wrapper is intended to stay resident in memory as user changes, reloads,
 /// restarts the Flutter app.
-abstract class ResidentCompiler {
-  factory ResidentCompiler(
-    String sdkRoot, {
-    required BuildMode buildMode,
+abstract interface class ResidentCompiler {
+  factory ResidentCompiler({
+    required TargetPlatform targetPlatform,
+    required BuildInfo buildInfo,
     required Logger logger,
     required ProcessManager processManager,
     required Artifacts artifacts,
     required Platform platform,
     required FileSystem fileSystem,
     required ShutdownHooks shutdownHooks,
-    bool testCompilation,
-    bool trackWidgetCreation,
-    bool includeUnsupportedPlatformLibraryStubs,
-    String packagesPath,
-    List<String> fileSystemRoots,
-    String? fileSystemScheme,
-    String initializeFromDill,
-    bool assumeInitializeFromDillUpToDate,
-    TargetModel targetModel,
-    bool unsafePackageSerialization,
-    String? frontendServerStarterPath,
-    List<String> extraFrontEndOptions,
-    String platformDill,
-    List<String>? dartDefines,
-    String librariesSpec,
-  }) = DefaultResidentCompiler;
+    required Config config,
+    bool testCompilation = false,
+    TargetModel? targetModelOverride,
+  }) {
+    String sdkRoot = artifacts.getArtifactPath(
+      Artifact.flutterPatchedSdkPath,
+      platform: targetPlatform,
+      mode: buildInfo.mode,
+    );
+    String? platformDillPath;
+    String? librariesSpec;
+    TargetModel targetModel = targetModelOverride ?? .flutter;
+
+    if (targetPlatform case .web_javascript) {
+      sdkRoot = artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
+      targetModel = .dartdevc;
+
+      const platformDillName = 'ddc_outline.dill';
+      platformDillPath = fileSystem
+          .file(
+            fileSystem.path.join(
+              artifacts.getHostArtifact(.webPlatformKernelFolder).path,
+              platformDillName,
+            ),
+          )
+          .absolute
+          .uri
+          .toString();
+
+      librariesSpec = fileSystem
+          .file(artifacts.getHostArtifact(.flutterWebLibrariesJson))
+          .uri
+          .toString();
+
+      buildInfo = buildInfo.copyWith(
+        // Override the filesystem scheme so that the frontend_server can find
+        // the generated entrypoint code.
+        fileSystemScheme: 'org-dartlang-app',
+        extraFrontEndOptions: [
+          ...buildInfo.extraFrontEndOptions,
+          if (buildInfo.webEnableHotReload)
+          // These flags are only valid to be passed when compiling with DDC.
+          ...<String>['--dartdevc-canary', '--dartdevc-module-format=ddc'],
+        ],
+      );
+    } else if (targetPlatform case .fuchsia_arm64 || .fuchsia_x64) {
+      targetModel = .flutterRunner;
+    } else {
+      buildInfo = buildInfo.copyWith(
+        extraFrontEndOptions: [
+          ...buildInfo.extraFrontEndOptions,
+          '--enable-experiment=alternative-invalidation-strategy',
+        ],
+      );
+    }
+
+    return DefaultResidentCompiler(
+      sdkRoot,
+      buildInfo: buildInfo,
+      logger: logger,
+      processManager: processManager,
+      artifacts: artifacts,
+      platform: platform,
+      fileSystem: fileSystem,
+      shutdownHooks: shutdownHooks,
+      config: config,
+      targetModel: targetModel,
+      platformDill: platformDillPath,
+      librariesSpec: librariesSpec,
+      testCompilation: testCompilation,
+    );
+  }
 
   // TODO(zanderso): find a better way to configure additional file system
   // roots from the runner.
@@ -633,39 +691,46 @@ abstract class ResidentCompiler {
 class DefaultResidentCompiler implements ResidentCompiler {
   DefaultResidentCompiler(
     String sdkRoot, {
-    required this.buildMode,
+    required BuildInfo buildInfo,
     required Logger logger,
     required ProcessManager processManager,
     required this.artifacts,
     required Platform platform,
     required FileSystem fileSystem,
     required ShutdownHooks shutdownHooks,
+    required Config config,
     this.testCompilation = false,
-    this.trackWidgetCreation = true,
-    this.includeUnsupportedPlatformLibraryStubs = false,
-    this.packagesPath,
-    List<String> fileSystemRoots = const <String>[],
-    this.fileSystemScheme,
-    this.initializeFromDill,
-    this.assumeInitializeFromDillUpToDate = false,
     this.targetModel = TargetModel.flutter,
-    this.unsafePackageSerialization = false,
-    this.frontendServerStarterPath,
-    this.extraFrontEndOptions,
     this.platformDill,
-    List<String>? dartDefines,
     this.librariesSpec,
     @visibleForTesting StdoutHandler? stdoutHandler,
-  }) : _logger = logger,
+  }) : buildMode = buildInfo.mode,
+       trackWidgetCreation = buildInfo.trackWidgetCreation,
+       includeUnsupportedPlatformLibraryStubs = buildInfo.includeUnsupportedPlatformLibraryStubs,
+       packagesPath = buildInfo.packageConfigPath,
+       initializeFromDill =
+           buildInfo.initializeFromDill ??
+           getDefaultCachedKernelPath(
+             config: config,
+             fileSystem: fileSystem,
+             trackWidgetCreation: buildInfo.trackWidgetCreation,
+             dartDefines: buildInfo.dartDefines,
+             extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+           ),
+       extraFrontEndOptions = buildInfo.extraFrontEndOptions,
+       fileSystemScheme = buildInfo.fileSystemScheme,
+       assumeInitializeFromDillUpToDate = buildInfo.assumeInitializeFromDillUpToDate,
+       frontendServerStarterPath = buildInfo.frontendServerStarterPath,
+       _logger = logger,
        _processManager = processManager,
        _shutdownHooks = shutdownHooks,
        _stdoutHandler = stdoutHandler ?? StdoutHandler(logger: logger, fileSystem: fileSystem),
        _platform = platform,
-       dartDefines = dartDefines ?? const <String>[],
+       dartDefines = buildInfo.dartDefines,
        // This is a URI, not a file path, so the forward slash is correct even on Windows.
        sdkRoot = sdkRoot.endsWith('/') ? sdkRoot : '$sdkRoot/',
        // Make a copy, we might need to modify it later.
-       fileSystemRoots = List<String>.from(fileSystemRoots) {
+       fileSystemRoots = List<String>.from(buildInfo.fileSystemRoots) {
     // Currently, the only developer tooling that requires support for importing unsupported
     // platform libraries at compile time is the widget previewer. Only developer tooling use cases
     // should support this, so this is restricted to the widget previewer's runtime target for now.
@@ -693,7 +758,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
   final String? fileSystemScheme;
   final String? initializeFromDill;
   final bool assumeInitializeFromDillUpToDate;
-  final bool unsafePackageSerialization;
   final String? frontendServerStarterPath;
   final List<String>? extraFrontEndOptions;
   final List<String> dartDefines;
@@ -867,52 +931,48 @@ class DefaultResidentCompiler implements ResidentCompiler {
       ];
     }
 
-    final List<String> command =
-        commandToStartFrontendServer +
-        <String>[
-          '--sdk-root',
-          sdkRoot,
-          '--incremental',
-          if (testCompilation) '--no-print-incremental-dependencies',
-          '--target=$targetModel',
-          // TODO(annagrin): remove once this becomes the default behavior
-          // in the frontend_server.
-          // https://github.com/flutter/flutter/issues/59902
-          '--experimental-emit-debug-metadata',
-          for (final Object dartDefine in dartDefines) '-D$dartDefine',
-          if (outputPath != null) ...<String>['--output-dill', outputPath],
-          // If we have a platform dill, we don't need to pass the libraries spec,
-          // since the information is embedded in the .dill file.
-          if (librariesSpec != null && platformDill == null) ...<String>[
-            '--libraries-spec',
-            librariesSpec!,
-          ],
-          if (packagesPath != null) ...<String>['--packages', packagesPath!],
-          ...buildModeOptions(buildMode, dartDefines),
-          if (trackWidgetCreation) '--track-widget-creation',
-          if (includeUnsupportedPlatformLibraryStubs)
-            '--include-unsupported-platform-library-stubs',
-          for (final String root in fileSystemRoots) ...<String>['--filesystem-root', root],
-          if (fileSystemScheme != null) ...<String>['--filesystem-scheme', fileSystemScheme!],
-          if (initializeFromDill != null) ...<String>[
-            '--initialize-from-dill',
-            initializeFromDill!,
-          ],
-          if (assumeInitializeFromDillUpToDate) '--assume-initialize-from-dill-up-to-date',
-          if (additionalSourceUri != null) ...<String>[
-            '--source',
-            additionalSourceUri,
-            '--source',
-            'package:flutter/src/dart_plugin_registrant.dart',
-            '-Dflutter.dart_plugin_registrant=$additionalSourceUri',
-          ],
-          if (nativeAssetsUri != null) ...<String>['--native-assets', nativeAssetsUri],
-          if (platformDill != null) ...<String>['--platform', platformDill!],
-          if (unsafePackageSerialization) '--unsafe-package-serialization',
-          // See: https://github.com/flutter/flutter/issues/103994
-          '--verbosity=error',
-          ...?_filterExtraFrontEndOptions(extraFrontEndOptions),
-        ];
+    final command = <String>[
+      ...commandToStartFrontendServer,
+      ...<String>[
+        '--sdk-root',
+        sdkRoot,
+        '--incremental',
+        if (testCompilation) '--no-print-incremental-dependencies',
+        '--target=$targetModel',
+        // TODO(annagrin): remove once this becomes the default behavior
+        // in the frontend_server.
+        // https://github.com/flutter/flutter/issues/59902
+        '--experimental-emit-debug-metadata',
+        for (final Object dartDefine in dartDefines) '-D$dartDefine',
+        if (outputPath != null) ...<String>['--output-dill', outputPath],
+        // If we have a platform dill, we don't need to pass the libraries spec,
+        // since the information is embedded in the .dill file.
+        if (librariesSpec != null && platformDill == null) ...<String>[
+          '--libraries-spec',
+          librariesSpec!,
+        ],
+        if (packagesPath != null) ...<String>['--packages', packagesPath!],
+        ...buildModeOptions(buildMode, dartDefines),
+        if (trackWidgetCreation) '--track-widget-creation',
+        if (includeUnsupportedPlatformLibraryStubs) '--include-unsupported-platform-library-stubs',
+        for (final String root in fileSystemRoots) ...<String>['--filesystem-root', root],
+        if (fileSystemScheme != null) ...<String>['--filesystem-scheme', fileSystemScheme!],
+        if (initializeFromDill != null) ...<String>['--initialize-from-dill', initializeFromDill!],
+        if (assumeInitializeFromDillUpToDate) '--assume-initialize-from-dill-up-to-date',
+        if (additionalSourceUri != null) ...<String>[
+          '--source',
+          additionalSourceUri,
+          '--source',
+          'package:flutter/src/dart_plugin_registrant.dart',
+          '-Dflutter.dart_plugin_registrant=$additionalSourceUri',
+        ],
+        if (nativeAssetsUri != null) ...<String>['--native-assets', nativeAssetsUri],
+        if (platformDill != null) ...<String>['--platform', platformDill!],
+        // See: https://github.com/flutter/flutter/issues/103994
+        '--verbosity=error',
+        ...?_filterExtraFrontEndOptions(extraFrontEndOptions),
+      ],
+    ];
     _logger.printTrace(command.join(' '));
     _server = await _processManager.start(command);
     _server?.stdout

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -9,7 +9,6 @@ import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import 'application_package.dart';
-import 'artifacts.dart';
 import 'asset.dart';
 import 'base/command_help.dart';
 import 'base/common.dart';
@@ -44,35 +43,11 @@ class FlutterDevice {
   FlutterDevice(
     this.device, {
     required this.buildInfo,
-    TargetModel targetModel = TargetModel.flutter,
-    this.targetPlatform,
-    ResidentCompiler? generator,
-    this.userIdentifier,
+    required this.targetPlatform,
+    required this.generator,
     required this.developmentShaderCompiler,
-  }) : generator =
-           generator ??
-           ResidentCompiler(
-             globals.artifacts!.getArtifactPath(
-               Artifact.flutterPatchedSdkPath,
-               platform: targetPlatform,
-               mode: buildInfo.mode,
-             ),
-             buildMode: buildInfo.mode,
-             trackWidgetCreation: buildInfo.trackWidgetCreation,
-             fileSystemRoots: buildInfo.fileSystemRoots,
-             fileSystemScheme: buildInfo.fileSystemScheme,
-             targetModel: targetModel,
-             dartDefines: buildInfo.dartDefines,
-             packagesPath: buildInfo.packageConfigPath,
-             frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-             extraFrontEndOptions: buildInfo.extraFrontEndOptions,
-             artifacts: globals.artifacts!,
-             processManager: globals.processManager,
-             logger: globals.logger,
-             platform: globals.platform,
-             fileSystem: globals.fs,
-             shutdownHooks: globals.shutdownHooks,
-           );
+    this.userIdentifier,
+  });
 
   /// Create a [FlutterDevice] with optional code generation enabled.
   static Future<FlutterDevice> create(
@@ -80,14 +55,10 @@ class FlutterDevice {
     required String? target,
     required BuildInfo buildInfo,
     required Platform platform,
-    TargetModel targetModel = TargetModel.flutter,
-    List<String>? experimentalFlags,
     String? userIdentifier,
+    TargetModel? targetModelOverride,
   }) async {
     final TargetPlatform targetPlatform = await device.targetPlatform;
-    if (device.platformType == PlatformType.fuchsia) {
-      targetModel = TargetModel.flutterRunner;
-    }
     final shaderCompiler = DevelopmentShaderCompiler(
       shaderCompiler: ShaderCompiler(
         artifacts: globals.artifacts!,
@@ -98,104 +69,21 @@ class FlutterDevice {
       fileSystem: globals.fs,
     );
 
-    final ResidentCompiler generator;
-
-    // For both web and non-web platforms we initialize dill to/from
-    // a shared location for faster bootstrapping. If the compiler fails
-    // due to a kernel target or version mismatch, no error is reported
-    // and the compiler starts up as normal. Unexpected errors will print
-    // a warning message and dump some debug information which can be
-    // used to file a bug, but the compiler will still start up correctly.
-    if (targetPlatform == TargetPlatform.web_javascript) {
-      // TODO(zanderso): consistently provide these flags across platforms.
-      const platformDillName = 'ddc_outline.dill';
-
-      final String platformDillPath = globals.fs.path.join(
-        globals.artifacts!.getHostArtifact(HostArtifact.webPlatformKernelFolder).path,
-        platformDillName,
-      );
-      final extraFrontEndOptions = <String>[
-        ...buildInfo.extraFrontEndOptions,
-        if (buildInfo.webEnableHotReload)
-        // These flags are only valid to be passed when compiling with DDC.
-        ...<String>['--dartdevc-canary', '--dartdevc-module-format=ddc'],
-      ];
-
-      generator = ResidentCompiler(
-        globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path,
-        buildMode: buildInfo.mode,
-        trackWidgetCreation: buildInfo.trackWidgetCreation,
-        includeUnsupportedPlatformLibraryStubs: buildInfo.includeUnsupportedPlatformLibraryStubs,
-        fileSystemRoots: buildInfo.fileSystemRoots,
-        // Override the filesystem scheme so that the frontend_server can find
-        // the generated entrypoint code.
-        fileSystemScheme: 'org-dartlang-app',
-        initializeFromDill:
-            buildInfo.initializeFromDill ??
-            getDefaultCachedKernelPath(
-              trackWidgetCreation: buildInfo.trackWidgetCreation,
-              dartDefines: buildInfo.dartDefines,
-              extraFrontEndOptions: buildInfo.extraFrontEndOptions,
-            ),
-        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
-        targetModel: TargetModel.dartdevc,
-        frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-        extraFrontEndOptions: extraFrontEndOptions,
-        platformDill: globals.fs.file(platformDillPath).absolute.uri.toString(),
-        dartDefines: buildInfo.dartDefines,
-        librariesSpec: globals.fs
-            .file(globals.artifacts!.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
-            .uri
-            .toString(),
-        packagesPath: buildInfo.packageConfigPath,
-        artifacts: globals.artifacts!,
-        processManager: globals.processManager,
-        logger: globals.logger,
-        fileSystem: globals.fs,
-        platform: platform,
-        shutdownHooks: globals.shutdownHooks,
-      );
-    } else {
-      List<String> extraFrontEndOptions = buildInfo.extraFrontEndOptions;
-      extraFrontEndOptions = <String>[
-        '--enable-experiment=alternative-invalidation-strategy',
-        ...extraFrontEndOptions,
-      ];
-      generator = ResidentCompiler(
-        globals.artifacts!.getArtifactPath(
-          Artifact.flutterPatchedSdkPath,
-          platform: targetPlatform,
-          mode: buildInfo.mode,
-        ),
-        buildMode: buildInfo.mode,
-        trackWidgetCreation: buildInfo.trackWidgetCreation,
-        fileSystemRoots: buildInfo.fileSystemRoots,
-        fileSystemScheme: buildInfo.fileSystemScheme,
-        targetModel: targetModel,
-        dartDefines: buildInfo.dartDefines,
-        frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-        extraFrontEndOptions: extraFrontEndOptions,
-        initializeFromDill:
-            buildInfo.initializeFromDill ??
-            getDefaultCachedKernelPath(
-              trackWidgetCreation: buildInfo.trackWidgetCreation,
-              dartDefines: buildInfo.dartDefines,
-              extraFrontEndOptions: extraFrontEndOptions,
-            ),
-        assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
-        packagesPath: buildInfo.packageConfigPath,
-        artifacts: globals.artifacts!,
-        processManager: globals.processManager,
-        logger: globals.logger,
-        platform: platform,
-        fileSystem: globals.fs,
-        shutdownHooks: globals.shutdownHooks,
-      );
-    }
+    final generator = ResidentCompiler(
+      artifacts: globals.artifacts!,
+      processManager: globals.processManager,
+      logger: globals.logger,
+      fileSystem: globals.fs,
+      platform: platform,
+      shutdownHooks: globals.shutdownHooks,
+      config: globals.config,
+      targetPlatform: targetPlatform,
+      buildInfo: buildInfo,
+      targetModelOverride: targetModelOverride,
+    );
 
     return FlutterDevice(
       device,
-      targetModel: targetModel,
       targetPlatform: targetPlatform,
       generator: generator,
       buildInfo: buildInfo,
@@ -204,7 +92,7 @@ class FlutterDevice {
     );
   }
 
-  final TargetPlatform? targetPlatform;
+  final TargetPlatform targetPlatform;
   final Device? device;
   final ResidentCompiler? generator;
   final BuildInfo buildInfo;
@@ -1314,6 +1202,8 @@ abstract class ResidentRunner extends ResidentHandlers {
         trackWidgetCreation: trackWidgetCreation,
         dartDefines: debuggingOptions.buildInfo.dartDefines,
         extraFrontEndOptions: debuggingOptions.buildInfo.extraFrontEndOptions,
+        config: globals.config,
+        fileSystem: globals.fs,
       );
       globals.fs.file(copyPath).parent.createSync(recursive: true);
       outputDill.copySync(copyPath);

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
-import '../artifacts.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../bundle.dart';
@@ -114,6 +113,8 @@ class TestCompiler {
              getBuildDirectory(),
              'test_cache',
              getDefaultCachedKernelPath(
+               config: globals.config,
+               fileSystem: globals.fs,
                trackWidgetCreation: buildInfo.trackWidgetCreation,
                dartDefines: buildInfo.dartDefines,
                extraFrontEndOptions: buildInfo.extraFrontEndOptions,
@@ -179,23 +180,16 @@ class TestCompiler {
   @visibleForTesting
   Future<ResidentCompiler?> createCompiler() async {
     final residentCompiler = ResidentCompiler(
-      globals.artifacts!.getArtifactPath(Artifact.flutterPatchedSdkPath),
       artifacts: globals.artifacts!,
       logger: globals.logger,
       processManager: globals.processManager,
-      buildMode: buildInfo.mode,
-      trackWidgetCreation: buildInfo.trackWidgetCreation,
-      initializeFromDill: testFilePath,
-      dartDefines: buildInfo.dartDefines,
-      packagesPath: buildInfo.packageConfigPath,
-      frontendServerStarterPath: buildInfo.frontendServerStarterPath,
-      extraFrontEndOptions: buildInfo.extraFrontEndOptions,
+      buildInfo: buildInfo,
       platform: globals.platform,
       testCompilation: true,
       fileSystem: globals.fs,
-      fileSystemRoots: buildInfo.fileSystemRoots,
-      fileSystemScheme: buildInfo.fileSystemScheme,
       shutdownHooks: globals.shutdownHooks,
+      config: globals.config,
+      targetPlatform: .tester,
     );
     return residentCompiler;
   }

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -258,6 +258,7 @@ class TestFlutterDevice extends FlutterDevice {
     required this.exception,
     required ResidentCompiler generator,
   }) : super(
+         targetPlatform: .unsupported,
          device,
          buildInfo: BuildInfo.debug,
          generator: generator,

--- a/packages/flutter_tools/test/general.shard/compile_expression_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_expression_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -32,16 +33,18 @@ void main() {
     testLogger = BufferLogger.test();
     processManager = FakeProcessManager();
     frontendServerStdIn = MemoryIOSink();
-    fileSystem = MemoryFileSystem.test();
+    fileSystem = MemoryFileSystem.test()
+      ..file(Artifact.flutterPatchedSdkPath.toString()).createSync();
     generator = ResidentCompiler(
-      'sdkroot',
-      buildMode: BuildMode.debug,
-      artifacts: Artifacts.test(),
+      targetPlatform: .unsupported,
+      buildInfo: BuildInfo.debug,
+      artifacts: Artifacts.test(fileSystem: fileSystem),
       processManager: processManager,
       logger: testLogger,
       platform: FakePlatform(),
       fileSystem: fileSystem,
       shutdownHooks: FakeShutdownHooks(),
+      config: Config.test(),
     );
 
     stdErrStreamController = StreamController<String>();

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/async_guard.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -39,6 +40,8 @@ void main() {
     '--experimental-emit-debug-metadata',
     '--output-dill',
     '/build/',
+    '--packages',
+    '.dart_tool/package_config.json',
     '-Ddart.vm.profile=false',
     '-Ddart.vm.product=false',
     '--enable-asserts',
@@ -57,7 +60,7 @@ void main() {
     );
     generator = DefaultResidentCompiler(
       'sdkroot',
-      buildMode: BuildMode.debug,
+      buildInfo: BuildInfo.debug,
       logger: testLogger,
       processManager: fakeProcessManager,
       artifacts: Artifacts.test(),
@@ -65,23 +68,26 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       stdoutHandler: generatorStdoutHandler,
       shutdownHooks: FakeShutdownHooks(),
+      config: Config.test(),
     );
     generatorWithScheme = DefaultResidentCompiler(
       'sdkroot',
-      buildMode: BuildMode.debug,
+      buildInfo: BuildInfo.debug.copyWith(
+        fileSystemRoots: <String>['/foo/bar/fizz'],
+        fileSystemScheme: 'scheme',
+      ),
       logger: testLogger,
       processManager: fakeProcessManager,
       artifacts: Artifacts.test(),
       platform: FakePlatform(),
-      fileSystemRoots: <String>['/foo/bar/fizz'],
-      fileSystemScheme: 'scheme',
       fileSystem: MemoryFileSystem.test(),
       stdoutHandler: generatorWithSchemeStdoutHandler,
       shutdownHooks: FakeShutdownHooks(),
+      config: Config.test(),
     );
     generatorWithPlatformDillAndLibrariesSpec = DefaultResidentCompiler(
       'sdkroot',
-      buildMode: BuildMode.debug,
+      buildInfo: BuildInfo.debug,
       logger: testLogger,
       processManager: fakeProcessManager,
       artifacts: Artifacts.test(),
@@ -91,13 +97,19 @@ void main() {
       platformDill: '/foo/platform.dill',
       librariesSpec: '/bar/libraries.json',
       shutdownHooks: FakeShutdownHooks(),
+      config: Config.test(),
     );
   });
 
   testWithoutContext('incremental compile single dart compile', () async {
     fakeProcessManager.addCommand(
       FakeCommand(
-        command: const <String>[...frontendServerCommand, '--verbosity=error'],
+        command: const <String>[
+          ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
+          '--verbosity=error',
+        ],
         stdout: 'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0',
         stdin: frontendServerStdIn,
       ),
@@ -126,6 +138,8 @@ void main() {
           '/foo/bar/fizz',
           '--filesystem-scheme',
           'scheme',
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
           '--verbosity=error',
         ],
         stdout: 'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0',
@@ -150,7 +164,12 @@ void main() {
   testWithoutContext('incremental compile single dart compile abnormally terminates', () async {
     fakeProcessManager.addCommand(
       FakeCommand(
-        command: const <String>[...frontendServerCommand, '--verbosity=error'],
+        command: const <String>[
+          ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
+          '--verbosity=error',
+        ],
         stdin: frontendServerStdIn,
       ),
     );
@@ -176,7 +195,12 @@ void main() {
     () async {
       fakeProcessManager.addCommand(
         FakeCommand(
-          command: const <String>[...frontendServerCommand, '--verbosity=error'],
+          command: const <String>[
+            ...frontendServerCommand,
+            '--initialize-from-dill',
+            'build/cache.dill.track.dill',
+            '--verbosity=error',
+          ],
           stdin: frontendServerStdIn,
           exitCode: 1,
         ),
@@ -203,7 +227,12 @@ void main() {
     final completer = Completer<void>();
     fakeProcessManager.addCommand(
       FakeCommand(
-        command: const <String>[...frontendServerCommand, '--verbosity=error'],
+        command: const <String>[
+          ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
+          '--verbosity=error',
+        ],
         stdout: 'result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0',
         stdin: frontendServerStdIn,
         completer: completer,
@@ -271,6 +300,8 @@ void main() {
           '/foo/bar/fizz',
           '--filesystem-scheme',
           'scheme',
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
           '--verbosity=error',
         ],
         stdout: 'result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0',
@@ -356,6 +387,8 @@ void main() {
             '/foo/bar/fizz',
             '--filesystem-scheme',
             'scheme',
+            '--initialize-from-dill',
+            'build/cache.dill.track.dill',
             '--verbosity=error',
           ],
           stdout: 'result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0',
@@ -433,7 +466,12 @@ void main() {
     final completer = Completer<void>();
     fakeProcessManager.addCommand(
       FakeCommand(
-        command: const <String>[...frontendServerCommand, '--verbosity=error'],
+        command: const <String>[
+          ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
+          '--verbosity=error',
+        ],
         stdout: 'result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0',
         stdin: frontendServerStdIn,
         completer: completer,
@@ -479,7 +517,12 @@ void main() {
     final completer = Completer<void>();
     fakeProcessManager.addCommand(
       FakeCommand(
-        command: const <String>[...frontendServerCommand, '--verbosity=error'],
+        command: const <String>[
+          ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
+          '--verbosity=error',
+        ],
         stdout: 'result abc\nline0\nline1\nabc\nabc /path/to/main.dart.dill 0',
         stdin: frontendServerStdIn,
         completer: completer,
@@ -529,6 +572,8 @@ void main() {
           '/foo/bar/fizz',
           '--filesystem-scheme',
           'scheme',
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
           '--source',
           'some/dir/plugin_registrant.dart',
           '--source',
@@ -565,6 +610,8 @@ void main() {
       FakeCommand(
         command: const <String>[
           ...frontendServerCommand,
+          '--initialize-from-dill',
+          'build/cache.dill.track.dill',
           '--platform',
           '/foo/platform.dill',
           '--verbosity=error',

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -584,7 +584,6 @@ void main() {
 
     final residentCompiler = DefaultResidentCompiler(
       'sdkroot',
-      buildMode: BuildMode.debug,
       logger: logger,
       processManager: fakeProcessManager,
       artifacts: Artifacts.test(),
@@ -592,6 +591,8 @@ void main() {
       fileSystem: fileSystem,
       stdoutHandler: generatorStdoutHandler,
       shutdownHooks: FakeShutdownHooks(),
+      config: Config.test(),
+      buildInfo: BuildInfo.debug,
     );
 
     fileSystem.file('lib/foo.txt.dill').createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/hot_shared.dart
+++ b/packages/flutter_tools/test/general.shard/hot_shared.dart
@@ -138,7 +138,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   Future<void> handleHotRestart() async {}
 
   @override
-  TargetPlatform? get targetPlatform => device._targetPlatform;
+  TargetPlatform get targetPlatform => device._targetPlatform;
 }
 
 class TestFlutterDevice extends FlutterDevice {
@@ -148,6 +148,7 @@ class TestFlutterDevice extends FlutterDevice {
     required ResidentCompiler generator,
   }) : super(
          device,
+         targetPlatform: TargetPlatform.unsupported,
          buildInfo: BuildInfo.debug,
          generator: generator,
          developmentShaderCompiler: const FakeShaderCompiler(),

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -253,6 +253,7 @@ name: my_app
           final devices = <FlutterDevice>[
             FlutterDevice(
               device,
+              targetPlatform: .unsupported,
               generator: residentCompiler,
               buildInfo: BuildInfo.debug,
               developmentShaderCompiler: const FakeShaderCompiler(),
@@ -283,6 +284,7 @@ name: my_app
           final devices = <FlutterDevice>[
             FlutterDevice(
               device,
+              targetPlatform: .unsupported,
               generator: residentCompiler,
               buildInfo: BuildInfo.debug,
               developmentShaderCompiler: const FakeShaderCompiler(),

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -155,7 +155,12 @@ class FakeDartDevelopmentServiceException implements DartDevelopmentServiceExcep
 class TestFlutterDevice extends FlutterDevice {
   TestFlutterDevice(super.device, {Stream<Uri>? vmServiceUris})
     : _vmServiceUris = vmServiceUris,
-      super(buildInfo: BuildInfo.debug, developmentShaderCompiler: const FakeShaderCompiler());
+      super(
+        generator: FakeResidentCompiler(),
+        targetPlatform: .unsupported,
+        buildInfo: BuildInfo.debug,
+        developmentShaderCompiler: const FakeShaderCompiler(),
+      );
 
   final Stream<Uri>? _vmServiceUris;
 
@@ -277,6 +282,7 @@ class FakeDelegateFlutterDevice extends FlutterDevice {
     ResidentCompiler residentCompiler,
     this.fakeDevFS,
   ) : super(
+        targetPlatform: .unsupported,
         buildInfo: buildInfo,
         generator: residentCompiler,
         developmentShaderCompiler: const FakeShaderCompiler(),

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1258,6 +1258,7 @@ void main() {
     final residentRunner = FakeResidentRunner(
       FlutterDevice(
         FakeDevice(),
+        targetPlatform: .unsupported,
         buildInfo: BuildInfo.debug,
         generator: FakeResidentCompiler(),
         developmentShaderCompiler: const FakeShaderCompiler(),


### PR DESCRIPTION
Moves the initialization logic for web and non-web compilers into the `ResidentCompiler` factory and reduces code duplication.

Also bumps the flutter_tools Dart SDK version to ^3.10.0 to enable dot shorthands.