### PR TITLE
Remove material from text_semantics_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -228,7 +228,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/reassemble_test.dart',
     'packages/flutter/test/widgets/html_element_view_test.dart',
     'packages/flutter/test/widgets/navigator_test.dart',
-    'packages/flutter/test/widgets/text_semantics_test.dart',
     'packages/flutter/test/widgets/safe_area_test.dart',
     'packages/flutter/test/widgets/page_view_test.dart',
     'packages/flutter/test/widgets/undo_history_test.dart',

--- a/packages/flutter/test/widgets/text_semantics_test.dart
+++ b/packages/flutter/test/widgets/text_semantics_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
@@ -198,9 +198,21 @@ void main() {
       'THEN the SemanticsNode contains the correct language tag', (WidgetTester tester) async {
     const locale = Locale('de', 'DE');
     const text = 'Flutter 2050';
+
     await tester.pumpWidget(
-      const MaterialApp(
-        home: SelectionArea(child: Text(text, locale: locale)),
+      WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        home: const _DummySelectionContainer(child: Text(text, locale: locale)),
+        pageRouteBuilder: <T>(RouteSettings settings, WidgetBuilder builder) {
+          return PageRouteBuilder<T>(
+            pageBuilder:
+                (
+                  BuildContext context,
+                  Animation<double> animation,
+                  Animation<double> secondaryAnimation,
+                ) => builder(context),
+          );
+        },
       ),
     );
     await tester.pumpAndSettle();
@@ -222,4 +234,36 @@ void main() {
     expect(targetNode.label, text);
     expect(localeStringAttribute.locale.toLanguageTag(), 'de-DE');
   });
+}
+
+// Taken from the selection container API example.
+class _DummySelectionContainer extends StatefulWidget {
+  const _DummySelectionContainer({required this.child});
+
+  final Widget child;
+
+  @override
+  State<StatefulWidget> createState() => _DummySelectionContainerState();
+}
+
+class _DummySelectionContainerState extends State<_DummySelectionContainer> {
+  final _DummySelectionDelegate delegate = _DummySelectionDelegate();
+
+  @override
+  void dispose() {
+    delegate.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectionContainer(delegate: delegate, child: widget.child);
+  }
+}
+
+class _DummySelectionDelegate extends MultiSelectableSelectionContainerDelegate {
+  _DummySelectionDelegate();
+
+  @override
+  void ensureChildUpdated(Selectable selectable) {}
 }


### PR DESCRIPTION
This PR removes material from text_semantics_test.dart

It only used a SelectionArea, which I replaced with a dummy representation (there was an example in the selection area api samples)

Part of https://github.com/flutter/flutter/issues/177415

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
