### PR TITLE
Reduce reliance on Material in page_transitions_test.dart

### DIFF
--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -689,4 +689,96 @@ void main() {
     await tester.pump();
     expect(find.byType(BottomSheet), findsNothing);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/6451
+  testWidgets(
+    'Check back gesture with a persistent bottom sheet showing',
+    (WidgetTester tester) async {
+      final GlobalKey containerKey1 = GlobalKey();
+      final GlobalKey containerKey2 = GlobalKey();
+      final routes = <String, WidgetBuilder>{
+        '/': (_) => Scaffold(key: containerKey1, body: const Text('Home')),
+        '/sheet': (_) => PersistentBottomSheetTest(key: containerKey2),
+      };
+
+      await tester.pumpWidget(MaterialApp(routes: routes));
+
+      Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Sheet'), isOnstage);
+
+      // Drag from left edge to invoke the gesture. We should go back.
+      TestGesture gesture = await tester.startGesture(const Offset(5.0, 100.0));
+      await gesture.moveBy(const Offset(500.0, 0.0));
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Sheet'), isOnstage);
+
+      // Show the bottom sheet.
+      final sheet = containerKey2.currentState! as PersistentBottomSheetTestState;
+      sheet.showBottomSheet();
+
+      await tester.pump(const Duration(seconds: 1));
+
+      // Drag from left edge to invoke the gesture. Nothing should happen.
+      gesture = await tester.startGesture(const Offset(5.0, 100.0));
+      await gesture.moveBy(const Offset(500.0, 0.0));
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Sheet'), isOnstage);
+
+      // Sheet did not call setState (since the gesture did nothing).
+      expect(sheet.setStateCalled, isFalse);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+}
+
+class PersistentBottomSheetTest extends StatefulWidget {
+  const PersistentBottomSheetTest({super.key});
+
+  @override
+  PersistentBottomSheetTestState createState() => PersistentBottomSheetTestState();
+}
+
+class PersistentBottomSheetTestState extends State<PersistentBottomSheetTest> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  bool setStateCalled = false;
+
+  void showBottomSheet() {
+    _scaffoldKey.currentState!
+        .showBottomSheet((BuildContext context) {
+          return const Text('bottomSheet');
+        })
+        .closed
+        .whenComplete(() {
+          setState(() {
+            setStateCalled = true;
+          });
+        });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(key: _scaffoldKey, body: const Text('Sheet'));
+  }
 }

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -694,8 +694,8 @@ void main() {
   testWidgets(
     'Check back gesture with a persistent bottom sheet showing',
     (WidgetTester tester) async {
-      final GlobalKey containerKey1 = GlobalKey();
-      final GlobalKey containerKey2 = GlobalKey();
+      final GlobalKey<ScaffoldState> containerKey1 = GlobalKey();
+      final GlobalKey<PersistentBottomSheetTestState> containerKey2 = GlobalKey();
       final routes = <String, WidgetBuilder>{
         '/': (_) => Scaffold(key: containerKey1, body: const Text('Home')),
         '/sheet': (_) => PersistentBottomSheetTest(key: containerKey2),
@@ -727,7 +727,7 @@ void main() {
       expect(find.text('Sheet'), isOnstage);
 
       // Show the bottom sheet.
-      final sheet = containerKey2.currentState! as PersistentBottomSheetTestState;
+      final PersistentBottomSheetTestState sheet = containerKey2.currentState!;
       sheet.showBottomSheet();
 
       await tester.pump(const Duration(seconds: 1));

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -15,37 +15,6 @@ class TestOverlayRoute extends OverlayRoute<void> {
   Widget _build(BuildContext context) => const Text('Overlay');
 }
 
-class PersistentBottomSheetTest extends StatefulWidget {
-  const PersistentBottomSheetTest({super.key});
-
-  @override
-  PersistentBottomSheetTestState createState() => PersistentBottomSheetTestState();
-}
-
-class PersistentBottomSheetTestState extends State<PersistentBottomSheetTest> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  bool setStateCalled = false;
-
-  void showBottomSheet() {
-    _scaffoldKey.currentState!
-        .showBottomSheet((BuildContext context) {
-          return const Text('bottomSheet');
-        })
-        .closed
-        .whenComplete(() {
-          setState(() {
-            setStateCalled = true;
-          });
-        });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(key: _scaffoldKey, body: const Text('Sheet'));
-  }
-}
-
 void main() {
   testWidgets('Check onstage/offstage handling around transitions', (WidgetTester tester) async {
     final GlobalKey containerKey1 = GlobalKey();
@@ -242,67 +211,6 @@ void main() {
 
       expect(find.text('Home'), isOnstage);
       expect(find.text('Settings'), findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.iOS,
-      TargetPlatform.macOS,
-    }),
-  );
-
-  // Tests bug https://github.com/flutter/flutter/issues/6451
-  testWidgets(
-    'Check back gesture with a persistent bottom sheet showing',
-    (WidgetTester tester) async {
-      final GlobalKey containerKey1 = GlobalKey();
-      final GlobalKey containerKey2 = GlobalKey();
-      final routes = <String, WidgetBuilder>{
-        '/': (_) => Scaffold(key: containerKey1, body: const Text('Home')),
-        '/sheet': (_) => PersistentBottomSheetTest(key: containerKey2),
-      };
-
-      await tester.pumpWidget(MaterialApp(routes: routes));
-
-      Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
-
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-
-      expect(find.text('Home'), findsNothing);
-      expect(find.text('Sheet'), isOnstage);
-
-      // Drag from left edge to invoke the gesture. We should go back.
-      TestGesture gesture = await tester.startGesture(const Offset(5.0, 100.0));
-      await gesture.moveBy(const Offset(500.0, 0.0));
-      await gesture.up();
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-
-      Navigator.pushNamed(containerKey1.currentContext!, '/sheet');
-
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-
-      expect(find.text('Home'), findsNothing);
-      expect(find.text('Sheet'), isOnstage);
-
-      // Show the bottom sheet.
-      final sheet = containerKey2.currentState! as PersistentBottomSheetTestState;
-      sheet.showBottomSheet();
-
-      await tester.pump(const Duration(seconds: 1));
-
-      // Drag from left edge to invoke the gesture. Nothing should happen.
-      gesture = await tester.startGesture(const Offset(5.0, 100.0));
-      await gesture.moveBy(const Offset(500.0, 0.0));
-      await gesture.up();
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-
-      expect(find.text('Home'), findsNothing);
-      expect(find.text('Sheet'), isOnstage);
-
-      // Sheet did not call setState (since the gesture did nothing).
-      expect(sheet.setStateCalled, isFalse);
     },
     variant: const TargetPlatformVariant(<TargetPlatform>{
       TargetPlatform.iOS,

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -103,16 +103,16 @@ void main() {
       final GlobalKey containerKey2 = GlobalKey();
       const kHeroTag = 'hero';
       final routes = <String, WidgetBuilder>{
-        '/': (_) => Scaffold(
+        '/': (_) => SizedBox(
           key: containerKey1,
-          body: const ColoredBox(
+          child: const ColoredBox(
             color: Color(0xff00ffff),
             child: Hero(tag: kHeroTag, child: Text('Home')),
           ),
         ),
-        '/settings': (_) => Scaffold(
+        '/settings': (_) => SizedBox(
           key: containerKey2,
-          body: Container(
+          child: Container(
             padding: const EdgeInsets.all(100.0),
             color: const Color(0xffff00ff),
             child: const Hero(tag: kHeroTag, child: Text('Settings')),
@@ -172,8 +172,8 @@ void main() {
       final GlobalKey containerKey1 = GlobalKey();
       final GlobalKey containerKey2 = GlobalKey();
       final routes = <String, WidgetBuilder>{
-        '/': (_) => Scaffold(key: containerKey1, body: const Text('Home')),
-        '/settings': (_) => Scaffold(key: containerKey2, body: const Text('Settings')),
+        '/': (_) => SizedBox(key: containerKey1, child: const Text('Home')),
+        '/settings': (_) => SizedBox(key: containerKey2, child: const Text('Settings')),
       };
 
       await tester.pumpWidget(MaterialApp(routes: routes));
@@ -224,9 +224,14 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(routes: routes));
 
-    final PageRoute<void> route = MaterialPageRoute<void>(
+    final PageRoute<void> route = PageRouteBuilder<void>(
       settings: const RouteSettings(name: '/page'),
-      builder: (BuildContext context) => const Center(child: Text('page')),
+      pageBuilder:
+          (
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+          ) => const Center(child: Text('page')),
     );
 
     var popCount = 0;

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -8,9 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 class TestOverlayRoute extends OverlayRoute<void> {
   TestOverlayRoute({super.settings});
   @override
-  Iterable<OverlayEntry> createOverlayEntries() sync* {
-    yield OverlayEntry(builder: _build);
-  }
+  Iterable<OverlayEntry> createOverlayEntries() => [OverlayEntry(builder: _build)];
 
   Widget _build(BuildContext context) => const Text('Overlay');
 }


### PR DESCRIPTION
This PR reduces the reliance on Material in page_transitions_test.dart but does not entirely remove it.

1) Moves a test for persistent bottom sheet to the right file
2) Fixes a use of `sync*` (not sure why this is not caught by dev/bots/analyze.dart, that _does_ check for `sync*` cc @Piinks )
3) Replaces some easy usages of Material widgets with its widget counterparts.

The only thing that I did not yet fix is replacing `MaterialApp` in this file. That probably needs @victorsanni 's work on page transitions to be addressed first?

Part of https://github.com/flutter/flutter/issues/177415

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
