### PR TITLE
[native assets] Split debug info into `.dsym` files

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -550,16 +550,19 @@ class Context {
         );
       }
 
-      runRsync(
-        extraArgs: <String>['--filter', '- native_assets.yaml', '--filter', '- native_assets.json'],
-        frameworkDirectory.path,
-        xcodeFrameworksDir,
-      );
+      runRsync(frameworkDirectory.path, xcodeFrameworksDir);
       if (codesign && expandedCodeSignIdentity != null) {
         _codesignFramework(
           expandedCodeSignIdentity,
           '$xcodeFrameworksDir/$framework.framework/$framework',
         );
+      }
+
+      final Directory dsymDirectory = directoryFromPath(
+        '$nativeAssetsPath$framework.framework.dSYM',
+      );
+      if (dsymDirectory.existsSync()) {
+        runRsync(dsymDirectory.path, '${environment['BUILT_PRODUCTS_DIR']}/');
       }
     }
   }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -118,6 +118,11 @@ Future<void> copyNativeCodeAssetsIOS(
     }
     await lipoDylibs(dylibFile, sources);
 
+    if (buildMode != BuildMode.debug) {
+      await dsymutilDylib(dylibFile, '${frameworkDir.path}.dSYM');
+      await stripDylib(dylibFile);
+    }
+
     final String dylibFileName = dylibFile.basename;
     final newInstallName = '@rpath/$dylibFileName.framework/$dylibFileName';
     final Set<String> oldInstallNames = await getInstallNamesDylib(dylibFile);

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -159,6 +159,10 @@ Future<void> copyNativeCodeAssetsMacOS(
       ),
     );
     await lipoDylibs(dylibFile, sources);
