### PR TITLE
Use AccessibilityFocusBlockType.blockSubtree to replace BlockSemantics in modal routes.

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -5176,6 +5176,7 @@ final class _SemanticsParentData {
         other.blocksUserActions == blocksUserActions &&
         other.explicitChildNodes == explicitChildNodes &&
         other.localeForChildren == localeForChildren &&
+        other.accessibilityFocusBlockType == accessibilityFocusBlockType &&
         setEquals<SemanticsTag>(other.tagsForChildren, tagsForChildren);
   }
 
@@ -5186,6 +5187,7 @@ final class _SemanticsParentData {
       blocksUserActions,
       explicitChildNodes,
       localeForChildren,
+      accessibilityFocusBlockType,
       Object.hashAllUnordered(tagsForChildren ?? const <SemanticsTag>{}),
     );
   }

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -261,11 +261,10 @@ class ModalBarrier extends StatelessWidget {
       barrier = _SemanticsClipper(clipDetailsNotifier: clipDetailsNotifier!, child: barrier);
     }
 
-    return BlockSemantics(
-      child: ExcludeSemantics(
+    return ExcludeSemantics(
         excluding: excluding,
-        child: _ModalBarrierGestureDetector(onDismiss: handleDismiss, child: barrier),
-      ),
+        child: _ModalBarrierGestureDetector(onDismiss: handleDismiss, child: barrier)
+
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1191,61 +1191,66 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
         canPop: widget.route.canPop, // _routeSetState is called if this updates
         opaque: widget.route.opaque, // _routeSetState is called if this updates
         impliesAppBarDismissal: widget.route.impliesAppBarDismissal,
-        child: Offstage(
-          offstage: widget.route.offstage, // _routeSetState is called if this updates
-          child: PageStorage(
-            bucket: widget.route._storageBucket, // immutable
-            child: Builder(
-              builder: (BuildContext context) {
-                return Actions(
-                  actions: <Type, Action<Intent>>{DismissIntent: _DismissModalAction(context)},
-                  child: PrimaryScrollController(
-                    controller: primaryScrollController,
-                    child: FocusScope.withExternalFocusNode(
-                      focusScopeNode: focusScopeNode, // immutable
-                      child: RepaintBoundary(
-                        child: ListenableBuilder(
-                          listenable: _listenable, // immutable
-                          builder: (BuildContext context, Widget? child) {
-                            return widget.route._buildFlexibleTransitions(
-                              context,
-                              widget.route.animation!,
-                              widget.route.secondaryAnimation!,
-                              // This additional ListenableBuilder is include because if the
-                              // value of the userGestureInProgressNotifier changes, it's
-                              // only necessary to rebuild the IgnorePointer widget and set
-                              // the focus node's ability to focus.
-                              ListenableBuilder(
-                                listenable:
-                                    widget.route.navigator?.userGestureInProgressNotifier ??
-                                    ValueNotifier<bool>(false),
-                                builder: (BuildContext context, Widget? child) {
-                                  final bool ignoreEvents = _shouldIgnoreFocusRequest;
-                                  focusScopeNode.canRequestFocus = !ignoreEvents;
-                                  return IgnorePointer(ignoring: ignoreEvents, child: child);
+        child: Semantics(
+          accessibilityFocusBlockType: widget.route.isCurrent
+              ? AccessibilityFocusBlockType.none
+              : AccessibilityFocusBlockType.blockSubtree,
+          child: Offstage(
+            offstage: widget.route.offstage, // _routeSetState is called if this updates
+            child: PageStorage(
+              bucket: widget.route._storageBucket, // immutable
+              child: Builder(
+                builder: (BuildContext context) {
+                  return Actions(
+                    actions: <Type, Action<Intent>>{DismissIntent: _DismissModalAction(context)},
+                    child: PrimaryScrollController(
+                      controller: primaryScrollController,
+                      child: FocusScope.withExternalFocusNode(
+                        focusScopeNode: focusScopeNode, // immutable
+                        child: RepaintBoundary(
+                          child: ListenableBuilder(
+                            listenable: _listenable, // immutable
+                            builder: (BuildContext context, Widget? child) {
+                              return widget.route._buildFlexibleTransitions(
+                                context,
+                                widget.route.animation!,
+                                widget.route.secondaryAnimation!,
+                                // This additional ListenableBuilder is include because if the
+                                // value of the userGestureInProgressNotifier changes, it's
+                                // only necessary to rebuild the IgnorePointer widget and set
+                                // the focus node's ability to focus.
+                                ListenableBuilder(
+                                  listenable:
+                                      widget.route.navigator?.userGestureInProgressNotifier ??
+                                      ValueNotifier<bool>(false),
+                                  builder: (BuildContext context, Widget? child) {
+                                    final bool ignoreEvents = _shouldIgnoreFocusRequest;
+                                    focusScopeNode.canRequestFocus = !ignoreEvents;
+                                    return IgnorePointer(ignoring: ignoreEvents, child: child);
+                                  },
+                                  child: child,
+                                ),
+                              );
+                            },
+                            child: _page ??= RepaintBoundary(
+                              key: widget.route._subtreeKey, // immutable
+                              child: Builder(
+                                builder: (BuildContext context) {
+                                  return widget.route.buildPage(
+                                    context,
+                                    widget.route.animation!,
+                                    widget.route.secondaryAnimation!,
+                                  );
                                 },
-                                child: child,
                               ),
-                            );
-                          },
-                          child: _page ??= RepaintBoundary(
-                            key: widget.route._subtreeKey, // immutable
-                            child: Builder(
-                              builder: (BuildContext context) {
-                                return widget.route.buildPage(
-                                  context,
-                                  widget.route.animation!,
-                                  widget.route.secondaryAnimation!,
-                                );
-                              },
                             ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                );
-              },
+                  );
+                },
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/166258 

The way `BlockSemantics` works : it drops those blocked semantics nodes  from tree.
The way AccessibilityFocusBlockType works: the nodes are still in the semantics tree but with a flag "isAccessibilityFocusBlocked: true "

This will stop a live region node from being dropped from the tree and added to the tree again, and thus live region announcing things again. 


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
