### PR TITLE
fix: swap app and engine version in vk::ApplicationInfo

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -141,6 +141,10 @@ Context::BackendType ContextVK::GetBackendType() const {
   return Context::BackendType::kVulkan;
 }
 
+/* version 2.0.0 */
+static constexpr uint32_t kImpellerEngineVersion =
+    VK_MAKE_API_VERSION(0, 2, 0, 0);
+
 void ContextVK::Setup(Settings settings) {
   TRACE_EVENT0("impeller", "ContextVK::Setup");
 
@@ -217,8 +221,7 @@ void ContextVK::Setup(Settings settings) {
   // variant, major, minor, patch
   application_info.setApplicationVersion(VK_API_VERSION_1_0);
   application_info.setApiVersion(VK_API_VERSION_1_1);
-  application_info.setEngineVersion(
-      VK_MAKE_API_VERSION(0, 2, 0, 0) /*version 2.0.0*/);
+  application_info.setEngineVersion(kImpellerEngineVersion);
   application_info.setPEngineName("Impeller");
   application_info.setPApplicationName("Impeller");
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/context_vk.cc
@@ -206,19 +206,19 @@ void ContextVK::Setup(Settings settings) {
 
   vk::ApplicationInfo application_info;
 
-  // Use the same encoding macro as vulkan versions, but otherwise application
+  // Use the same encoding macro as vulkan versions, but otherwise engine
   // version is intended to be the version of the Impeller engine. This version
   // information, along with the application name below is provided to allow
   // IHVs to make optimizations and/or disable functionality based on knowledge
   // of the engine version (for example, to work around bugs). We don't tie this
   // to the overall Flutter version as that version is not yet defined when the
-  // engine is compiled. Instead we can manually bump it occassionally.
+  // engine is compiled. Instead we can manually bump it occasionally.
   //
   // variant, major, minor, patch
-  application_info.setApplicationVersion(
-      VK_MAKE_API_VERSION(0, 2, 0, 0) /*version 2.0.0*/);
+  application_info.setApplicationVersion(VK_API_VERSION_1_0);
   application_info.setApiVersion(VK_API_VERSION_1_1);
-  application_info.setEngineVersion(VK_API_VERSION_1_0);
+  application_info.setEngineVersion(
+      VK_MAKE_API_VERSION(0, 2, 0, 0) /*version 2.0.0*/);
   application_info.setPEngineName("Impeller");
   application_info.setPApplicationName("Impeller");
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -121,7 +121,14 @@ constexpr std::array<std::pair<std::string_view, PowerVRGPU>, 6> kGpuSeriesMap =
     }};
 }  // namespace
 
+// Pixel 10 device ID from ANGLE/Chromium source code.
+// https://chromium.googlesource.com/chromium/src/+/main/testing/buildbot/buildbot_json_magic_substitutions.py#51
+// https://source.chromium.org/chromium/chromium/src/+/main:content/test/gpu/gpu_tests/gpu_integration_test.py;l=1396;drc=6cce000efb9f288a9d51d42c7ab38b38beb5d77c
 const uint32_t kPixel10DeviceID = 0x71061212;
+// PowerVR 25.1@6794074 - the device_driver_version_ is a packed version number
+// which is vendor specific. This appears to be the PowerVR DDK build number.
+// https://www.khronos.org/conformance/adopters/conformant-products/opencl#submission_466
+// https://vulkan.gpuinfo.org/listreports.php?devicename=Google+Pixel+10&platform=android
 const uint32_t kPixel10MinDriverVersion = 6794074;  // Corresponds to 25.1
 
 AdrenoGPU GetAdrenoVersion(std::string_view version) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.h
@@ -280,6 +280,8 @@ class DriverInfoVK {
  private:
   bool is_valid_ = false;
   Version api_version_;
+  uint32_t driver_version_;
+  uint32_t device_id_ = 0;
   VendorVK vendor_ = VendorVK::kUnknown;
   DeviceTypeVK type_ = DeviceTypeVK::kUnknown;
   // If the VendorVK is  VendorVK::kQualcomm, this will be populated with the


### PR DESCRIPTION
The driver on PIxel 10 requires Flutter to set the `engine` version to something higher than 1.0. We had previous set the application version without effect. With this change, I see we can get a valid vulkan context.

- ran some testing against reported errors (saw none)
- compiled and ran wonderous with validation layers (runs)
- still researching 

towards: #179812


> On a pixel 10, the Vulkan engine version must be bumped up past 1.0 and any other additional checks gating Vulkan removed. It must be confirmed that Impeller is able to create a Vulkan context.

Pixel 10 gets a Vulkan context with just the engine version bump.

> The usual sample applications must render accurately.

wonderous and failing code passes and renders correctly

> The reduced test cases in the internal doc must be tested.

it does.

> If testing is successful, the engine version update may be committed. This is necessary for enabling Vulkan on Pixel 10 but not sufficient to ensure stability of newer Vulkan enabled Impeller applications on Pixel 10 devices that have not yet been updated.

This PR does that.

> Impeller must detect the driver version and self-reject Vulkan on device older than the current Pixel 10 GPU driver version. The IHV reports that a safe conservative driver version is >= 25.1 and any verification must happen on versions past this. Impeller should still base its checks on the driver version that we verify correctness on. What we have today works well and it is not advised to introduce instability for the sake of enabling Vulkan on this device.

Done - driver_version appears to be a build number, so monotonically increasing.