### PR TITLE
[native_assets] Fix `flutter build ios-framework`

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -343,22 +343,8 @@ class Context {
   }) {
     // Copy native assets referenced in the native_assets.json file for the
     // current build.
-    final String sourceRoot = environment['SOURCE_ROOT'] ?? '';
-    var projectPath = '$sourceRoot/..';
-    if (environment['FLUTTER_APPLICATION_PATH'] != null) {
-      projectPath = environment['FLUTTER_APPLICATION_PATH']!;
-    }
-    final String flutterBuildDir = environment['FLUTTER_BUILD_DIR']!;
-    var nativeAssetsPath = '$projectPath/$flutterBuildDir/native_assets/${platform.name}/';
-    final String? builtProductsDir = environment['BUILT_PRODUCTS_DIR'];
-    if (builtProductsDir != null) {
-      final Directory nativeAssetsInBuiltProducts = directoryFromPath(
-        '$builtProductsDir/native_assets/',
-      );
-      if (nativeAssetsInBuiltProducts.existsSync()) {
-        nativeAssetsPath = '${nativeAssetsInBuiltProducts.path}/';
-      }
-    }
+    final String builtProductsDir = environment['BUILT_PRODUCTS_DIR']!;
+    final nativeAssetsPath = '$builtProductsDir/native_assets/';
     final bool verbose = (environment['VERBOSE_SCRIPT_LOGGING'] ?? '').isNotEmpty;
 
     final Set<String> referencedFrameworks = {};

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -349,7 +349,16 @@ class Context {
       projectPath = environment['FLUTTER_APPLICATION_PATH']!;
     }
     final String flutterBuildDir = environment['FLUTTER_BUILD_DIR']!;
-    final nativeAssetsPath = '$projectPath/$flutterBuildDir/native_assets/${platform.name}/';
+    var nativeAssetsPath = '$projectPath/$flutterBuildDir/native_assets/${platform.name}/';
+    final String? builtProductsDir = environment['BUILT_PRODUCTS_DIR'];
+    if (builtProductsDir != null) {
+      final Directory nativeAssetsInBuiltProducts = directoryFromPath(
+        '$builtProductsDir/native_assets/',
+      );
+      if (nativeAssetsInBuiltProducts.existsSync()) {
+        nativeAssetsPath = '${nativeAssetsInBuiltProducts.path}/';
+      }
+    }
     final bool verbose = (environment['VERBOSE_SCRIPT_LOGGING'] ?? '').isNotEmpty;
 
     final Set<String> referencedFrameworks = {};

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -719,10 +719,8 @@ class FlutterPlugin : Plugin<Project> {
                             into(abi ?: "null")
                         }
                         // Copy the native assets created by build.dart and placed in build/native_assets by flutter assemble.
-                        val buildDir =
-                            "${FlutterPluginUtils.getFlutterSourceDirectory(project)}/build"
                         val nativeAssetsDir =
-                            "$buildDir/native_assets/android/jniLibs/lib"
+                            "${flutterCompileTask.intermediateDir}/native_assets/jniLibs/lib"
                         from("$nativeAssetsDir/$abi") {
                             include("*.so")
                             into(abi ?: "null")

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -31,6 +31,7 @@ abstract class AndroidAssetBundle extends Target {
   @override
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/app.dill'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
   ];
 

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -247,17 +247,14 @@ class CopyAssets extends Target {
   String get name => 'copy_assets';
 
   @override
-  List<Target> get dependencies => const <Target>[
-    DartBuildForNative(),
-    KernelSnapshot(),
-    InstallCodeAssets(),
-  ];
+  List<Target> get dependencies => const <Target>[DartBuildForNative(), KernelSnapshot()];
 
   @override
   List<Source> get inputs => const <Source>[
     Source.pattern(
       '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/assets.dart',
     ),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
     ...ShaderCompiler.inputs,
   ];
@@ -288,11 +285,6 @@ class CopyAssets extends Target {
       targetPlatform: targetPlatform,
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
-      additionalContent: <String, DevFSContent>{
-        'NativeAssetsManifest.json': DevFSFileContent(
-          environment.buildDir.childFile('native_assets.json'),
-        ),
-      },
     );
     environment.depFileService.writeToFile(
       depfile,

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -39,6 +39,7 @@ class CopyFlutterBundle extends Target {
     Source.artifact(Artifact.vmSnapshotData, mode: BuildMode.debug),
     Source.artifact(Artifact.isolateSnapshotData, mode: BuildMode.debug),
     Source.pattern('{BUILD_DIR}/app.dill'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
     ...ShaderCompiler.inputs,
   ];
@@ -48,6 +49,7 @@ class CopyFlutterBundle extends Target {
     Source.pattern('{OUTPUT_DIR}/vm_snapshot_data'),
     Source.pattern('{OUTPUT_DIR}/isolate_snapshot_data'),
     Source.pattern('{OUTPUT_DIR}/kernel_blob.bin'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
   ];
 
   @override

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -623,6 +623,7 @@ abstract class IosAssetBundle extends Target {
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/App.framework/App'),
     Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
     ...ShaderCompiler.inputs,
   ];

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -104,6 +104,7 @@ abstract class BundleLinuxAssets extends Target {
   List<Source> get inputs => const <Source>[
     Source.pattern('{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/linux.dart'),
     Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
   ];
 

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -383,6 +383,7 @@ abstract class MacOSBundleFlutterAssets extends Target {
   @override
   List<Source> get inputs => const <Source>[
     Source.pattern('{BUILD_DIR}/App.framework/App'),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...IconTreeShaker.inputs,
   ];
 

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -2,6 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// The build mode and target architecture can be changed from the
+/// native build project (Xcode etc.), so only `flutter assemble` has the
+/// information about build-mode and target architecture.
+///
+/// Also, only `flutter assemble` has access to the code sign identity.
+///
+/// Hence running the build hooks for code assets and the installation steps
+/// need to be run in the `Target`s in `flutter assemble`.
+library;
+
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 
@@ -60,7 +70,10 @@ class DartBuild extends Target {
 
     final depfile = Depfile(
       <File>[for (final Uri dependency in result.dependencies) fileSystem.file(dependency)],
-      <File>[fileSystem.file(dartHookResultJsonFile)],
+      <File>[
+        fileSystem.file(dartHookResultJsonFile),
+        for (final Uri uri in result.filesToBeBundled) fileSystem.file(uri),
+      ],
     );
     final File outputDepfile = environment.buildDir.childFile(depFilename);
     if (!outputDepfile.parent.existsSync()) {
@@ -122,10 +135,6 @@ class DartBuildForNative extends DartBuild {
 }
 
 /// Installs the code assets from a [DartBuild] Flutter app.
-///
-/// The build mode and target architecture can be changed from the
-/// native build project (Xcode etc.), so only `flutter assemble` has the
-/// information about build-mode and target architecture.
 class InstallCodeAssets extends Target {
   const InstallCodeAssets();
 
@@ -149,7 +158,7 @@ class InstallCodeAssets extends Target {
       targetUri = targetUri.resolve('$osName/');
     }
 
-    await installCodeAssets(
+    final List<File> installedFiles = await installCodeAssets(
       dartHookResult: dartHookResult,
       environmentDefines: environment.defines,
       targetPlatform: targetPlatform,
@@ -160,10 +169,9 @@ class InstallCodeAssets extends Target {
     );
     assert(await fileSystem.file(nativeAssetsFileUri).exists());
 
-    final depfile = Depfile(
-      <File>[for (final Uri file in dartHookResult.filesToBeBundled) fileSystem.file(file)],
-      <File>[fileSystem.file(nativeAssetsFileUri)],
-    );
+    final depfile = Depfile(<File>[
+      for (final Uri file in dartHookResult.filesToBeBundled) fileSystem.file(file),
+    ], installedFiles);
     final File outputDepfile = environment.buildDir.childFile(depFilename);
     environment.depFileService.writeToFile(depfile, outputDepfile);
     if (!await outputDepfile.exists()) {

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -578,6 +578,7 @@ class WebReleaseBundle extends Target {
   @override
   List<Source> get inputs => <Source>[
     const Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
+    const Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     ...buildPatternStems.map((String file) => Source.pattern('{BUILD_DIR}/$file')),
   ];
 

--- a/packages/flutter_tools/lib/src/build_system/targets/windows.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/windows.dart
@@ -118,6 +118,7 @@ abstract class BundleWindowsAssets extends Target {
     Source.pattern(
       '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/windows.dart',
     ),
+    Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),
     Source.pattern('{PROJECT_DIR}/pubspec.yaml'),
     ...IconTreeShaker.inputs,
   ];

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -146,7 +146,7 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     }
   }
 
-  static Iterable<String> findFrameworkNames(Directory outputDirectory) {
+  static Iterable<String> findCodeAssetFrameworkNames(Directory outputDirectory) {
     final Directory nativeAssetsDirectory = outputDirectory.childDirectory('native_assets');
     if (!nativeAssetsDirectory.existsSync()) {
       return const <String>[];
@@ -332,8 +332,8 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
 
       // Package native assets.
       final Iterable<String> frameworkNames = <String>{
-        ...BuildFrameworkCommand.findFrameworkNames(simulatorBuildOutput),
-        ...BuildFrameworkCommand.findFrameworkNames(iPhoneBuildOutput),
+        ...BuildFrameworkCommand.findCodeAssetFrameworkNames(simulatorBuildOutput),
+        ...BuildFrameworkCommand.findCodeAssetFrameworkNames(iPhoneBuildOutput),
       };
       for (final frameworkName in frameworkNames) {
         final Directory frameworkDirectoryDevice = iPhoneBuildOutput

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -16,6 +16,7 @@ import '../build_info.dart';
 import '../build_system/build_system.dart';
 import '../build_system/targets/ios.dart';
 import '../cache.dart';
+import '../convert.dart';
 import '../darwin/darwin.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
@@ -156,6 +157,85 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
         .whereType<Directory>()
         .where((Directory d) => !d.basename.endsWith('.dSYM'))
         .map((Directory d) => d.basename);
+  }
+
+  /// Parses the NativeAssetsManifest.json in [outputDirectory] and returns a
+  /// mapping from asset ID to the path of the code asset within the bundle
+  /// (e.g., "MyFramework.framework/MyFramework").
+  static Map<String, String> parseNativeAssetsManifest(
+    Directory outputDirectory,
+  ) {
+    final File manifestFile = outputDirectory
+        .childDirectory('App.framework')
+        .childDirectory('flutter_assets')
+        .childFile('NativeAssetsManifest.json');
+    if (!manifestFile.existsSync()) {
+      return const <String, String>{};
+    }
+    final manifest =
+        json.decode(manifestFile.readAsStringSync()) as Map<String, Object?>;
+    final nativeAssets =
+        manifest['native-assets'] as Map<String, Object?>?;
+    if (nativeAssets == null) {
+      return const <String, String>{};
+    }
+    final result = <String, String>{};
+    for (final Object? targetAssets in nativeAssets.values) {
+      if (targetAssets is! Map<String, Object?>) {
+        continue;
+      }
+      for (final MapEntry<String, Object?> entry in targetAssets.entries) {
+        final String assetId = entry.key;
+        final Object? pathInfo = entry.value;
+        if (pathInfo is List<Object?> && pathInfo.length >= 2) {
+          final path = pathInfo[1]! as String;
+          result[assetId] = path;
+        }
+      }
+    }
+    return result;
+  }
+
+  /// Verifies that code assets built for physical devices and simulators are
+  /// consistent.
+  ///
+  /// The physical device build is considered the source of truth. Every asset
+  /// in the simulator build must also be in the physical device build and have
+  /// the same framework path.
+  static void verifyCodeAssetConsistency(
+    Directory iPhoneBuildOutput,
+    Directory simulatorBuildOutput,
+  ) {
+    final Map<String, String> deviceAssets =
+        BuildFrameworkCommand.parseNativeAssetsManifest(iPhoneBuildOutput);
+    final Map<String, String> simulatorAssets =
+        BuildFrameworkCommand.parseNativeAssetsManifest(simulatorBuildOutput);
+
+    for (final String assetId in simulatorAssets.keys) {
+      final String? deviceAssetPath = deviceAssets[assetId];
+      final String simulatorAssetPath = simulatorAssets[assetId]!;
+      if (deviceAssetPath == null) {
+        throwToolExit(
+          'The simulator build contains a code asset "$assetId" that is '
+          'not present in the physical device build. \n'
+          'The device build is the source of truth for distributed '
+          'frameworks. \n'
+          'Ensure "$assetId" is also built for physical devices.',
+        );
+      }
+      if (deviceAssetPath != simulatorAssetPath) {
+        throwToolExit(
+          'Consistent code asset framework names are required for '
+          'XCFramework creation.\n'
+          'The asset "$assetId" has different framework paths across '
+          'platforms:\n'
+          '  - iphoneos: $deviceAssetPath\n'
+          '  - iphonesimulator: $simulatorAssetPath\n\n'
+          'Ensure the "build.dart" hook produces consistent filenames for '
+          'all targets.',
+        );
+      }
+    }
   }
 
   static Future<void> produceXCFramework(
@@ -331,6 +411,11 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
       );
 
       // Package native assets.
+      BuildFrameworkCommand.verifyCodeAssetConsistency(
+        iPhoneBuildOutput,
+        simulatorBuildOutput,
+      );
+
       final Iterable<String> frameworkNames = <String>{
         ...BuildFrameworkCommand.findCodeAssetFrameworkNames(simulatorBuildOutput),
         ...BuildFrameworkCommand.findCodeAssetFrameworkNames(iPhoneBuildOutput),

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -209,19 +209,10 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
       simulatorBuildOutput,
     );
 
-    for (final String assetId in simulatorAssets.keys) {
-      final String? deviceAssetPath = deviceAssets[assetId];
-      final String simulatorAssetPath = simulatorAssets[assetId]!;
-      if (deviceAssetPath == null) {
-        throwToolExit(
-          'The simulator build contains a code asset "$assetId" that is '
-          'not present in the physical device build. \n'
-          'The device build is the source of truth for distributed '
-          'frameworks. \n'
-          'Ensure "$assetId" is also built for physical devices.',
-        );
-      }
-      if (deviceAssetPath != simulatorAssetPath) {
+    for (final String assetId in deviceAssets.keys) {
+      final String deviceAssetPath = deviceAssets[assetId]!;
+      final String? simulatorAssetPath = simulatorAssets[assetId];
+      if (simulatorAssetPath != null && deviceAssetPath != simulatorAssetPath) {
         throwToolExit(
           'Consistent code asset framework names are required for '
           'XCFramework creation.\n'
@@ -229,8 +220,23 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
           'platforms:\n'
           '  - iphoneos: $deviceAssetPath\n'
           '  - iphonesimulator: $simulatorAssetPath\n\n'
-          'Ensure the "build.dart" hook produces consistent filenames for '
-          'all targets.',
+          'This is likely an issue in the package providing the asset. '
+          'Please report this to the package maintainers and ensure the '
+          '"build.dart" hook produces consistent filenames.',
+        );
+      }
+    }
+
+    for (final String assetId in simulatorAssets.keys) {
+      if (!deviceAssets.containsKey(assetId)) {
+        throwToolExit(
+          'The simulator build contains a code asset "$assetId" that is '
+          'not present in the physical device build. \n'
+          'The device build is the source of truth for distributed '
+          'frameworks. \n\n'
+          'This is likely an issue in the package providing the asset. '
+          'Please report this to the package maintainers and ensure '
+          '"$assetId" is also built for physical devices.',
         );
       }
     }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -162,9 +162,7 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
   /// Parses the NativeAssetsManifest.json in [outputDirectory] and returns a
   /// mapping from asset ID to the path of the code asset within the bundle
   /// (e.g., "MyFramework.framework/MyFramework").
-  static Map<String, String> parseNativeAssetsManifest(
-    Directory outputDirectory,
-  ) {
+  static Map<String, String> parseNativeAssetsManifest(Directory outputDirectory) {
     final File manifestFile = outputDirectory
         .childDirectory('App.framework')
         .childDirectory('flutter_assets')
@@ -172,10 +170,8 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     if (!manifestFile.existsSync()) {
       return const <String, String>{};
     }
-    final manifest =
-        json.decode(manifestFile.readAsStringSync()) as Map<String, Object?>;
-    final nativeAssets =
-        manifest['native-assets'] as Map<String, Object?>?;
+    final manifest = json.decode(manifestFile.readAsStringSync()) as Map<String, Object?>;
+    final nativeAssets = manifest['native-assets'] as Map<String, Object?>?;
     if (nativeAssets == null) {
       return const <String, String>{};
     }
@@ -206,10 +202,12 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     Directory iPhoneBuildOutput,
     Directory simulatorBuildOutput,
   ) {
-    final Map<String, String> deviceAssets =
-        BuildFrameworkCommand.parseNativeAssetsManifest(iPhoneBuildOutput);
-    final Map<String, String> simulatorAssets =
-        BuildFrameworkCommand.parseNativeAssetsManifest(simulatorBuildOutput);
+    final Map<String, String> deviceAssets = BuildFrameworkCommand.parseNativeAssetsManifest(
+      iPhoneBuildOutput,
+    );
+    final Map<String, String> simulatorAssets = BuildFrameworkCommand.parseNativeAssetsManifest(
+      simulatorBuildOutput,
+    );
 
     for (final String assetId in simulatorAssets.keys) {
       final String? deviceAssetPath = deviceAssets[assetId];
@@ -411,10 +409,7 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
       );
 
       // Package native assets.
-      BuildFrameworkCommand.verifyCodeAssetConsistency(
-        iPhoneBuildOutput,
-        simulatorBuildOutput,
-      );
+      BuildFrameworkCommand.verifyCodeAssetConsistency(iPhoneBuildOutput, simulatorBuildOutput);
 
       final Iterable<String> frameworkNames = <String>{
         ...BuildFrameworkCommand.findCodeAssetFrameworkNames(simulatorBuildOutput),

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -118,7 +118,9 @@ class BuildMacOSFrameworkCommand extends BuildFrameworkCommand {
       globals.logger.printStatus(' └─Moving to ${globals.fs.path.relative(modeDirectory.path)}');
 
       // Package native assets.
-      final Iterable<String> frameworkNames = BuildFrameworkCommand.findFrameworkNames(buildOutput);
+      final Iterable<String> frameworkNames = BuildFrameworkCommand.findCodeAssetFrameworkNames(
+        buildOutput,
+      );
       for (final frameworkName in frameworkNames) {
         final Directory frameworkDirectory = buildOutput
             .childDirectory('native_assets')

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -118,16 +118,14 @@ class BuildMacOSFrameworkCommand extends BuildFrameworkCommand {
       globals.logger.printStatus(' └─Moving to ${globals.fs.path.relative(modeDirectory.path)}');
 
       // Package native assets.
-      final Directory nativeAssetsDirectory = buildOutput.childDirectory('native_assets');
-      final Iterable<Directory> frameworkDirectories = nativeAssetsDirectory
-          .listSync()
-          .whereType<Directory>()
-          .where((d) => !d.basename.endsWith('.dSYM'));
-      for (final frameworkDirectory in frameworkDirectories) {
-        final frameworks = [frameworkDirectory];
+      final Iterable<String> frameworkNames = BuildFrameworkCommand.findFrameworkNames(buildOutput);
+      for (final frameworkName in frameworkNames) {
+        final Directory frameworkDirectory = buildOutput
+            .childDirectory('native_assets')
+            .childDirectory(frameworkName);
         await BuildFrameworkCommand.produceXCFramework(
-          frameworks,
-          frameworkDirectory.basename.replaceAll('.framework', ''),
+          <Directory>[frameworkDirectory],
+          frameworkName.replaceAll('.framework', ''),
           modeDirectory,
           globals.processManager,
         );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
@@ -17,7 +17,7 @@ int targetAndroidNdkApi(Map<String, String> environmentDefines) {
 }
 
 Future<void> copyNativeCodeAssetsAndroid(
-  Uri buildUri,
+  Uri targetUri,
   Map<FlutterCodeAsset, KernelAsset> assetTargetLocations,
   FileSystem fileSystem,
 ) async {
@@ -26,7 +26,7 @@ Future<void> copyNativeCodeAssetsAndroid(
     for (final AndroidArch androidArch in AndroidArch.values) androidArch.archName,
   ];
   for (final jniArchDir in jniArchDirs) {
-    final Uri archUri = buildUri.resolve('jniLibs/lib/$jniArchDir/');
+    final Uri archUri = targetUri.resolve('jniLibs/lib/$jniArchDir/');
     await fileSystem.directory(archUri).create(recursive: true);
   }
   for (final MapEntry<FlutterCodeAsset, KernelAsset> assetMapping in assetTargetLocations.entries) {
@@ -34,9 +34,9 @@ Future<void> copyNativeCodeAssetsAndroid(
     final Uri target = (assetMapping.value.path as KernelAssetAbsolutePath).uri;
     final AndroidArch androidArch = _getAndroidArch(assetMapping.value.target.architecture);
     final String jniArchDir = androidArch.archName;
-    final Uri archUri = buildUri.resolve('jniLibs/lib/$jniArchDir/');
-    final Uri targetUri = archUri.resolveUri(target);
-    final String targetFullPath = targetUri.toFilePath();
+    final Uri archUri = targetUri.resolve('jniLibs/lib/$jniArchDir/');
+    final Uri assetTargetUri = archUri.resolveUri(target);
+    final String targetFullPath = assetTargetUri.toFilePath();
     await fileSystem.file(source).copy(targetFullPath);
   }
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
@@ -16,12 +16,13 @@ int targetAndroidNdkApi(Map<String, String> environmentDefines) {
   return int.parse(environmentDefines[kMinSdkVersion] ?? minSdkVersion);
 }
 
-Future<void> copyNativeCodeAssetsAndroid(
+Future<List<File>> copyNativeCodeAssetsAndroid(
   Uri targetUri,
   Map<FlutterCodeAsset, KernelAsset> assetTargetLocations,
   FileSystem fileSystem,
 ) async {
   assert(assetTargetLocations.isNotEmpty);
+  final installedFiles = <File>[];
   final jniArchDirs = <String>[
     for (final AndroidArch androidArch in AndroidArch.values) androidArch.archName,
   ];
@@ -37,8 +38,10 @@ Future<void> copyNativeCodeAssetsAndroid(
     final Uri archUri = targetUri.resolve('jniLibs/lib/$jniArchDir/');
     final Uri assetTargetUri = archUri.resolveUri(target);
     final String targetFullPath = assetTargetUri.toFilePath();
-    await fileSystem.file(source).copy(targetFullPath);
+    final File installedFile = await fileSystem.file(source).copy(targetFullPath);
+    installedFiles.add(installedFile);
   }
+  return installedFiles;
 }
 
 /// Get the [Architecture] for [androidArch].

--- a/packages/flutter_tools/lib/src/isolated/native_assets/dart_hook_result.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/dart_hook_result.dart
@@ -110,6 +110,7 @@ final class DartHooksResult {
   List<Uri> get filesToBeBundled => <Uri>[
     for (final FlutterCodeAsset code in codeAssets)
       if (code.codeAsset.linkMode is DynamicLoadingBundled) code.codeAsset.file!,
+    for (final DataAsset asset in dataAssets) asset.file,
   ];
 
   FlutterHookResult get asFlutterResult {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -93,7 +93,7 @@ KernelAsset _targetLocationIOS(FlutterCodeAsset asset, Set<String> alreadyTakenN
 /// Code signing is also done here, so that it doesn't have to be done in
 /// in xcode_backend.dart.
 Future<void> copyNativeCodeAssetsIOS(
-  Uri buildUri,
+  Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
   BuildMode buildMode,
@@ -110,8 +110,8 @@ Future<void> copyNativeCodeAssetsIOS(
       for (final FlutterCodeAsset source in assetMapping.value)
         fileSystem.file(source.codeAsset.file),
     ];
-    final Uri targetUri = buildUri.resolveUri(target);
-    final File dylibFile = fileSystem.file(targetUri);
+    final Uri assetTargetUri = targetUri.resolveUri(target);
+    final File dylibFile = fileSystem.file(assetTargetUri);
     final Directory frameworkDir = dylibFile.parent;
     if (!await frameworkDir.exists()) {
       await frameworkDir.create(recursive: true);
@@ -132,7 +132,7 @@ Future<void> copyNativeCodeAssetsIOS(
     dylibs.add((dylibFile, newInstallName, frameworkDir));
 
     await createInfoPlist(
-      targetUri.pathSegments.last,
+      assetTargetUri.pathSegments.last,
       frameworkDir,
       minimumIOSVersion: '$targetIOSVersion.0',
     );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -29,22 +29,16 @@ Architecture getNativeIOSArchitecture(DarwinArch darwinArch) {
   };
 }
 
+/// Groups native assets by their target framework path for iOS
+/// multi-architecture bundling.
 Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocationsIOS(
   List<FlutterCodeAsset> nativeAssets,
 ) {
-  final alreadyTakenNames = <String>{};
-  final result = <KernelAssetPath, List<FlutterCodeAsset>>{};
-  final idToPath = <String, KernelAssetPath>{};
-  for (final asset in nativeAssets) {
-    // Use same target path for all assets with the same id.
-    final String assetId = asset.codeAsset.id;
-    final KernelAssetPath path =
-        idToPath[assetId] ?? _targetLocationIOS(asset, alreadyTakenNames).path;
-    idToPath[assetId] = path;
-    result[path] ??= <FlutterCodeAsset>[];
-    result[path]!.add(asset);
-  }
-  return result;
+  return fatAssetTargetLocations(
+    nativeAssets,
+    (FlutterCodeAsset asset, Set<String> alreadyTakenNames) =>
+        _targetLocationIOS(asset, alreadyTakenNames),
+  );
 }
 
 Map<FlutterCodeAsset, KernelAsset> assetTargetLocationsIOS(List<FlutterCodeAsset> nativeAssets) {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -86,7 +86,7 @@ KernelAsset _targetLocationIOS(FlutterCodeAsset asset, Set<String> alreadyTakenN
 ///
 /// Code signing is also done here, so that it doesn't have to be done in
 /// in xcode_backend.dart.
-Future<void> copyNativeCodeAssetsIOS(
+Future<List<File>> copyNativeCodeAssetsIOS(
   Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
@@ -94,6 +94,7 @@ Future<void> copyNativeCodeAssetsIOS(
   FileSystem fileSystem,
 ) async {
   assert(assetTargetLocations.isNotEmpty);
+  final installedFiles = <File>[];
   final oldToNewInstallNames = <String, String>{};
   final dylibs = <(File, String, Directory)>[];
 
@@ -111,10 +112,15 @@ Future<void> copyNativeCodeAssetsIOS(
       await frameworkDir.create(recursive: true);
     }
     await lipoDylibs(dylibFile, sources);
+    installedFiles.add(dylibFile);
 
     if (buildMode != BuildMode.debug) {
-      await dsymutilDylib(dylibFile, '${frameworkDir.path}.dSYM');
+      final dsymPath = '${frameworkDir.path}.dSYM';
+      await dsymutilDylib(dylibFile, dsymPath);
       await stripDylib(dylibFile);
+      installedFiles.addAll(
+        fileSystem.directory(dsymPath).listSync(recursive: true).whereType<File>(),
+      );
     }
 
     final String dylibFileName = dylibFile.basename;
@@ -130,10 +136,12 @@ Future<void> copyNativeCodeAssetsIOS(
       frameworkDir,
       minimumIOSVersion: '$targetIOSVersion.0',
     );
+    installedFiles.add(frameworkDir.childFile('Info.plist'));
   }
 
   for (final (File dylibFile, String newInstallName, Directory frameworkDir) in dylibs) {
     await setInstallNamesDylib(dylibFile, newInstallName, oldToNewInstallNames);
     await codesignDylib(codesignIdentity, buildMode, frameworkDir);
   }
+  return installedFiles;
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -107,7 +107,7 @@ KernelAsset _targetLocationMacOS(
 /// Code signing is also done here, so that it doesn't have to be done in
 /// in macos_assemble.sh.
 Future<void> copyNativeCodeAssetsMacOS(
-  Uri buildUri,
+  Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
   BuildMode buildMode,
@@ -125,9 +125,9 @@ Future<void> copyNativeCodeAssetsMacOS(
       for (final FlutterCodeAsset source in assetMapping.value)
         fileSystem.file(source.codeAsset.file),
     ];
-    final Uri targetUri = buildUri.resolveUri(target);
-    final String name = targetUri.pathSegments.last;
-    final Directory frameworkDir = fileSystem.file(targetUri).parent;
+    final Uri assetTargetUri = targetUri.resolveUri(target);
+    final String name = assetTargetUri.pathSegments.last;
+    final Directory frameworkDir = fileSystem.file(assetTargetUri).parent;
     if (await frameworkDir.exists()) {
       await frameworkDir.delete(recursive: true);
     }
@@ -205,7 +205,7 @@ Future<void> copyNativeCodeAssetsMacOS(
 ///
 /// Code signing is also done here.
 Future<void> copyNativeCodeAssetsMacOSFlutterTester(
-  Uri buildUri,
+  Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
   BuildMode buildMode,
@@ -223,8 +223,8 @@ Future<void> copyNativeCodeAssetsMacOSFlutterTester(
       for (final FlutterCodeAsset source in assetMapping.value)
         fileSystem.file(source.codeAsset.file),
     ];
-    final Uri targetUri = buildUri.resolveUri(target);
-    final File dylibFile = fileSystem.file(targetUri);
+    final Uri assetTargetUri = targetUri.resolveUri(target);
+    final File dylibFile = fileSystem.file(assetTargetUri);
     final Directory targetParent = dylibFile.parent;
     if (!await targetParent.exists()) {
       await targetParent.create(recursive: true);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -100,7 +100,7 @@ KernelAsset _targetLocationMacOS(
 ///
 /// Code signing is also done here, so that it doesn't have to be done in
 /// in macos_assemble.sh.
-Future<void> copyNativeCodeAssetsMacOS(
+Future<List<File>> copyNativeCodeAssetsMacOS(
   Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
@@ -108,7 +108,7 @@ Future<void> copyNativeCodeAssetsMacOS(
   FileSystem fileSystem,
 ) async {
   assert(assetTargetLocations.isNotEmpty);
-
+  final installedFiles = <File>[];
   final oldToNewInstallNames = <String, String>{};
   final dylibs = <(File, String, Directory)>[];
 
@@ -154,8 +154,12 @@ Future<void> copyNativeCodeAssetsMacOS(
     );
     await lipoDylibs(dylibFile, sources);
     if (buildMode != BuildMode.debug) {
-      await dsymutilDylib(dylibFile, '${frameworkDir.path}.dSYM');
+      final dsymPath = '${frameworkDir.path}.dSYM';
+      await dsymutilDylib(dylibFile, dsymPath);
       await stripDylib(dylibFile);
+      installedFiles.addAll(
+        fileSystem.directory(dsymPath).listSync(recursive: true).whereType<File>(),
+      );
     }
     final Link dylibLink = frameworkDir.childLink(name);
     await dylibLink.create(
@@ -174,6 +178,7 @@ Future<void> copyNativeCodeAssetsMacOS(
     dylibs.add((dylibFile, newInstallName, frameworkDir));
 
     await createInfoPlist(name, resourcesDir);
+    installedFiles.addAll(frameworkDir.listSync(recursive: true).whereType<File>());
   }
 
   for (final (File dylibFile, String newInstallName, Directory frameworkDir) in dylibs) {
@@ -185,6 +190,7 @@ Future<void> copyNativeCodeAssetsMacOS(
       await codesignDylib(codesignIdentity, buildMode, frameworkDir);
     }
   }
+  return installedFiles;
 }
 
 /// Copies native assets for flutter tester.
@@ -198,7 +204,7 @@ Future<void> copyNativeCodeAssetsMacOS(
 /// so that the referenced library can be found the dynamic linker.
 ///
 /// Code signing is also done here.
-Future<void> copyNativeCodeAssetsMacOSFlutterTester(
+Future<List<File>> copyNativeCodeAssetsMacOSFlutterTester(
   Uri targetUri,
   Map<KernelAssetPath, List<FlutterCodeAsset>> assetTargetLocations,
   String? codesignIdentity,
@@ -206,7 +212,7 @@ Future<void> copyNativeCodeAssetsMacOSFlutterTester(
   FileSystem fileSystem,
 ) async {
   assert(assetTargetLocations.isNotEmpty);
-
+  final installedFiles = <File>[];
   final oldToNewInstallNames = <String, String>{};
   final dylibs = <(File, String)>[];
 
@@ -224,6 +230,7 @@ Future<void> copyNativeCodeAssetsMacOSFlutterTester(
       await targetParent.create(recursive: true);
     }
     await lipoDylibs(dylibFile, sources);
+    installedFiles.add(dylibFile);
     final String newInstallName = dylibFile.path;
     final Set<String> oldInstallNames = await getInstallNamesDylib(dylibFile);
     for (final oldInstallName in oldInstallNames) {
@@ -236,4 +243,5 @@ Future<void> copyNativeCodeAssetsMacOSFlutterTester(
     await setInstallNamesDylib(dylibFile, newInstallName, oldToNewInstallNames);
     await codesignDylib(codesignIdentity, buildMode, dylibFile);
   }
+  return installedFiles;
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -22,23 +22,17 @@ Architecture getNativeMacOSArchitecture(DarwinArch darwinArch) {
   };
 }
 
+/// Groups native assets by their target framework path for macOS
+/// multi-architecture bundling.
 Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocationsMacOS(
   List<FlutterCodeAsset> nativeAssets,
   Uri? absolutePath,
 ) {
-  final alreadyTakenNames = <String>{};
-  final result = <KernelAssetPath, List<FlutterCodeAsset>>{};
-  final idToPath = <String, KernelAssetPath>{};
-  for (final asset in nativeAssets) {
-    // Use same target path for all assets with the same id.
-    final String assetId = asset.codeAsset.id;
-    final KernelAssetPath path =
-        idToPath[assetId] ?? _targetLocationMacOS(asset, absolutePath, alreadyTakenNames).path;
-    idToPath[assetId] = path;
-    result[path] ??= <FlutterCodeAsset>[];
-    result[path]!.add(asset);
-  }
-  return result;
+  return fatAssetTargetLocations(
+    nativeAssets,
+    (FlutterCodeAsset asset, Set<String> alreadyTakenNames) =>
+        _targetLocationMacOS(asset, absolutePath, alreadyTakenNames),
+  );
 }
 
 Map<FlutterCodeAsset, KernelAsset> assetTargetLocationsMacOS(

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -344,10 +344,8 @@ Map<Architecture?, List<String>> parseOtoolArchitectureSections(String output) {
 /// architecture is used.
 Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
   List<FlutterCodeAsset> nativeAssets,
-  KernelAsset Function(
-    FlutterCodeAsset asset,
-    Set<String> alreadyTakenNames,
-  ) targetLocationCallback,
+  KernelAsset Function(FlutterCodeAsset asset, Set<String> alreadyTakenNames)
+  targetLocationCallback,
 ) {
   final alreadyTakenNames = <String>{};
   final result = <KernelAssetPath, List<FlutterCodeAsset>>{};
@@ -356,14 +354,11 @@ Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
     // Use same target path for all assets with the same id.
     final String assetId = asset.codeAsset.id;
     final KernelAssetPath? existingPath = idToPath[assetId];
-    final KernelAssetPath currentPath =
-        targetLocationCallback(asset, alreadyTakenNames).path;
+    final KernelAssetPath currentPath = targetLocationCallback(asset, alreadyTakenNames).path;
 
     if (existingPath != null && existingPath != currentPath) {
-      final String existingName =
-          (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
-      final String currentName =
-          (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
+      final String existingName = (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
+      final String currentName = (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
       globals.logger.printWarning(
         'Code asset "$assetId" has different framework names for '
         'different architectures. Picking "$existingName" and '

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -5,12 +5,14 @@
 // Shared logic between iOS and macOS implementations of native assets.
 
 import 'package:code_assets/code_assets.dart';
+import 'package:hooks_runner/hooks_runner.dart';
 
 import '../../../base/common.dart';
 import '../../../base/file_system.dart';
 import '../../../base/process.dart';
 import '../../../build_info.dart';
 import '../../../globals.dart' as globals;
+import '../native_assets.dart';
 
 /// Create an `Info.plist` in [target] for a framework with a single dylib.
 ///
@@ -328,4 +330,52 @@ Map<Architecture?, List<String>> parseOtoolArchitectureSections(String output) {
   }
 
   return architectureSections;
+}
+
+/// Groups native assets by their target framework path for multi-architecture
+/// bundling.
+///
+/// On macOS and iOS, architecture-specific binaries for the same Asset ID are
+/// combined into a single "fat" (universal) binary using `lipo`. This function
+/// ensures that all assets with the same ID map to the same framework location.
+///
+/// If different architectures for the same Asset ID have different framework
+/// names, a warning is issued, and the name of the first encountered
+/// architecture is used.
+Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
+  List<FlutterCodeAsset> nativeAssets,
+  KernelAsset Function(
+    FlutterCodeAsset asset,
+    Set<String> alreadyTakenNames,
+  ) targetLocationCallback,
+) {
+  final alreadyTakenNames = <String>{};
+  final result = <KernelAssetPath, List<FlutterCodeAsset>>{};
+  final idToPath = <String, KernelAssetPath>{};
+  for (final asset in nativeAssets) {
+    // Use same target path for all assets with the same id.
+    final String assetId = asset.codeAsset.id;
+    final KernelAssetPath? existingPath = idToPath[assetId];
+    final KernelAssetPath currentPath =
+        targetLocationCallback(asset, alreadyTakenNames).path;
+
+    if (existingPath != null && existingPath != currentPath) {
+      final String existingName =
+          (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
+      final String currentName =
+          (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
+      globals.logger.printWarning(
+        'Code asset "$assetId" has different framework names for '
+        'different architectures. Picking "$existingName" and '
+        'ignoring "$currentName". Ensuring consistent filenames in '
+        '"build.dart" is recommended.',
+      );
+    }
+
+    final KernelAssetPath path = existingPath ?? currentPath;
+    idToPath[assetId] = path;
+    result[path] ??= <FlutterCodeAsset>[];
+    result[path]!.add(asset);
+  }
+  return result;
 }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -360,15 +360,14 @@ Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
     if (existingPath != null && existingPath != currentPath) {
       final String existingName = (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
       final String currentName = (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
-      final message =
-          'Code asset "$assetId" has different framework names for '
-          'different architectures. Picking "$existingName" and '
-          'ignoring "$currentName". This is likely an issue in the '
-          'package providing the asset. Please report this to the '
-          'package maintainers and ensure the "build.dart" hook '
-          'produces consistent filenames.';
-      globals.logger.printWarning(message);
-      printXcodeWarning(message);
+      printXcodeWarning(
+        'Code asset "$assetId" has different framework names for '
+        'different architectures. Picking "$existingName" and '
+        'ignoring "$currentName". This is likely an issue in the '
+        'package providing the asset. Please report this to the '
+        'package maintainers and ensure the "build.dart" hook '
+        'produces consistent filenames.',
+      );
     }
 
     final KernelAssetPath path = existingPath ?? currentPath;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -360,14 +360,15 @@ Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
     if (existingPath != null && existingPath != currentPath) {
       final String existingName = (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
       final String currentName = (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
-      printXcodeWarning(
-        'Code asset "$assetId" has different framework names for '
-        'different architectures. Picking "$existingName" and '
-        'ignoring "$currentName". This is likely an issue in the '
-        'package providing the asset. Please report this to the '
-        'package maintainers and ensure the "build.dart" hook '
-        'produces consistent filenames.',
-      );
+      final message =
+          'Code asset "$assetId" has different framework names for '
+          'different architectures. Picking "$existingName" and '
+          'ignoring "$currentName". This is likely an issue in the '
+          'package providing the asset. Please report this to the '
+          'package maintainers and ensure the "build.dart" hook '
+          'produces consistent filenames.';
+      globals.logger.printWarning(message);
+      printXcodeWarning(message);
     }
 
     final KernelAssetPath path = existingPath ?? currentPath;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -11,6 +11,7 @@ import '../../../base/common.dart';
 import '../../../base/file_system.dart';
 import '../../../base/process.dart';
 import '../../../build_info.dart';
+import '../../../build_system/targets/darwin.dart';
 import '../../../globals.dart' as globals;
 import '../native_assets.dart';
 
@@ -359,11 +360,13 @@ Map<KernelAssetPath, List<FlutterCodeAsset>> fatAssetTargetLocations(
     if (existingPath != null && existingPath != currentPath) {
       final String existingName = (existingPath as KernelAssetAbsolutePath).uri.pathSegments.first;
       final String currentName = (currentPath as KernelAssetAbsolutePath).uri.pathSegments.first;
-      globals.logger.printWarning(
+      printXcodeWarning(
         'Code asset "$assetId" has different framework names for '
         'different architectures. Picking "$existingName" and '
-        'ignoring "$currentName". Ensuring consistent filenames in '
-        '"build.dart" is recommended.',
+        'ignoring "$currentName". This is likely an issue in the '
+        'package providing the asset. Please report this to the '
+        'package maintainers and ensure the "build.dart" hook '
+        'produces consistent filenames.',
       );
     }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -441,6 +441,9 @@ Future<void> _copyNativeCodeAssetsForOS(
   if (!targetDir.existsSync()) {
     targetDir.createSync(recursive: true);
   }
+  await for (final FileSystemEntity entity in targetDir.list()) {
+    await entity.delete(recursive: true);
+  }
 
   if (assetTargetLocations.isEmpty) {
     return;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -437,7 +437,7 @@ Future<void> _copyNativeCodeAssetsForOS(
         codeAsset: assetTargetLocations[codeAsset]!,
   };
 
-  final Directory targetDir = fileSystem.directory(targetUri.toFilePath());
+  final Directory targetDir = fileSystem.directory(targetUri);
   if (!targetDir.existsSync()) {
     targetDir.createSync(recursive: true);
   }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -90,7 +90,7 @@ Future<DartHooksResult> runFlutterSpecificHooks({
   );
 }
 
-Future<void> installCodeAssets({
+Future<List<File>> installCodeAssets({
   required DartHooksResult dartHookResult,
   required Map<String, String> environmentDefines,
   required TargetPlatform targetPlatform,
@@ -110,7 +110,7 @@ Future<void> installCodeAssets({
     flutterTester,
     targetUri,
   );
-  await _copyNativeCodeAssetsForOS(
+  final List<File> installedFiles = await _copyNativeCodeAssetsForOS(
     targetOS,
     targetUri,
     buildMode,
@@ -124,6 +124,7 @@ Future<void> installCodeAssets({
     nativeAssetsFileUri,
     fileSystem,
   );
+  return <File>[fileSystem.file(nativeAssetsFileUri), ...installedFiles];
 }
 
 /// Programmatic API to be used by Dart launchers to invoke native builds.
@@ -418,7 +419,7 @@ Map<FlutterCodeAsset, KernelAsset> assetTargetLocationsForOS(
   }
 }
 
-Future<void> _copyNativeCodeAssetsForOS(
+Future<List<File>> _copyNativeCodeAssetsForOS(
   OS targetOS,
   Uri targetUri,
   BuildMode buildMode,
@@ -446,16 +447,17 @@ Future<void> _copyNativeCodeAssetsForOS(
   }
 
   if (assetTargetLocations.isEmpty) {
-    return;
+    return const <File>[];
   }
 
   globals.logger.printTrace('Copying native assets to ${targetUri.toFilePath()}.');
   final List<FlutterCodeAsset> codeAssets = assetTargetLocations.keys.toList();
+  final List<File> installedFiles;
   switch (targetOS) {
     case OS.windows:
     case OS.linux:
       assert(codesignIdentity == null);
-      await _copyNativeCodeAssetsToBundleOnWindowsLinux(
+      installedFiles = await _copyNativeCodeAssetsToBundleOnWindowsLinux(
         targetUri,
         assetTargetLocations,
         buildMode,
@@ -463,7 +465,7 @@ Future<void> _copyNativeCodeAssetsForOS(
       );
     case OS.macOS:
       if (flutterTester) {
-        await copyNativeCodeAssetsMacOSFlutterTester(
+        installedFiles = await copyNativeCodeAssetsMacOSFlutterTester(
           targetUri,
           fatAssetTargetLocationsMacOS(codeAssets, targetUri),
           codesignIdentity,
@@ -471,7 +473,7 @@ Future<void> _copyNativeCodeAssetsForOS(
           fileSystem,
         );
       } else {
-        await copyNativeCodeAssetsMacOS(
+        installedFiles = await copyNativeCodeAssetsMacOS(
           targetUri,
           fatAssetTargetLocationsMacOS(codeAssets, null),
           codesignIdentity,
@@ -480,7 +482,7 @@ Future<void> _copyNativeCodeAssetsForOS(
         );
       }
     case OS.iOS:
-      await copyNativeCodeAssetsIOS(
+      installedFiles = await copyNativeCodeAssetsIOS(
         targetUri,
         fatAssetTargetLocationsIOS(codeAssets),
         codesignIdentity,
@@ -489,11 +491,16 @@ Future<void> _copyNativeCodeAssetsForOS(
       );
     case OS.android:
       assert(codesignIdentity == null);
-      await copyNativeCodeAssetsAndroid(targetUri, assetTargetLocations, fileSystem);
+      installedFiles = await copyNativeCodeAssetsAndroid(
+        targetUri,
+        assetTargetLocations,
+        fileSystem,
+      );
     default:
       throw StateError('This should be unreachable.');
   }
   globals.logger.printTrace('Copying native assets done.');
+  return installedFiles;
 }
 
 /// Invokes the build of all transitive Dart packages.
@@ -617,7 +624,7 @@ Future<LinkResult> _link(
   return linkResult;
 }
 
-Future<void> _copyNativeCodeAssetsToBundleOnWindowsLinux(
+Future<List<File>> _copyNativeCodeAssetsToBundleOnWindowsLinux(
   Uri targetUri,
   Map<FlutterCodeAsset, KernelAsset> assetTargetLocations,
   BuildMode buildMode,
@@ -625,13 +632,16 @@ Future<void> _copyNativeCodeAssetsToBundleOnWindowsLinux(
 ) async {
   assert(assetTargetLocations.isNotEmpty);
 
+  final installedFiles = <File>[];
   for (final MapEntry<FlutterCodeAsset, KernelAsset> assetMapping in assetTargetLocations.entries) {
     final Uri source = assetMapping.key.codeAsset.file!;
     final Uri target = (assetMapping.value.path as KernelAssetAbsolutePath).uri;
     final Uri assetTargetUri = targetUri.resolveUri(target);
     final String targetFullPath = assetTargetUri.toFilePath();
-    await fileSystem.file(source).copy(targetFullPath);
+    final File installedFile = await fileSystem.file(source).copy(targetFullPath);
+    installedFiles.add(installedFile);
   }
+  return installedFiles;
 }
 
 Never _throwNativeAssetsBuildFailed() {

--- a/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/test/native_assets.dart
@@ -22,8 +22,10 @@ class TestCompilerNativeAssetsBuilderImpl implements TestCompilerNativeAssetsBui
   Future<Uri?> build(BuildInfo buildInfo) => testCompilerBuildNativeAssets(buildInfo);
 
   @override
-  String windowsBuildDirectory(FlutterProject project) =>
-      nativeAssetsBuildUri(project.directory.uri, OS.windows.name).toFilePath();
+  String windowsBuildDirectory(FlutterProject project) {
+    final String buildDir = getBuildDirectory();
+    return project.directory.uri.resolve('$buildDir/native_assets/windows/').toFilePath();
+  }
 }
 
 Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
@@ -61,7 +63,9 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
   // `build/native_assets/<os>/native_assets.json` file which uses absolute
   // paths to the shared libraries.
   final OS targetOS = getNativeOSFromTargetPlatform(TargetPlatform.tester);
-  final Uri buildUri = nativeAssetsBuildUri(projectUri, targetOS.name);
+  final String buildDir = getBuildDirectory();
+  final String osName = targetOS.name;
+  final Uri buildUri = projectUri.resolve('$buildDir/native_assets/$osName/');
   final Uri nativeAssetsFileUri = buildUri.resolve('native_assets.json');
 
   final environmentDefines = <String, String>{kBuildMode: buildInfo.mode.cliName};
@@ -85,6 +89,7 @@ Future<Uri?> testCompilerBuildNativeAssets(BuildInfo buildInfo) async {
     projectUri: projectUri,
     fileSystem: globals.fs,
     nativeAssetsFileUri: nativeAssetsFileUri,
+    targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/$osName/'),
   );
   assert(await globals.fs.file(nativeAssetsFileUri).exists());
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -731,4 +731,30 @@ void main() {
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
   });
+
+  group('findFrameworkNames', () {
+    late MemoryFileSystem fileSystem;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+    });
+
+    testWithoutContext('finds frameworks in native_assets', () {
+      final Directory output = fileSystem.directory('output')..createSync();
+      final Directory nativeAssets = output.childDirectory('native_assets')..createSync();
+      nativeAssets.childDirectory('foo.framework').createSync();
+      nativeAssets.childDirectory('bar.framework').createSync();
+      nativeAssets.childDirectory('baz.framework.dSYM').createSync(); // Should be ignored
+      nativeAssets.childFile('something_else').createSync(); // Should be ignored
+
+      final Iterable<String> names = BuildFrameworkCommand.findFrameworkNames(output);
+      expect(names, unorderedEquals(<String>['foo.framework', 'bar.framework']));
+    });
+
+    testWithoutContext('returns empty if native_assets does not exist', () {
+      final Directory output = fileSystem.directory('output')..createSync();
+      final Iterable<String> names = BuildFrameworkCommand.findFrameworkNames(output);
+      expect(names, isEmpty);
+    });
+  });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -747,13 +747,13 @@ void main() {
       nativeAssets.childDirectory('baz.framework.dSYM').createSync(); // Should be ignored
       nativeAssets.childFile('something_else').createSync(); // Should be ignored
 
-      final Iterable<String> names = BuildFrameworkCommand.findFrameworkNames(output);
+      final Iterable<String> names = BuildFrameworkCommand.findCodeAssetFrameworkNames(output);
       expect(names, unorderedEquals(<String>['foo.framework', 'bar.framework']));
     });
 
     testWithoutContext('returns empty if native_assets does not exist', () {
       final Directory output = fileSystem.directory('output')..createSync();
-      final Iterable<String> names = BuildFrameworkCommand.findFrameworkNames(output);
+      final Iterable<String> names = BuildFrameworkCommand.findCodeAssetFrameworkNames(output);
       expect(names, isEmpty);
     });
   });

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -18,6 +20,7 @@ import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/test_build_system.dart';
+import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   late MemoryFileSystem memoryFileSystem;
@@ -347,6 +350,201 @@ void main() {
         });
       });
     });
+  });
+
+  group('native assets', () {
+    late FakeFlutterVersion fakeFlutterVersion;
+    late Cache cache;
+
+    setUp(() {
+      fakeFlutterVersion = FakeFlutterVersion(
+        frameworkVersion: '1.13.11',
+        gitTagVersion: const GitTagVersion(
+          x: 1,
+          y: 13,
+          z: 11,
+          commits: 0,
+          hash: 'abcdef',
+          gitTag: '1.13.11',
+        ),
+      );
+      final Directory rootOverride = memoryFileSystem.directory('cache');
+      cache = Cache.test(
+        rootOverride: rootOverride,
+        platform: fakePlatform,
+        fileSystem: memoryFileSystem,
+        processManager: FakeProcessManager.any(),
+      );
+    });
+
+    testUsingContext(
+      'throws if simulator contains extra assets',
+      () async {
+        final Directory projectDir = memoryFileSystem.directory('project')..createSync();
+        projectDir.childDirectory('ios').createSync();
+        projectDir.childDirectory('ios').childDirectory('Pods').createSync();
+        projectDir.childDirectory('lib').childFile('main.dart').createSync(recursive: true);
+        projectDir.childDirectory('.dart_tool').childFile('package_config.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '{"configVersion": 2, "packages": [{"name": "project", "rootUri": "../", "packageUri": "lib/", "languageVersion": "3.0"}]}',
+          );
+        projectDir
+            .childDirectory('.dart_tool')
+            .childFile('package_graph.json')
+            .writeAsStringSync(
+              '{"configVersion": 1, "packages": [{"name": "project", "rootUri": "..", "packageUri": "lib/", "dependencies": []}]}',
+            );
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: project');
+        projectDir.childFile('.metadata').createSync();
+        memoryFileSystem.currentDirectory = projectDir;
+
+        final command = BuildIOSFrameworkCommand(
+          logger: BufferLogger.test(),
+          buildSystem: TestBuildSystem.all(BuildResult(success: true), (
+            Target target,
+            Environment environment,
+          ) {
+            final Directory output = environment.outputDir;
+            output.childDirectory('App.framework').childFile('App').createSync(recursive: true);
+            final File manifest = output
+                .childDirectory('App.framework')
+                .childDirectory('flutter_assets')
+                .childFile('NativeAssetsManifest.json');
+            manifest.createSync(recursive: true);
+            if (output.path.contains('iphoneos')) {
+              manifest.writeAsStringSync('{"format-version": [1, 0, 0], "native-assets": {}}');
+            } else {
+              manifest.writeAsStringSync(
+                '{"format-version": [1, 0, 0], "native-assets": {"ios_x64": {"package:project/asset1": ["absolute", "Foo.framework/Foo"]}}}',
+              );
+            }
+          }),
+          platform: fakePlatform,
+          flutterVersion: fakeFlutterVersion,
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        // Mock engine artifacts. _TestArtifacts uses a string like this for getArtifactPath.
+        memoryFileSystem
+            .directory('Artifact.flutterXcframework.TargetPlatform.ios.debug')
+            .createSync(recursive: true);
+
+        final Directory buildDir =
+            projectDir.childDirectory('.dart_tool').childDirectory('flutter_build')
+              ..createSync(recursive: true);
+        buildDir
+            .childFile('dart_build_result.json')
+            .writeAsStringSync('{"codeAssets": [], "dataAssets": [], "dependencies": []}');
+
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        await expectLater(
+          () => runner.run(<String>[
+            'ios-framework',
+            '--no-pub',
+            '--no-plugins',
+            '--no-profile',
+            '--no-release',
+          ]),
+          throwsToolExit(
+            message:
+                'The simulator build contains a code asset "package:project/asset1" that is not present in the physical device build.',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Artifacts: () => Artifacts.test(fileSystem: memoryFileSystem),
+      },
+    );
+
+    testUsingContext(
+      'throws if framework names are inconsistent',
+      () async {
+        final Directory projectDir = memoryFileSystem.directory('project')..createSync();
+        projectDir.childDirectory('ios').createSync();
+        projectDir.childDirectory('ios').childDirectory('Pods').createSync();
+        projectDir.childDirectory('lib').childFile('main.dart').createSync(recursive: true);
+        projectDir.childDirectory('.dart_tool').childFile('package_config.json')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '{"configVersion": 2, "packages": [{"name": "project", "rootUri": "../", "packageUri": "lib/", "languageVersion": "3.0"}]}',
+          );
+        projectDir
+            .childDirectory('.dart_tool')
+            .childFile('package_graph.json')
+            .writeAsStringSync(
+              '{"configVersion": 1, "packages": [{"name": "project", "rootUri": "..", "packageUri": "lib/", "dependencies": []}]}',
+            );
+        projectDir.childFile('pubspec.yaml').writeAsStringSync('name: project');
+        projectDir.childFile('.metadata').createSync();
+        memoryFileSystem.currentDirectory = projectDir;
+
+        final command = BuildIOSFrameworkCommand(
+          logger: BufferLogger.test(),
+          buildSystem: TestBuildSystem.all(BuildResult(success: true), (
+            Target target,
+            Environment environment,
+          ) {
+            final Directory output = environment.outputDir;
+            output.childDirectory('App.framework').childFile('App').createSync(recursive: true);
+            final File manifest = output
+                .childDirectory('App.framework')
+                .childDirectory('flutter_assets')
+                .childFile('NativeAssetsManifest.json');
+            manifest.createSync(recursive: true);
+            if (output.path.contains('iphoneos')) {
+              manifest.writeAsStringSync(
+                '{"format-version": [1, 0, 0], "native-assets": {"ios_arm64": {"package:project/asset1": ["absolute", "Foo.framework/Foo"]}}}',
+              );
+            } else {
+              manifest.writeAsStringSync(
+                '{"format-version": [1, 0, 0], "native-assets": {"ios_x64": {"package:project/asset1": ["absolute", "Bar.framework/Bar"]}}}',
+              );
+            }
+          }),
+          platform: fakePlatform,
+          flutterVersion: fakeFlutterVersion,
+          cache: cache,
+          verboseHelp: false,
+        );
+
+        // Mock engine artifacts
+        memoryFileSystem
+            .directory('Artifact.flutterXcframework.TargetPlatform.ios.debug')
+            .createSync(recursive: true);
+
+        final Directory buildDir =
+            projectDir.childDirectory('.dart_tool').childDirectory('flutter_build')
+              ..createSync(recursive: true);
+        buildDir
+            .childFile('dart_build_result.json')
+            .writeAsStringSync('{"codeAssets": [], "dataAssets": [], "dependencies": []}');
+
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        await expectLater(
+          () => runner.run(<String>[
+            'ios-framework',
+            '--no-pub',
+            '--no-plugins',
+            '--no-profile',
+            '--no-release',
+          ]),
+          throwsToolExit(
+            message:
+                'Consistent code asset framework names are required for XCFramework creation.\n'
+                'The asset "package:project/asset1" has different framework paths across platforms:',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => memoryFileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Artifacts: () => Artifacts.test(fileSystem: memoryFileSystem),
+      },
+    );
   });
 
   group('build macos-framework', () {
@@ -732,7 +930,7 @@ void main() {
     });
   });
 
-  group('findFrameworkNames', () {
+  group('findCodeAssetFrameworkNames', () {
     late MemoryFileSystem fileSystem;
 
     setUp(() {
@@ -755,6 +953,35 @@ void main() {
       final Directory output = fileSystem.directory('output')..createSync();
       final Iterable<String> names = BuildFrameworkCommand.findCodeAssetFrameworkNames(output);
       expect(names, isEmpty);
+    });
+
+    testWithoutContext('parseNativeAssetsManifest', () {
+      final Directory output = fileSystem.directory('output')..createSync();
+      final File manifest = output
+          .childDirectory('App.framework')
+          .childDirectory('flutter_assets')
+          .childFile('NativeAssetsManifest.json');
+      manifest.createSync(recursive: true);
+      manifest.writeAsStringSync('''
+{
+  "format-version": [1, 0, 0],
+  "native-assets": {
+    "ios_arm64": {
+      "package:project/asset1": ["absolute", "Foo.framework/Foo"],
+      "package:project/asset2": ["absolute", "Bar.framework/Bar"]
+    },
+    "ios_x64": {
+      "package:project/asset1": ["absolute", "Foo.framework/Foo"]
+    }
+  }
+}
+''');
+
+      final Map<String, String> assets = BuildFrameworkCommand.parseNativeAssetsManifest(output);
+      expect(assets, <String, String>{
+        'package:project/asset1': 'Foo.framework/Foo',
+        'package:project/asset2': 'Bar.framework/Bar',
+      });
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/android/native_assets_test.dart
@@ -101,6 +101,7 @@ void main() {
           projectUri: projectUri,
           fileSystem: fileSystem,
           nativeAssetsFileUri: nonFlutterTesterAssetUri,
+          targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/android/'),
         );
         expect(
           (globals.logger as BufferLogger).traceText,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -143,32 +143,34 @@ void main() {
         // Create the framework dylib.
         const FakeCommand(
           command: <Pattern>[
+            'xcrun',
             'lipo',
             '-create',
             '-output',
-            '/build/native_assets/ios/foo.framework/foo',
+            '/native_assets/foo.framework/foo',
             'foo.framework/foo',
           ],
         ),
         const FakeCommand(
           command: <Pattern>[
+            'xcrun',
             'dsymutil',
-            '/build/native_assets/ios/foo.framework/foo',
+            '/native_assets/foo.framework/foo',
             '-o',
-            '/build/native_assets/ios/foo.framework.dSYM',
+            '/native_assets/foo.framework.dSYM',
           ],
         ),
         const FakeCommand(
-          command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/foo.framework/foo'],
+          command: <Pattern>['xcrun', 'strip', '-x', '-S', '/native_assets/foo.framework/foo'],
         ),
         // Lookup the original install names of the dylib.
         // There can be different install names for different architectures.
         FakeCommand(
-          command: const <Pattern>['otool', '-D', '/build/native_assets/ios/foo.framework/foo'],
+          command: const <Pattern>['xcrun', 'otool', '-D', '/native_assets/foo.framework/foo'],
           stdout: <String>[
-            '/build/native_assets/ios/foo.framework/foo (architecture x86_64):',
+            '/native_assets/foo.framework/foo (architecture x86_64):',
             '@rpath/libfoo.dylib',
-            '/build/native_assets/ios/foo.framework/foo (architecture arm64):',
+            '/native_assets/foo.framework/foo (architecture arm64):',
             '@rpath/libfoo.dylib',
           ].join('\n'),
         ),
@@ -178,24 +180,26 @@ void main() {
         // is ignored if the dylib does not depend on the target dylib.
         const FakeCommand(
           command: <Pattern>[
+            'xcrun',
             'install_name_tool',
             '-id',
             '@rpath/foo.framework/foo',
             '-change',
             '@rpath/libfoo.dylib',
             '@rpath/foo.framework/foo',
-            '/build/native_assets/ios/foo.framework/foo',
+            '/native_assets/foo.framework/foo',
           ],
         ),
         // Only after all changes to the dylib have been made do we sign it.
         const FakeCommand(
           command: <Pattern>[
+            'xcrun',
             'codesign',
             '--force',
             '--sign',
             '-',
             '--timestamp=none',
-            '/build/native_assets/ios/foo.framework',
+            '/native_assets/foo.framework',
           ],
         ),
       ]),

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -138,27 +138,36 @@ void main() {
   testUsingContext(
     'NativeAssets with an asset',
     overrides: <Type, Generator>{
-      FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         // Create the framework dylib.
-        const FakeCommand(
-          command: <Pattern>[
+        FakeCommand(
+          command: const <Pattern>[
             'xcrun',
             'lipo',
             '-create',
             '-output',
             '/native_assets/foo.framework/foo',
-            'foo.framework/foo',
+            'libfoo.dylib',
           ],
+          onRun: (_) {
+            iosEnvironment.fileSystem
+                .file('/native_assets/foo.framework/foo')
+                .createSync(recursive: true);
+          },
         ),
-        const FakeCommand(
-          command: <Pattern>[
+        FakeCommand(
+          command: const <Pattern>[
             'xcrun',
             'dsymutil',
             '/native_assets/foo.framework/foo',
             '-o',
             '/native_assets/foo.framework.dSYM',
           ],
+          onRun: (_) {
+            iosEnvironment.fileSystem
+                .directory('/native_assets/foo.framework.dSYM')
+                .createSync(recursive: true);
+          },
         ),
         const FakeCommand(
           command: <Pattern>['xcrun', 'strip', '-x', '-S', '/native_assets/foo.framework/foo'],
@@ -212,49 +221,80 @@ void main() {
           package: 'foo',
           name: 'foo.dart',
           linkMode: DynamicLoadingBundled(),
-          file: Uri.file('foo.framework/foo'),
+          file: Uri.file('libfoo.dylib'),
         ),
       ];
+      final String libFooPath = iosEnvironment.fileSystem.file('libfoo.dylib').path;
       final FlutterNativeAssetsBuildRunner buildRunner = FakeFlutterNativeAssetsBuildRunner(
         packagesWithNativeAssetsResult: <String>['foo'],
         buildResult: FakeFlutterNativeAssetsBuilderResult.fromAssets(
           dependencies: <Uri>[Uri.file('src/foo.c')],
         ),
+        onBuild: (input) {
+          iosEnvironment.fileSystem.file(libFooPath).createSync(recursive: true);
+          return FakeFlutterNativeAssetsBuilderResult.fromAssets(
+            dependencies: <Uri>[Uri.file('src/foo.c')],
+          );
+        },
         linkResult: FakeFlutterNativeAssetsBuilderResult.fromAssets(codeAssets: codeAssets),
       );
-      await DartBuildForNative(buildRunner: buildRunner).build(iosEnvironment);
-      await const InstallCodeAssets().build(iosEnvironment);
 
-      // We don't care about the specific format, but
-      //  * dart build output should depend on C source
-      //  * installation output should depend on shared library from dart build
-
-      final File dartHookResult = iosEnvironment.buildDir.childFile(
+      final File dartHookResultJsonFile = iosEnvironment.buildDir.childFile(
         DartBuild.dartHookResultFilename,
       );
-      final File buildDepsFile = iosEnvironment.buildDir.childFile(DartBuild.depFilename);
-      expect(buildDepsFile, exists);
+      final dartBuildForNative = DartBuildForNative(buildRunner: buildRunner);
+      await dartBuildForNative.build(iosEnvironment);
+      const installCodeAssets = InstallCodeAssets();
+      await installCodeAssets.build(iosEnvironment);
+
+      // Verify DartBuildForNative dependencies.
+      final List<String> buildInputs = _resolvedInputs(dartBuildForNative, iosEnvironment);
+      final List<String> buildOutputs = _resolvedOutputs(dartBuildForNative, iosEnvironment);
+      // Re-run if the C source changes.
       expect(
-        buildDepsFile.readAsStringSync(),
-        stringContainsInOrder(<String>[dartHookResult.path, ':', 'src/foo.c']),
+        buildInputs,
+        contains(iosEnvironment.fileSystem.file('src/foo.c').path),
+      );
+      // Re-created if the result JSON is deleted.
+      expect(
+        buildOutputs,
+        contains(dartHookResultJsonFile.path),
+      );
+      // Re-created if the dylib is deleted.
+      expect(
+        buildOutputs,
+        contains(libFooPath),
       );
 
       final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(
         InstallCodeAssets.nativeAssetsFilename,
       );
-      final File installDepsFile = iosEnvironment.buildDir.childFile(InstallCodeAssets.depFilename);
-      expect(installDepsFile, exists);
+
+      // Verify InstallCodeAssets dependencies.
+      final List<String> installInputs = _resolvedInputs(installCodeAssets, iosEnvironment);
+      final List<String> installOutputs = _resolvedOutputs(installCodeAssets, iosEnvironment);
+      // Re-run if the dylib changes.
       expect(
-        installDepsFile.readAsStringSync(),
-        stringContainsInOrder(<String>[nativeAssetsYaml.path, ':', 'foo.framework/foo']),
+        installInputs,
+        contains(libFooPath),
       );
+      // Re-created if the final manifest is deleted.
+      expect(
+        installOutputs,
+        contains(nativeAssetsYaml.path),
+      );
+      // Re-created if deleted by Xcode "Product > Clean Build Folder...".
+      expect(
+        installOutputs,
+        contains(
+          iosEnvironment.outputDir
+              .childDirectory('native_assets')
+              .childFile('foo.framework/foo')
+              .path,
+        ),
+      );
+
       expect(nativeAssetsYaml, exists);
-      // We don't care about the specific format, but it should contain the
-      // asset id and the path to the dylib.
-      expect(
-        nativeAssetsYaml.readAsStringSync(),
-        stringContainsInOrder(<String>['package:foo/foo.dart', 'foo.framework']),
-      );
     },
   );
 
@@ -290,4 +330,12 @@ void main() {
       },
     );
   }
+}
+
+List<String> _resolvedOutputs(Target target, Environment environment) {
+  return target.resolveOutputs(environment).sources.map((File f) => f.path).toList();
+}
+
+List<String> _resolvedInputs(Target target, Environment environment) {
+  return target.resolveInputs(environment).sources.map((File f) => f.path).toList();
 }

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -251,20 +251,11 @@ void main() {
       final List<String> buildInputs = _resolvedInputs(dartBuildForNative, iosEnvironment);
       final List<String> buildOutputs = _resolvedOutputs(dartBuildForNative, iosEnvironment);
       // Re-run if the C source changes.
-      expect(
-        buildInputs,
-        contains(iosEnvironment.fileSystem.file('src/foo.c').path),
-      );
+      expect(buildInputs, contains(iosEnvironment.fileSystem.file('src/foo.c').path));
       // Re-created if the result JSON is deleted.
-      expect(
-        buildOutputs,
-        contains(dartHookResultJsonFile.path),
-      );
+      expect(buildOutputs, contains(dartHookResultJsonFile.path));
       // Re-created if the dylib is deleted.
-      expect(
-        buildOutputs,
-        contains(libFooPath),
-      );
+      expect(buildOutputs, contains(libFooPath));
 
       final File nativeAssetsYaml = iosEnvironment.buildDir.childFile(
         InstallCodeAssets.nativeAssetsFilename,
@@ -274,15 +265,9 @@ void main() {
       final List<String> installInputs = _resolvedInputs(installCodeAssets, iosEnvironment);
       final List<String> installOutputs = _resolvedOutputs(installCodeAssets, iosEnvironment);
       // Re-run if the dylib changes.
-      expect(
-        installInputs,
-        contains(libFooPath),
-      );
+      expect(installInputs, contains(libFooPath));
       // Re-created if the final manifest is deleted.
-      expect(
-        installOutputs,
-        contains(nativeAssetsYaml.path),
-      );
+      expect(installOutputs, contains(nativeAssetsYaml.path));
       // Re-created if deleted by Xcode "Product > Clean Build Folder...".
       expect(
         installOutputs,

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -54,6 +54,7 @@ void main() {
         ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'lipo',
               '-create',
               '-output',
@@ -65,6 +66,7 @@ void main() {
           if (buildMode == BuildMode.release) ...<FakeCommand>[
             const FakeCommand(
               command: <Pattern>[
+                'xcrun',
                 'dsymutil',
                 '/build/native_assets/ios/bar.framework/bar',
                 '-o',
@@ -72,11 +74,22 @@ void main() {
               ],
             ),
             const FakeCommand(
-              command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/bar.framework/bar'],
+              command: <Pattern>[
+                'xcrun',
+                'strip',
+                '-x',
+                '-S',
+                '/build/native_assets/ios/bar.framework/bar',
+              ],
             ),
           ],
           FakeCommand(
-            command: const <Pattern>['otool', '-D', '/build/native_assets/ios/bar.framework/bar'],
+            command: const <Pattern>[
+              'xcrun',
+              'otool',
+              '-D',
+              '/build/native_assets/ios/bar.framework/bar',
+            ],
             stdout: <String>[
               '/build/native_assets/ios/bar.framework/bar (architecture x86_64):',
               '@rpath/libbar.dylib',
@@ -86,6 +99,7 @@ void main() {
           ),
           const FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'lipo',
               '-create',
               '-output',
@@ -97,6 +111,7 @@ void main() {
           if (buildMode == BuildMode.release) ...<FakeCommand>[
             const FakeCommand(
               command: <Pattern>[
+                'xcrun',
                 'dsymutil',
                 '/build/native_assets/ios/buz.framework/buz',
                 '-o',
@@ -104,11 +119,22 @@ void main() {
               ],
             ),
             const FakeCommand(
-              command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/buz.framework/buz'],
+              command: <Pattern>[
+                'xcrun',
+                'strip',
+                '-x',
+                '-S',
+                '/build/native_assets/ios/buz.framework/buz',
+              ],
             ),
           ],
           FakeCommand(
-            command: const <Pattern>['otool', '-D', '/build/native_assets/ios/buz.framework/buz'],
+            command: const <Pattern>[
+              'xcrun',
+              'otool',
+              '-D',
+              '/build/native_assets/ios/buz.framework/buz',
+            ],
             stdout: <String>[
               '/build/native_assets/ios/buz.framework/buz (architecture x86_64):',
               '@rpath/libbuz.dylib',
@@ -118,6 +144,7 @@ void main() {
           ),
           const FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'install_name_tool',
               '-id',
               '@rpath/bar.framework/bar',
@@ -132,6 +159,7 @@ void main() {
           ),
           FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'codesign',
               '--force',
               '--sign',
@@ -142,6 +170,7 @@ void main() {
           ),
           const FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'install_name_tool',
               '-id',
               '@rpath/buz.framework/buz',
@@ -156,6 +185,7 @@ void main() {
           ),
           FakeCommand(
             command: <Pattern>[
+              'xcrun',
               'codesign',
               '--force',
               '--sign',
@@ -227,6 +257,7 @@ void main() {
           projectUri: projectUri,
           fileSystem: fileSystem,
           nativeAssetsFileUri: nonFlutterTesterAssetUri,
+          targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/ios/'),
         );
         expect(
           (globals.logger as BufferLogger).traceText,

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -11,12 +11,14 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart' hide Target;
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
+import 'package:flutter_tools/src/isolated/native_assets/ios/native_assets.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:hooks/hooks.dart';
+import 'package:hooks_runner/hooks_runner.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
@@ -273,4 +275,46 @@ void main() {
       },
     );
   }
+
+  testUsingContext(
+    'pick-first warning',
+    () async {
+      final assets = <FlutterCodeAsset>[
+        FlutterCodeAsset(
+          codeAsset: CodeAsset(
+            package: 'bar',
+            name: 'bar.dart',
+            linkMode: DynamicLoadingBundled(),
+            file: Uri.file('arm64/libbar.dylib'),
+          ),
+          target: Target.fromArchitectureAndOS(Architecture.arm64, OS.iOS),
+        ),
+        FlutterCodeAsset(
+          codeAsset: CodeAsset(
+            package: 'bar',
+            name: 'bar.dart',
+            linkMode: DynamicLoadingBundled(),
+            file: Uri.file('x64/libbar_different.dylib'),
+          ),
+          target: Target.fromArchitectureAndOS(Architecture.x64, OS.iOS),
+        ),
+      ];
+
+      fatAssetTargetLocationsIOS(assets);
+
+      expect(
+        logger.warningText,
+        contains(
+          'Code asset "package:bar/bar.dart" has different framework names for '
+          'different architectures. Picking "bar.framework" and '
+          'ignoring "bar_different.framework".',
+        ),
+      );
+    },
+    overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Logger: () => logger,
+    },
+  );
 }

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -77,7 +77,9 @@ void main() {
                 '/build/native_assets/ios/bar.framework.dSYM',
               ],
               onRun: (_) {
-                fileSystem.directory('/build/native_assets/ios/bar.framework.dSYM').createSync(recursive: true);
+                fileSystem
+                    .directory('/build/native_assets/ios/bar.framework.dSYM')
+                    .createSync(recursive: true);
               },
             ),
             const FakeCommand(
@@ -125,7 +127,9 @@ void main() {
                 '/build/native_assets/ios/buz.framework.dSYM',
               ],
               onRun: (_) {
-                fileSystem.directory('/build/native_assets/ios/buz.framework.dSYM').createSync(recursive: true);
+                fileSystem
+                    .directory('/build/native_assets/ios/buz.framework.dSYM')
+                    .createSync(recursive: true);
               },
             ),
             const FakeCommand(
@@ -313,11 +317,13 @@ void main() {
       final fakeStdio = globals.stdio as FakeStdio;
       expect(
         fakeStdio.writtenToStderr,
-        contains(contains(
-          'Code asset "package:bar/bar.dart" has different framework names for '
-          'different architectures. Picking "bar.framework" and '
-          'ignoring "bar_different.framework".',
-        )),
+        contains(
+          contains(
+            'Code asset "package:bar/bar.dart" has different framework names for '
+            'different architectures. Picking "bar.framework" and '
+            'ignoring "bar_different.framework".',
+          ),
+        ),
       );
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -66,14 +66,17 @@ void main() {
             ],
           ),
           if (buildMode == BuildMode.release) ...<FakeCommand>[
-            const FakeCommand(
-              command: <Pattern>[
+            FakeCommand(
+              command: const <Pattern>[
                 'xcrun',
                 'dsymutil',
                 '/build/native_assets/ios/bar.framework/bar',
                 '-o',
                 '/build/native_assets/ios/bar.framework.dSYM',
               ],
+              onRun: (_) {
+                fileSystem.directory('/build/native_assets/ios/bar.framework.dSYM').createSync(recursive: true);
+              },
             ),
             const FakeCommand(
               command: <Pattern>[
@@ -111,14 +114,17 @@ void main() {
             ],
           ),
           if (buildMode == BuildMode.release) ...<FakeCommand>[
-            const FakeCommand(
-              command: <Pattern>[
+            FakeCommand(
+              command: const <Pattern>[
                 'xcrun',
                 'dsymutil',
                 '/build/native_assets/ios/buz.framework/buz',
                 '-o',
                 '/build/native_assets/ios/buz.framework.dSYM',
               ],
+              onRun: (_) {
+                fileSystem.directory('/build/native_assets/ios/buz.framework.dSYM').createSync(recursive: true);
+              },
             ),
             const FakeCommand(
               command: <Pattern>[

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -8,6 +8,7 @@ import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -22,6 +23,7 @@ import 'package:hooks_runner/hooks_runner.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fakes.dart';
 import '../fake_native_assets_build_runner.dart';
 
 void main() {
@@ -308,19 +310,21 @@ void main() {
 
       fatAssetTargetLocationsIOS(assets);
 
+      final fakeStdio = globals.stdio as FakeStdio;
       expect(
-        logger.warningText,
-        contains(
+        fakeStdio.writtenToStderr,
+        contains(contains(
           'Code asset "package:bar/bar.dart" has different framework names for '
           'different architectures. Picking "bar.framework" and '
           'ignoring "bar_different.framework".',
-        ),
+        )),
       );
     },
     overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       Logger: () => logger,
+      Stdio: () => FakeStdio(),
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -82,6 +82,7 @@ void main() {
             if (flutterTester) ...<FakeCommand>[
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'lipo',
                   '-create',
                   '-output',
@@ -91,12 +92,12 @@ void main() {
               ),
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
-                  command: <Pattern>['dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                  command: <Pattern>['xcrun', 'dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
                 ),
-                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBar]),
+                FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBar]),
               ],
               FakeCommand(
-                command: <Pattern>['otool', '-D', dylibPathBar],
+                command: <Pattern>['xcrun', 'otool', '-D', dylibPathBar],
                 stdout: <String>[
                   '$dylibPathBar (architecture x86_64):',
                   '@rpath/libbar.dylib',
@@ -106,6 +107,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'lipo',
                   '-create',
                   '-output',
@@ -115,12 +117,12 @@ void main() {
               ),
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
-                  command: <Pattern>['dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                  command: <Pattern>['xcrun', 'dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
                 ),
-                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBuz]),
+                FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBuz]),
               ],
               FakeCommand(
-                command: <Pattern>['otool', '-D', dylibPathBuz],
+                command: <Pattern>['xcrun', 'otool', '-D', dylibPathBuz],
                 stdout: <String>[
                   '$dylibPathBuz (architecture ${isArm64 ? 'arm64' : 'x86_64'}):',
                   '@rpath/libbuz.dylib',
@@ -128,6 +130,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'install_name_tool',
                   '-id',
                   dylibPathBar,
@@ -142,6 +145,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'codesign',
                   '--force',
                   '--sign',
@@ -152,6 +156,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'install_name_tool',
                   '-id',
                   dylibPathBuz,
@@ -166,6 +171,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'codesign',
                   '--force',
                   '--sign',
@@ -177,6 +183,7 @@ void main() {
             ] else ...<FakeCommand>[
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'lipo',
                   '-create',
                   '-output',
@@ -187,12 +194,12 @@ void main() {
               ),
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
-                  command: <Pattern>['dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                  command: <Pattern>['xcrun', 'dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
                 ),
-                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBar]),
+                FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBar]),
               ],
               FakeCommand(
-                command: <Pattern>['otool', '-D', dylibPathBar],
+                command: <Pattern>['xcrun', 'otool', '-D', dylibPathBar],
                 stdout: <String>[
                   '$dylibPathBar (architecture x86_64):',
                   '@rpath/libbar.dylib',
@@ -202,6 +209,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'lipo',
                   '-create',
                   '-output',
@@ -212,12 +220,12 @@ void main() {
               ),
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
-                  command: <Pattern>['dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                  command: <Pattern>['xcrun', 'dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
                 ),
-                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBuz]),
+                FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBuz]),
               ],
               FakeCommand(
-                command: <Pattern>['otool', '-D', dylibPathBuz],
+                command: <Pattern>['xcrun', 'otool', '-D', dylibPathBuz],
                 stdout: <String>[
                   '$dylibPathBuz (architecture x86_64):',
                   '@rpath/libbuz.dylib',
@@ -227,6 +235,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'install_name_tool',
                   '-id',
                   '@rpath/bar.framework/bar',
@@ -241,6 +250,7 @@ void main() {
               ),
               FakeCommand(
                 command: <Pattern>[
+                  'xcrun',
                   'install_name_tool',
                   '-id',
                   '@rpath/buz.framework/buz',
@@ -336,6 +346,7 @@ void main() {
             projectUri: projectUri,
             fileSystem: fileSystem,
             nativeAssetsFileUri: nativeAssetsFileUri,
+            targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/macos/'),
           );
           final expectedArchsBeingBuilt = flutterTester
               ? (isArm64 ? 'macos_arm64' : 'macos_x64')

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -93,6 +93,9 @@ void main() {
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
                   command: <Pattern>['xcrun', 'dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                  onRun: (_) {
+                    fileSystem.directory('$signPathBar.dSYM').createSync(recursive: true);
+                  },
                 ),
                 FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBar]),
               ],
@@ -118,6 +121,9 @@ void main() {
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
                   command: <Pattern>['xcrun', 'dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                  onRun: (_) {
+                    fileSystem.directory('$signPathBuz.dSYM').createSync(recursive: true);
+                  },
                 ),
                 FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBuz]),
               ],
@@ -195,6 +201,9 @@ void main() {
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
                   command: <Pattern>['xcrun', 'dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                  onRun: (_) {
+                    fileSystem.directory('$signPathBar.dSYM').createSync(recursive: true);
+                  },
                 ),
                 FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBar]),
               ],
@@ -221,6 +230,9 @@ void main() {
               if (buildMode == BuildMode.release) ...<FakeCommand>[
                 FakeCommand(
                   command: <Pattern>['xcrun', 'dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                  onRun: (_) {
+                    fileSystem.directory('$signPathBuz.dSYM').createSync(recursive: true);
+                  },
                 ),
                 FakeCommand(command: <Pattern>['xcrun', 'strip', '-x', '-S', dylibPathBuz]),
               ],

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -89,6 +89,7 @@ void main() {
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,
+        targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/test/'),
       );
       expect(testLogger.traceText, isNot(contains('Copying native assets to')));
     },
@@ -145,6 +146,7 @@ void main() {
         buildCodeAssets: true,
         buildDataAssets: true,
       );
+      final Uri targetUri = environment.buildDir.uri.resolve('native_assets/');
       await installCodeAssets(
         dartHookResult: dartHookResult,
         environmentDefines: environmentDefines,
@@ -152,18 +154,13 @@ void main() {
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,
+        targetUri: targetUri,
       );
       expect(
         await fileSystem.file(nonFlutterTesterAssetUri).readAsString(),
         isNot(contains('package:bar/bar.dart')),
       );
-      expect(
-        environment.projectDir
-            .childDirectory('build')
-            .childDirectory('native_assets')
-            .childDirectory('windows'),
-        exists,
-      );
+      expect(fileSystem.directory(targetUri), exists);
     },
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/native_assets_test.dart
@@ -146,7 +146,7 @@ void main() {
         buildCodeAssets: true,
         buildDataAssets: true,
       );
-      final Uri targetUri = environment.buildDir.uri.resolve('native_assets/');
+      final Directory targetDirectory = environment.buildDir.childDirectory('native_assets');
       await installCodeAssets(
         dartHookResult: dartHookResult,
         environmentDefines: environmentDefines,
@@ -154,13 +154,13 @@ void main() {
         projectUri: projectUri,
         fileSystem: fileSystem,
         nativeAssetsFileUri: nonFlutterTesterAssetUri,
-        targetUri: targetUri,
+        targetUri: targetDirectory.uri,
       );
       expect(
         await fileSystem.file(nonFlutterTesterAssetUri).readAsString(),
         isNot(contains('package:bar/bar.dart')),
       );
-      expect(fileSystem.directory(targetUri), exists);
+      expect(targetDirectory, exists);
     },
   );
 

--- a/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/windows/native_assets_test.dart
@@ -117,6 +117,7 @@ void main() {
             projectUri: projectUri,
             fileSystem: fileSystem,
             nativeAssetsFileUri: nativeAssetsFileUri,
+            targetUri: projectUri.resolve('${getBuildDirectory()}/native_assets/windows/'),
           );
           final expectedOS = flutterTester ? OS.current.toString() : 'windows';
           final expectedArch = flutterTester ? Architecture.current.toString() : 'x64';


### PR DESCRIPTION
This PR fixes two issues. Accidental reuse of code assets between build modes and SDKs (https://github.com/flutter/flutter/issues/181724), and the bundling in ios-frameworks (https://github.com/flutter/flutter/issues/181382).

To fix the accidental caching, the `Target`s related to build hooks and code assets now output their files to `environment.outputDir` instead of `$projectDir/$buildDir/native_assets`.

* `xcode_backend` is updated to deal with this.
* `Flutter.kt` has been updated to deal with this.
* Because the `Target`s are responsible for caching, the code has been refactored to provide the target directories from there. The "global-ish" function `nativeAssetsBuildUri` that was calculating the directory before has been removed.
* `runFlutterSpecificHooks` has nothing to do with that directory, it's access to it has been removed.
* To avoid another cmakefile migration, the Linux and Windows implementation use the same directory. (Note that output dir and build dir overlap for Linux and Windows, while they do not for MacOS, iOS, and Android.)
* This also means that we don't have to read `NativeAssetsManifest.json` in `xcode_backend` anymore. Instead the `Target` clears the output directory, so we should not have any stale frameworks.
* Refactored `installCodeAssets` and its platform-specific implementations to return a list of all produced files. These are now added to the `Target`'s depfile. This fixes an issue where the build system would skip re-installing native assets after an Xcode "Clean Build Folder because it wasn't tracking the frameworks/dylibs as outputs.

Closes: https://github.com/flutter/flutter/issues/181724

Other `Target`s related tweaks:

* Added proper `Source.pattern('{BUILD_DIR}/${DartBuild.dartHookResultFilename}'),` for all `Target`s that depend on that file. These were missing. (The build system uses `dependencies` for ordering of `Target`s, but relies on `inputs` and `outputs` for caching.)
* Removed code assets from `CopyAssets`. That target is supposed to make an asset-bundle that is OS-independent if I understand correctly.

This PR changes the way code assets are bundled in `flutter build ios-framework`.

* This PR now packages in an `.xcframework`, which is necessary to be able to package both device and simulator.
* Run through the frameworks of both device and simulator and give errors on inconsistencies.

Closes: https://github.com/flutter/flutter/issues/181382

Other iOS related tweaks:

* Use `xcrun` for invoking all the commands. (This is used for producing the app framework, but was not for code assets frameworks.)
* Make sure all commands are added to the traces when running verbose. (Also to bring it in line for with the other `xcrun` commands.)

Testing:

* The integration test is updated to inspect the `xcframework`s.
* Added a test that simulates Xcode "Product > Clean Build Folder...", to check that it now correctly triggers a rebuild.
* We do _not_ have an integration test that _runs_ the frameworks output from `flutter build ios-framework` inside a host app at all as far as I'm aware.
  * dev/devicelab/bin/tasks/build_ios_framework_module_test.dart builds a framework, but doesn't run it in a host app
  * dev/integration_tests/ios_add2app_life_cycle/build_and_test.sh runs, but does so via `flutter build ios` not as a framework.
* Does not add an integration test for caching behavior between switching build modes. However, the proper functioning of `flutter build ios-framework` depends on the `Target`s for different not using overlapping directories.

Architectural approaches tried but didn't work:

* Subclass `InstallCodeAssets` per OS to be more precise in the `output`s on what files are output. This doesn't work because other OS-independent targets on the `InstallCodeAssets` target.