### PR TITLE
Fix TextScaler.clamp assertion failure when clamping already-clamped …

### DIFF
--- a/packages/flutter/lib/src/painting/text_scaler.dart
+++ b/packages/flutter/lib/src/painting/text_scaler.dart
@@ -132,9 +132,11 @@ final class _ClampedTextScaler implements TextScaler {
 
   @override
   TextScaler clamp({double minScaleFactor = 0, double maxScaleFactor = double.infinity}) {
-    return minScaleFactor == maxScaleFactor
+    final double newMinScale = max(minScale, minScaleFactor);
+    final double newMaxScale = min(maxScale, maxScaleFactor);
+    return newMinScale == newMaxScale
         ? _LinearTextScaler(minScaleFactor)
-        : _ClampedTextScaler(scaler, max(minScaleFactor, minScale), min(maxScaleFactor, maxScale));
+        : _ClampedTextScaler(scaler, newMinScale, newMaxScale);
   }
 
   @override

--- a/packages/flutter/lib/src/painting/text_scaler.dart
+++ b/packages/flutter/lib/src/painting/text_scaler.dart
@@ -135,7 +135,7 @@ final class _ClampedTextScaler implements TextScaler {
     final double newMinScale = max(minScale, minScaleFactor);
     final double newMaxScale = min(maxScale, maxScaleFactor);
     return newMinScale == newMaxScale
-        ? _LinearTextScaler(minScaleFactor)
+        ? _LinearTextScaler(newMinScale)
         : _ClampedTextScaler(scaler, newMinScale, newMaxScale);
   }
 


### PR DESCRIPTION
Fix `TextScaler.clamp` assertion failure when clamping already-clamped scalers

Fixes #174828

## Description

When calling `clamp()` on an already-clamped `TextScaler`, the `_ClampedTextScaler.clamp()` method was checking if `minScaleFactor == maxScaleFactor` **before** calculating the actual new min/max values. This caused assertion failures (`'maxScale > minScale': is not true`) when the calculated `newMinScale` and `newMaxScale` became equal after applying `max()`/`min()` operations.

### Example scenario that triggers the bug:
```dart
final textScaler = MediaQuery.of(context).textScaler;
// First clamp - creates a _ClampedTextScaler
textScaler.clamp(minScaleFactor: 1.0, maxScaleFactor: 1.1);
// Internal framework code calls clamp() again (e.g., in BottomNavigationBar)
// This could result in newMinScale == newMaxScale, triggering the assertion
```

### The fix:
Calculate `newMinScale` and `newMaxScale` **first**, then check for equality. If they are equal, return a `_LinearTextScaler` instead of creating a `_ClampedTextScaler` that would fail its constructor assertion.

**Before:**
```dart
TextScaler clamp({double minScaleFactor = 0, double maxScaleFactor = double.infinity}) {
    return minScaleFactor == maxScaleFactor
        ? _LinearTextScaler(minScaleFactor)
        : _ClampedTextScaler(scaler, max(minScaleFactor, minScale), min(maxScaleFactor, maxScale));
}
```

**After:**
```dart
TextScaler clamp({double minScaleFactor = 0, double maxScaleFactor = double.infinity}) {
    final double newMinScale = max(minScale, minScaleFactor);
    final double newMaxScale = min(maxScale, maxScaleFactor);
    return newMinScale == newMaxScale
        ? _LinearTextScaler(minScaleFactor)
        : _ClampedTextScaler(scaler, newMinScale, newMaxScale);
}
```
