### PR TITLE
[Material] modernize legacy switch statements to expressions across multiple files

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -803,18 +803,13 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final bool animateColor;
 
   bool _getEffectiveCenterTitle(ThemeData theme, AppBarThemeData appbarTheme) {
-    bool platformCenter() {
-      switch (theme.platform) {
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
-          return false;
-        case TargetPlatform.iOS:
-        case TargetPlatform.macOS:
-          return actions == null || actions!.length < 2;
-      }
-    }
+    bool platformCenter() => switch (theme.platform) {
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => false,
+      TargetPlatform.iOS || TargetPlatform.macOS => actions == null || actions!.length < 2,
+    };
 
     return centerTitle ?? appbarTheme.centerTitle ?? platformCenter();
   }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -803,13 +803,15 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final bool animateColor;
 
   bool _getEffectiveCenterTitle(ThemeData theme, AppBarThemeData appbarTheme) {
-    bool platformCenter() => switch (theme.platform) {
-      TargetPlatform.android ||
-      TargetPlatform.fuchsia ||
-      TargetPlatform.linux ||
-      TargetPlatform.windows => false,
-      TargetPlatform.iOS || TargetPlatform.macOS => actions == null || actions!.length < 2,
-    };
+    bool platformCenter() {
+      return switch (theme.platform) {
+        TargetPlatform.iOS || TargetPlatform.macOS => actions == null || actions!.length < 2,
+        TargetPlatform.android ||
+        TargetPlatform.fuchsia ||
+        TargetPlatform.linux ||
+        TargetPlatform.windows => false,
+      };
+    }
 
     return centerTitle ?? appbarTheme.centerTitle ?? platformCenter();
   }

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -683,18 +683,13 @@ class _ModalBottomSheet<T> extends StatefulWidget {
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   ParametricCurve<double> animationCurve = _modalBottomSheetCurve;
 
-  String _getRouteLabel(MaterialLocalizations localizations) {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        return '';
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return localizations.dialogLabel;
-    }
-  }
+  String _getRouteLabel(MaterialLocalizations localizations) => switch (defaultTargetPlatform) {
+    TargetPlatform.iOS || TargetPlatform.macOS => '',
+    TargetPlatform.android ||
+    TargetPlatform.fuchsia ||
+    TargetPlatform.linux ||
+    TargetPlatform.windows => localizations.dialogLabel,
+  };
 
   EdgeInsets _getNewClipDetails(Size topLayerSize) {
     return EdgeInsets.fromLTRB(0, 0, 0, topLayerSize.height);

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -771,17 +771,13 @@ class AlertDialog extends StatelessWidget {
         ? _DialogDefaultsM3(context)
         : _DialogDefaultsM2(context);
 
-    String? label = semanticLabel;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        break;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        label ??= MaterialLocalizations.of(context).alertDialogLabel;
-    }
+    final String? label = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => semanticLabel,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => semanticLabel ?? MaterialLocalizations.of(context).alertDialogLabel,
+    };
 
     // The paddingScaleFactor is used to adjust the padding of Dialog's
     // children.

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -250,17 +250,13 @@ class Drawer extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final DrawerThemeData drawerTheme = DrawerTheme.of(context);
-    String? label = semanticLabel;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        break;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        label = semanticLabel ?? MaterialLocalizations.of(context).drawerLabel;
-    }
+    final String? label = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS => semanticLabel,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => semanticLabel ?? MaterialLocalizations.of(context).drawerLabel,
+    };
     final bool useMaterial3 = Theme.of(context).useMaterial3;
     final isDrawerStart = DrawerController.maybeOf(context)?.alignment != DrawerAlignment.end;
     final DrawerThemeData defaults = useMaterial3
@@ -685,17 +681,14 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         return const SizedBox.shrink();
       }
     } else {
-      final bool platformHasBackButton;
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-          platformHasBackButton = true;
-        case TargetPlatform.iOS:
-        case TargetPlatform.macOS:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
-          platformHasBackButton = false;
-      }
+      final bool platformHasBackButton = switch (defaultTargetPlatform) {
+        TargetPlatform.android => true,
+        TargetPlatform.iOS ||
+        TargetPlatform.macOS ||
+        TargetPlatform.fuchsia ||
+        TargetPlatform.linux ||
+        TargetPlatform.windows => false,
+      };
 
       final Color scrimColor =
           widget.scrimColor ?? DrawerTheme.of(context).scrimColor ?? Colors.black54;


### PR DESCRIPTION
This PR modernizes legacy switch statements across several Material library files by converting them to Dart 3 switch expressions.

While exploring `dialog.dart` and `drawer.dart`, I noticed a recurring pattern of using switch statements for platform-based variable assignments (like semantic labels and boolean flags). I've expanded the cleanup to include `app_bar.dart` and `bottom_sheet.dart` to ensure consistency across the 

-> All relevant tests passed (370+ tests total across ` dialog_test.dart`, `drawer_test.dart`, `app_bar_test.dart`, and `bottom_sheet_test.dart`).

-> Verified with `flutter analyze` and `dart format`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA]. (I will sign it once the bot prompts me)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md