### PR TITLE
Fix overlay in size to content scenario with loose constraints

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1337,7 +1337,7 @@ class _RenderTheater extends RenderBox
 
   @override
   double? computeDryBaseline(BoxConstraints constraints, TextBaseline baseline) {
-    final Size size = constraints.biggest.isFinite
+    final Size size = constraints.isTight
         ? constraints.biggest
         : _findSizeDeterminingChild().getDryLayout(constraints);
     final nonPositionedChildConstraints = BoxConstraints.tight(size);
@@ -1362,7 +1362,7 @@ class _RenderTheater extends RenderBox
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    if (constraints.biggest.isFinite) {
+    if (constraints.isTight) {
       return constraints.biggest;
     }
     return _findSizeDeterminingChild().getDryLayout(constraints);
@@ -1412,7 +1412,7 @@ class _RenderTheater extends RenderBox
   @override
   void performLayout() {
     RenderBox? sizeDeterminingChild;
-    if (constraints.biggest.isFinite) {
+    if (constraints.isTight) {
       size = constraints.biggest;
     } else {
       sizeDeterminingChild = _findSizeDeterminingChild();
@@ -2668,7 +2668,7 @@ class _RenderLayoutSurrogateProxyBox extends RenderProxyBox {
     // needed.
     if (!theater._layingOutSizeDeterminingChild) {
       final BoxConstraints theaterConstraints = theater.constraints;
-      final Size boxSize = theaterConstraints.biggest.isFinite
+      final Size boxSize = theaterConstraints.isTight
           ? theaterConstraints.biggest
           : theater.size;
       deferredChild._doLayoutFrom(this, constraints: BoxConstraints.tight(boxSize));

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -2668,9 +2668,7 @@ class _RenderLayoutSurrogateProxyBox extends RenderProxyBox {
     // needed.
     if (!theater._layingOutSizeDeterminingChild) {
       final BoxConstraints theaterConstraints = theater.constraints;
-      final Size boxSize = theaterConstraints.isTight
-          ? theaterConstraints.biggest
-          : theater.size;
+      final Size boxSize = theaterConstraints.isTight ? theaterConstraints.biggest : theater.size;
       deferredChild._doLayoutFrom(this, constraints: BoxConstraints.tight(boxSize));
     }
   }

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -173,14 +173,14 @@ class OverlayEntry implements Listenable {
   /// Whether the content of this [OverlayEntry] can be used to size the
   /// [Overlay].
   ///
-  /// In most situations the overlay sizes itself based on its incoming
-  /// constraints to be as large as possible. However, if that would result in
-  /// an infinite size, it has to rely on one of its children to size itself. In
-  /// this situation, the overlay will consult the topmost non-[Positioned]
-  /// overlay entry that has this property set to true, lay it out with the
-  /// incoming [BoxConstraints] of the overlay, and force all other
-  /// non-[Positioned] overlay entries to have the same size. The [Positioned]
-  /// entries are laid out as usual based on the calculated size of the overlay.
+  /// In most situations the overlay should get tight constraints which
+  /// determine the size of overlay. However if the constraints are loose, it
+  /// has to rely on one of its children to size itself. In this situation, the
+  /// overlay will consult the topmost non-[Positioned] overlay entry that has
+  /// this property set to true, lay it out with the incoming [BoxConstraints]
+  /// of the overlay, and force all other non-[Positioned] overlay entries to
+  /// have the same size. The [Positioned] entries are laid out as usual based
+  /// on the calculated size of the overlay.
   ///
   /// Overlay entries that set this to true must be able to handle unconstrained
   /// [BoxConstraints].

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1645,7 +1645,10 @@ void main() {
             DefaultWidgetsLocalizations.delegate,
             DefaultMaterialLocalizations.delegate,
           ],
-          child: Directionality(textDirection: TextDirection.ltr, child: child),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Overlay.wrap(child: child),
+          ),
         );
       }
 
@@ -1653,19 +1656,11 @@ void main() {
         Scaffold(
           resizeToAvoidBottomInset: false,
           body: const Placeholder(),
-          bottomNavigationBar: Navigator(
-            onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<void>(
-                builder: (BuildContext context) {
-                  return BottomNavigationBar(
-                    items: const <BottomNavigationBarItem>[
-                      BottomNavigationBarItem(icon: Icon(Icons.add), label: 'test'),
-                      BottomNavigationBarItem(icon: Icon(Icons.add), label: 'test'),
-                    ],
-                  );
-                },
-              );
-            },
+          bottomNavigationBar: BottomNavigationBar(
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(icon: Icon(Icons.add), label: 'test'),
+              BottomNavigationBarItem(icon: Icon(Icons.add), label: 'test'),
+            ],
           ),
         ),
       );
@@ -1688,7 +1683,9 @@ void main() {
         ),
       );
       final Offset finalPoint = tester.getCenter(find.byType(Placeholder));
-      expect(initialPoint, finalPoint);
+      // BottomNavigationBar adds 20 pixel padding so the center point moves
+      // by 10 pixels.
+      expect(initialPoint, finalPoint.translate(0, 10));
     });
 
     testWidgets('floatingActionButton', (WidgetTester tester) async {

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -2622,24 +2622,24 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         builder: (BuildContext context, Widget? child) {
-          return Scaffold(
-            body: Padding(padding: const EdgeInsets.all(rootSpacing), child: child),
-          );
+          return Padding(padding: const EdgeInsets.all(rootSpacing), child: child);
         },
-        home: Material(
-          child: SearchAnchor(
-            isFullScreen: false,
-            builder: (BuildContext context, SearchController controller) {
-              return IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
-              );
-            },
-            suggestionsBuilder: (BuildContext context, SearchController controller) {
-              return <Widget>[];
-            },
+        home: Scaffold(
+          body: Material(
+            child: SearchAnchor(
+              isFullScreen: false,
+              builder: (BuildContext context, SearchController controller) {
+                return IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    controller.openView();
+                  },
+                );
+              },
+              suggestionsBuilder: (BuildContext context, SearchController controller) {
+                return <Widget>[];
+              },
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2718,33 +2718,31 @@ Future<void> mediaQueryBoilerplate(
             size: tester.view.physicalSize / tester.view.devicePixelRatio,
           ),
           child: Material(
-            child: Center(
-              child: Directionality(
-                textDirection: TextDirection.ltr,
-                child: Navigator(
-                  onGenerateRoute: (RouteSettings settings) {
-                    return MaterialPageRoute<void>(
-                      builder: (BuildContext context) {
-                        return TextButton(
-                          onPressed: () {
-                            showTimePicker(
-                              context: context,
-                              initialTime: initialTime,
-                              initialEntryMode: entryMode,
-                              helpText: helpText,
-                              hourLabelText: hourLabelText,
-                              minuteLabelText: minuteLabelText,
-                              errorInvalidText: errorInvalidText,
-                              onEntryModeChanged: onEntryModeChange,
-                              orientation: orientation,
-                            );
-                          },
-                          child: const Text('X'),
-                        );
-                      },
-                    );
-                  },
-                ),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Navigator(
+                onGenerateRoute: (RouteSettings settings) {
+                  return MaterialPageRoute<void>(
+                    builder: (BuildContext context) {
+                      return TextButton(
+                        onPressed: () {
+                          showTimePicker(
+                            context: context,
+                            initialTime: initialTime,
+                            initialEntryMode: entryMode,
+                            helpText: helpText,
+                            hourLabelText: hourLabelText,
+                            minuteLabelText: minuteLabelText,
+                            errorInvalidText: errorInvalidText,
+                            onEntryModeChanged: onEntryModeChange,
+                            orientation: orientation,
+                          );
+                        },
+                        child: const Text('X'),
+                      );
+                    },
+                  );
+                },
               ),
             ),
           ),

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1777,6 +1777,27 @@ void main() {
     expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
   });
 
+  testWidgets('Overlay.wrap is sized by child with loose constraints', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              minWidth: 10,
+              maxWidth: 700,
+              minHeight: 10,
+              maxHeight: 600,
+            ),
+            child: Overlay.wrap(child: const SizedBox(width: 123, height: 456)),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+  });
+
   testWidgets('Overlay is sized by child in an unconstrained environment', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -519,32 +519,27 @@ void main() {
 
   testWidgets('Text Inline widget textfield', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Center(
-        child: MaterialApp(
-          theme: ThemeData(useMaterial3: false),
-          home: RepaintBoundary(
-            child: Material(
-              child: Container(
-                width: 400.0,
-                height: 200.0,
-                decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
-                    TextSpan(
-                      text: 'My name is: ',
-                      style: TextStyle(fontSize: 20),
-                      children: <InlineSpan>[
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                        TextSpan(
-                          text: ', and my favorite city is: ',
-                          style: TextStyle(fontSize: 20),
-                        ),
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                      ],
-                    ),
-                    textDirection: TextDirection.ltr,
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: RepaintBoundary(
+          child: Material(
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'My name is: ',
+                    style: TextStyle(fontSize: 20),
+                    children: <InlineSpan>[
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
+                      TextSpan(text: ', and my favorite city is: ', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),
@@ -561,104 +556,102 @@ void main() {
   // This tests if multiple Text.rich widgets are able to inline nest within each other.
   testWidgets('Text Inline widget nesting', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Center(
-        child: MaterialApp(
-          theme: ThemeData(useMaterial3: false),
-          home: RepaintBoundary(
-            child: Material(
-              child: Container(
-                width: 400.0,
-                height: 200.0,
-                decoration: const BoxDecoration(color: Color(0xff00ff00)),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
-                    TextSpan(
-                      text: 'outer',
-                      style: TextStyle(fontSize: 20),
-                      children: <InlineSpan>[
-                        WidgetSpan(
-                          child: Text.rich(
-                            TextSpan(
-                              text: 'inner',
-                              style: TextStyle(color: Color(0xf402f4ff)),
-                              children: <InlineSpan>[
-                                WidgetSpan(
-                                  child: Text.rich(
-                                    TextSpan(
-                                      text: 'inner2',
-                                      style: TextStyle(color: Color(0xf003ffff)),
-                                      children: <InlineSpan>[
-                                        WidgetSpan(
-                                          child: SizedBox(
-                                            width: 50.0,
-                                            height: 55.0,
-                                            child: DecoratedBox(
-                                              decoration: BoxDecoration(color: Color(0xffffff30)),
-                                              child: Center(
-                                                child: SizedBox(
-                                                  width: 10.0,
-                                                  height: 15.0,
-                                                  child: DecoratedBox(
-                                                    decoration: BoxDecoration(
-                                                      color: Color(0xff5f00f0),
-                                                    ),
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: RepaintBoundary(
+          child: Material(
+            child: Container(
+              width: 400.0,
+              height: 200.0,
+              decoration: const BoxDecoration(color: Color(0xff00ff00)),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
+                child: const Text.rich(
+                  TextSpan(
+                    text: 'outer',
+                    style: TextStyle(fontSize: 20),
+                    children: <InlineSpan>[
+                      WidgetSpan(
+                        child: Text.rich(
+                          TextSpan(
+                            text: 'inner',
+                            style: TextStyle(color: Color(0xf402f4ff)),
+                            children: <InlineSpan>[
+                              WidgetSpan(
+                                child: Text.rich(
+                                  TextSpan(
+                                    text: 'inner2',
+                                    style: TextStyle(color: Color(0xf003ffff)),
+                                    children: <InlineSpan>[
+                                      WidgetSpan(
+                                        child: SizedBox(
+                                          width: 50.0,
+                                          height: 55.0,
+                                          child: DecoratedBox(
+                                            decoration: BoxDecoration(color: Color(0xffffff30)),
+                                            child: Center(
+                                              child: SizedBox(
+                                                width: 10.0,
+                                                height: 15.0,
+                                                child: DecoratedBox(
+                                                  decoration: BoxDecoration(
+                                                    color: Color(0xff5f00f0),
                                                   ),
                                                 ),
                                               ),
                                             ),
                                           ),
                                         ),
-                                      ],
-                                    ),
+                                      ),
+                                    ],
                                   ),
                                 ),
-                                WidgetSpan(
-                                  child: SizedBox(
-                                    width: 50.0,
-                                    height: 55.0,
-                                    child: DecoratedBox(
-                                      decoration: BoxDecoration(color: Color(0xff5fff00)),
-                                      child: Center(
-                                        child: SizedBox(
-                                          width: 10.0,
-                                          height: 15.0,
-                                          child: DecoratedBox(
-                                            decoration: BoxDecoration(color: Color(0xff5f0000)),
-                                          ),
+                              ),
+                              WidgetSpan(
+                                child: SizedBox(
+                                  width: 50.0,
+                                  height: 55.0,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(color: Color(0xff5fff00)),
+                                    child: Center(
+                                      child: SizedBox(
+                                        width: 10.0,
+                                        height: 15.0,
+                                        child: DecoratedBox(
+                                          decoration: BoxDecoration(color: Color(0xff5f0000)),
                                         ),
                                       ),
                                     ),
                                   ),
                                 ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
                         ),
-                        TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
-                        WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
-                        WidgetSpan(
-                          child: SizedBox(
-                            width: 50.0,
-                            height: 55.0,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(color: Color(0xffff00ff)),
-                              child: Center(
-                                child: SizedBox(
-                                  width: 10.0,
-                                  height: 15.0,
-                                  child: DecoratedBox(
-                                    decoration: BoxDecoration(color: Color(0xff0000ff)),
-                                  ),
+                      ),
+                      TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
+                      WidgetSpan(child: SizedBox(width: 70, height: 25, child: TextField())),
+                      WidgetSpan(
+                        child: SizedBox(
+                          width: 50.0,
+                          height: 55.0,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(color: Color(0xffff00ff)),
+                            child: Center(
+                              child: SizedBox(
+                                width: 10.0,
+                                height: 15.0,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(color: Color(0xff0000ff)),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ],
-                    ),
-                    textDirection: TextDirection.ltr,
+                      ),
+                    ],
                   ),
+                  textDirection: TextDirection.ltr,
                 ),
               ),
             ),


### PR DESCRIPTION
Right now overlay assumes that when sizing to contents the constraints are always unconstrained. That might not be true however, for example `constraints.biggest` may be limited to usable desktop size. If that happens the current behavior is that `Overlay` sizes itself to `constraints.biggest`, which defeats the purpose of views sized to contents.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