+    if (buildMode != BuildMode.debug) {
+      await dsymutilDylib(dylibFile, '${frameworkDir.path}.dSYM');
+      await stripDylib(dylibFile);
+    }
     final Link dylibLink = frameworkDir.childLink(name);
     await dylibLink.create(
       fileSystem.path.relative(

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets_host.dart
@@ -134,6 +134,38 @@ Future<Set<String>> getInstallNamesDylib(File dylibFile) async {
   };
 }
 
+/// Creates a dSYM bundle for a dylib.
+Future<void> dsymutilDylib(File dylibFile, String dsymPath) async {
+  final ProcessResult result = await globals.processManager.run(<String>[
+    'dsymutil',
+    dylibFile.path,
+    '-o',
+    dsymPath,
+  ]);
+  if (result.exitCode != 0) {
+    globals.logger.printError(result.stdout as String);
+    globals.logger.printError(result.stderr as String);
+    throwToolExit('dsymutil failed with exit code ${result.exitCode}');
+  }
+}
+
+/// Strips a dylib.
+///
+/// This is useful for release builds to reduce binary size.
+Future<void> stripDylib(File dylibFile) async {
+  final ProcessResult result = await globals.processManager.run(<String>[
+    'strip',
+    '-x', // Remove local symbols.
+    '-S', // Remove debugging symbol table.
+    dylibFile.path,
+  ]);
+  if (result.exitCode != 0) {
+    globals.logger.printError(result.stdout as String);
+    globals.logger.printError(result.stderr as String);
+    throwToolExit('strip failed with exit code ${result.exitCode}');
+  }
+}
+
 Future<void> codesignDylib(
   String? codesignIdentity,
   BuildMode buildMode,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -150,6 +150,17 @@ void main() {
             'foo.framework/foo',
           ],
         ),
+        const FakeCommand(
+          command: <Pattern>[
+            'dsymutil',
+            '/build/native_assets/ios/foo.framework/foo',
+            '-o',
+            '/build/native_assets/ios/foo.framework.dSYM',
+          ],
+        ),
+        const FakeCommand(
+          command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/foo.framework/foo'],
+        ),
         // Lookup the original install names of the dylib.
         // There can be different install names for different architectures.
         FakeCommand(

--- a/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/ios/native_assets_test.dart
@@ -62,6 +62,19 @@ void main() {
               'x64/libbar.dylib',
             ],
           ),
+          if (buildMode == BuildMode.release) ...<FakeCommand>[
+            const FakeCommand(
+              command: <Pattern>[
+                'dsymutil',
+                '/build/native_assets/ios/bar.framework/bar',
+                '-o',
+                '/build/native_assets/ios/bar.framework.dSYM',
+              ],
+            ),
+            const FakeCommand(
+              command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/bar.framework/bar'],
+            ),
+          ],
           FakeCommand(
             command: const <Pattern>['otool', '-D', '/build/native_assets/ios/bar.framework/bar'],
             stdout: <String>[
@@ -81,6 +94,19 @@ void main() {
               'x64/libbuz.dylib',
             ],
           ),
+          if (buildMode == BuildMode.release) ...<FakeCommand>[
+            const FakeCommand(
+              command: <Pattern>[
+                'dsymutil',
+                '/build/native_assets/ios/buz.framework/buz',
+                '-o',
+                '/build/native_assets/ios/buz.framework.dSYM',
+              ],
+            ),
+            const FakeCommand(
+              command: <Pattern>['strip', '-x', '-S', '/build/native_assets/ios/buz.framework/buz'],
+            ),
+          ],
           FakeCommand(
             command: const <Pattern>['otool', '-D', '/build/native_assets/ios/buz.framework/buz'],
             stdout: <String>[

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -89,6 +89,12 @@ void main() {
                   '${isArm64 ? 'arm64' : 'x64'}/libbar.dylib',
                 ],
               ),
+              if (buildMode == BuildMode.release) ...<FakeCommand>[
+                FakeCommand(
+                  command: <Pattern>['dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                ),
+                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBar]),
+              ],
               FakeCommand(
                 command: <Pattern>['otool', '-D', dylibPathBar],
                 stdout: <String>[
@@ -107,6 +113,12 @@ void main() {
                   '${isArm64 ? 'arm64' : 'x64'}/libbuz.dylib',
                 ],
               ),
+              if (buildMode == BuildMode.release) ...<FakeCommand>[
+                FakeCommand(
+                  command: <Pattern>['dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                ),
+                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBuz]),
+              ],
               FakeCommand(
                 command: <Pattern>['otool', '-D', dylibPathBuz],
                 stdout: <String>[
@@ -173,6 +185,12 @@ void main() {
                   'x64/libbar.dylib',
                 ],
               ),
+              if (buildMode == BuildMode.release) ...<FakeCommand>[
+                FakeCommand(
+                  command: <Pattern>['dsymutil', dylibPathBar, '-o', '$signPathBar.dSYM'],
+                ),
+                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBar]),
+              ],
               FakeCommand(
                 command: <Pattern>['otool', '-D', dylibPathBar],
                 stdout: <String>[
@@ -192,6 +210,12 @@ void main() {
                   'x64/libbuz.dylib',
                 ],
               ),
+              if (buildMode == BuildMode.release) ...<FakeCommand>[
+                FakeCommand(
+                  command: <Pattern>['dsymutil', dylibPathBuz, '-o', '$signPathBuz.dSYM'],
+                ),
+                FakeCommand(command: <Pattern>['strip', '-x', '-S', dylibPathBuz]),
+              ],
               FakeCommand(
                 command: <Pattern>['otool', '-D', dylibPathBuz],
                 stdout: <String>[

--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -799,6 +799,7 @@ void main() {
       nativeAssetsDir.createSync(recursive: true);
       final Directory ffiPackageDir = nativeAssetsDir.childDirectory('$ffiPackageName.framework')
         ..createSync();
+      nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
       nativeAssetsDir.childFile('random.txt').createSync();
       // In addition to the ffiPackageName framework, create an additional unrelated framework in
       // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -864,13 +865,21 @@ void main() {
               '--delete',
               '--filter',
               '- .DS_Store',
-              '--filter',
-              '- native_assets.yaml',
-              '--filter',
-              '- native_assets.json',
               // We should copy $ffiPackageName.framework, but not the unrelated framework path.
               ffiPackageDir.path,
               targetBuildDir.childDirectory(frameworksFolderPath).path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'rsync',
+              '-8',
+              '-av',
+              '--delete',
+              '--filter',
+              '- .DS_Store',
+              nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+              '${buildDir.path}/',
             ],
           ),
           FakeCommand(
@@ -946,6 +955,7 @@ void main() {
       nativeAssetsDir.createSync(recursive: true);
       final Directory ffiPackageDir = nativeAssetsDir.childDirectory('$ffiPackageName.framework')
         ..createSync();
+      nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
       nativeAssetsDir.childFile('random.txt').createSync();
       // In addition to the ffiPackageName framework, create an additional unrelated framework in
       // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1044,10 +1054,6 @@ void main() {
               '--delete',
               '--filter',
               '- .DS_Store',
-              '--filter',
-              '- native_assets.yaml',
-              '--filter',
-              '- native_assets.json',
               // We should copy $ffiPackageName.framework, but not the unrelated framework path.
               ffiPackageDir.path,
               targetBuildDir.childDirectory(frameworksFolderPath).path,
@@ -1065,6 +1071,18 @@ void main() {
                   .childDirectory(frameworksFolderPath)
                   .childFile('$ffiPackageName.framework/$ffiPackageName')
                   .path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'rsync',
+              '-8',
+              '-av',
+              '--delete',
+              '--filter',
+              '- .DS_Store',
+              nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+              '${buildDir.path}/',
             ],
           ),
         ],
@@ -1134,6 +1152,7 @@ void main() {
           final Directory ffiPackageDir = nativeAssetsDir.childDirectory(
             '$ffiPackageName.framework',
           )..createSync();
+          nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
           nativeAssetsDir.childFile('random.txt').createSync();
           // In addition to the ffiPackageName framework, create an additional unrelated framework in
           // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1190,12 +1209,20 @@ void main() {
                   '--delete',
                   '--filter',
                   '- .DS_Store',
-                  '--filter',
-                  '- native_assets.yaml',
-                  '--filter',
-                  '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'rsync',
+                  '-8',
+                  '-av',
+                  '--delete',
+                  '--filter',
+                  '- .DS_Store',
+                  nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+                  '${buildDir.path}/',
                 ],
               ),
               FakeCommand(
@@ -1297,6 +1324,7 @@ void main() {
           final Directory ffiPackageDir = nativeAssetsDir.childDirectory(
             '$ffiPackageName.framework',
           )..createSync();
+          nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
           nativeAssetsDir.childFile('random.txt').createSync();
           // In addition to the ffiPackageName framework, create an additional unrelated framework in
           // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1353,12 +1381,20 @@ void main() {
                   '--delete',
                   '--filter',
                   '- .DS_Store',
-                  '--filter',
-                  '- native_assets.yaml',
-                  '--filter',
-                  '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'rsync',
+                  '-8',
+                  '-av',
+                  '--delete',
+                  '--filter',
+                  '- .DS_Store',
+                  nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+                  '${buildDir.path}/',
                 ],
               ),
               FakeCommand(
@@ -1462,6 +1498,7 @@ void main() {
           final Directory ffiPackageDir = nativeAssetsDir.childDirectory(
             '$ffiPackageName.framework',
           )..createSync();
+          nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
           nativeAssetsDir.childFile('random.txt').createSync();
           // In addition to the ffiPackageName framework, create an additional unrelated framework in
           // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1533,10 +1570,6 @@ void main() {
                   '--delete',
                   '--filter',
                   '- .DS_Store',
-                  '--filter',
-                  '- native_assets.yaml',
-                  '--filter',
-                  '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
                 ],
@@ -1553,6 +1586,18 @@ void main() {
                       .childDirectory(frameworksFolderPath)
                       .childFile('$ffiPackageName.framework/$ffiPackageName')
                       .path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'rsync',
+                  '-8',
+                  '-av',
+                  '--delete',
+                  '--filter',
+                  '- .DS_Store',
+                  nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+                  '${buildDir.path}/',
                 ],
               ),
             ],
@@ -1622,6 +1667,7 @@ void main() {
           final Directory ffiPackageDir = nativeAssetsDir.childDirectory(
             '$ffiPackageName.framework',
           )..createSync();
+          nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
           nativeAssetsDir.childFile('random.txt').createSync();
           // In addition to the ffiPackageName framework, create an additional unrelated framework in
           // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1717,12 +1763,20 @@ void main() {
                   '--delete',
                   '--filter',
                   '- .DS_Store',
-                  '--filter',
-                  '- native_assets.yaml',
-                  '--filter',
-                  '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'rsync',
+                  '-8',
+                  '-av',
+                  '--delete',
+                  '--filter',
+                  '- .DS_Store',
+                  nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+                  '${buildDir.path}/',
                 ],
               ),
               FakeCommand(
@@ -1826,6 +1880,7 @@ void main() {
           final Directory ffiPackageDir = nativeAssetsDir.childDirectory(
             '$ffiPackageName.framework',
           )..createSync();
+          nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').createSync();
           nativeAssetsDir.childFile('random.txt').createSync();
           // In addition to the ffiPackageName framework, create an additional unrelated framework in
           // the same directory. It should not get copied since it is not referenced in the manifest.
@@ -1922,12 +1977,20 @@ void main() {
                   '--delete',
                   '--filter',
                   '- .DS_Store',
-                  '--filter',
-                  '- native_assets.yaml',
-                  '--filter',
-                  '- native_assets.json',
                   ffiPackageDir.path,
                   targetBuildDir.childDirectory(frameworksFolderPath).path,
+                ],
+              ),
+              FakeCommand(
+                command: <String>[
+                  'rsync',
+                  '-8',
+                  '-av',
+                  '--delete',
+                  '--filter',
+                  '- .DS_Store',
+                  nativeAssetsDir.childDirectory('$ffiPackageName.framework.dSYM').path,
+                  '${buildDir.path}/',
                 ],
               ),
             ],


### PR DESCRIPTION
This PR splits the debug info from code assets into separate dsym files for MacOS and iOS.

The splitting only happens if the build mode is not debug. This aligns with whether the debug symbols are separated out for the Flutter framework and the app Framework.

Closes: https://github.com/flutter/flutter/issues/181377

Testing: Added some tests to the integration test