### PR TITLE
Remove material from simple_semantics_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -240,7 +240,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/slivers_test.dart',
     'packages/flutter/test/widgets/navigator_restoration_test.dart',
     'packages/flutter/test/widgets/sliver_prototype_item_extent_test.dart',
-    'packages/flutter/test/widgets/simple_semantics_test.dart',
     'packages/flutter/test/widgets/image_filter_test.dart',
     'packages/flutter/test/widgets/navigator_on_did_remove_page_test.dart',
     'packages/flutter/test/widgets/opacity_test.dart',

--- a/packages/flutter/test/widgets/simple_semantics_test.dart
+++ b/packages/flutter/test/widgets/simple_semantics_test.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
@@ -35,15 +33,25 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Simple tree is simple - material', (WidgetTester tester) async {
+  testWidgets('Simple tree is simple - WidgetsApp', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
 
-    // Not using Text widget because of https://github.com/flutter/flutter/issues/12357.
     await tester.pumpWidget(
-      MaterialApp(
+      WidgetsApp(
+        color: const Color(0xFFFFFFFF),
         home: Center(
           child: Semantics(label: 'Hello!', child: const SizedBox(width: 10.0, height: 10.0)),
         ),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
+          return PageRouteBuilder<T>(
+            pageBuilder:
+                (
+                  BuildContext context,
+                  Animation<double> animation,
+                  Animation<double> secondaryAnimation,
+                ) => builder(context),
+          );
+        },
       ),
     );
 
@@ -62,17 +70,10 @@ void main() {
                   children: <TestSemantics>[
                     TestSemantics(
                       id: 3,
-                      rect: const Rect.fromLTWH(0.0, 0.0, 800.0, 600.0),
-                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
-                      children: <TestSemantics>[
-                        TestSemantics(
-                          id: 4,
-                          label: 'Hello!',
-                          textDirection: TextDirection.ltr,
-                          rect: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
-                          transform: Matrix4.translationValues(395.0, 295.0, 0.0),
-                        ),
-                      ],
+                      label: 'Hello!',
+                      textDirection: TextDirection.ltr,
+                      rect: const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
+                      transform: Matrix4.translationValues(395.0, 295.0, 0.0),
                     ),
                   ],
                 ),


### PR DESCRIPTION
This PR removes material from simple_semantics_test.dart

Since `WidgetsApp` does not include a scopes route, like how MaterialApp adds one, I had to update the test expectation for one test. Since that test seemed like a smoke test for SemanticsNode, I figured that was a valid choice here.

Part of https://github.com/flutter/flutter/issues/177415

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
