### PR TITLE
Updates GetDartSize to return the number of non-padding bytes

### DIFF
--- a/engine/src/flutter/impeller/core/runtime_types.cc
+++ b/engine/src/flutter/impeller/core/runtime_types.cc
@@ -9,10 +9,16 @@
 namespace impeller {
 
 size_t RuntimeUniformDescription::GetDartSize() const {
-  // Struct uniforms aren't yet supported, they only exist as Vulkan
-  // collections.
-  FML_DCHECK(type != kStruct);
-  size_t size = dimensions.rows * dimensions.cols * bit_width / 8u;
+  size_t size = 0;
+  if (!padding_layout.empty()) {
+    for (impeller::RuntimePaddingType byte_type : padding_layout) {
+      if (byte_type == RuntimePaddingType::kFloat) {
+        size += sizeof(float);
+      }
+    }
+  } else {
+    size = dimensions.rows * dimensions.cols * bit_width / 8u;
+  }
   if (array_elements.value_or(0) > 0) {
     // Covered by check on the line above.
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access)

--- a/engine/src/flutter/impeller/core/runtime_types.h
+++ b/engine/src/flutter/impeller/core/runtime_types.h
@@ -56,7 +56,8 @@ struct RuntimeUniformDescription {
   size_t struct_float_count = 0u;
 
   /// @brief  Computes the total number of bytes that this uniform requires for
-  /// representation in the Dart float buffer.
+  /// representation in the Dart float buffer. This is the size of the uniform
+  /// in floats without taking padding into account.
   size_t GetDartSize() const;
 
   /// @brief  Computes the total number of bytes that this uniform requires for

--- a/engine/src/flutter/lib/ui/painting/fragment_program.cc
+++ b/engine/src/flutter/lib/ui/painting/fragment_program.cc
@@ -83,7 +83,7 @@ Dart_Handle ConvertUniformDescriptionToMap(
   }
   {  // 2
     Dart_Handle size =
-        Dart_NewIntegerFromUint64(uniform_description.GetGPUSize());
+        Dart_NewIntegerFromUint64(uniform_description.GetDartSize());
     FML_DCHECK(!Dart_IsError(size));
     [[maybe_unused]] Dart_Handle result =
         Dart_ListSetAt(keys, 2, Dart_NewStringFromCString("size"));
@@ -162,7 +162,7 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
         impeller::RuntimeUniformType::kSampledImage) {
       sampled_image_count++;
     } else {
-      other_uniforms_bytes += uniform_description.GetGPUSize();
+      other_uniforms_bytes += uniform_description.GetDartSize();
     }
   }
 

--- a/engine/src/flutter/testing/dart/fragment_shader_test.dart
+++ b/engine/src/flutter/testing/dart/fragment_shader_test.dart
@@ -121,56 +121,68 @@ void main() async {
       slot.set(6.0, 7.0);
     });
 
-    _runSkiaTest('FragmentProgram getUniformVec2 wrong size', () async {
-      expect(
-        () => shader.getUniformVec2('iVec3Uniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('`iVec3Uniform` has size 3, not size 2.'),
+    test(
+      'FragmentProgram getUniformVec2 wrong size',
+      () async {
+        expect(
+          () => shader.getUniformVec2('iVec3Uniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('`iVec3Uniform` has size 3, not size 2.'),
+            ),
           ),
-        ),
-      );
-      expect(
-        () => shader.getUniformVec2('iFloatUniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('`iFloatUniform` has size 1, not size 2.'),
+        );
+        expect(
+          () => shader.getUniformVec2('iFloatUniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('`iFloatUniform` has size 1, not size 2.'),
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
-    _runSkiaTest('FragmentProgram getUniformVec3', () async {
-      final UniformVec3Slot slot = shader.getUniformVec3('iVec3Uniform');
-      slot.set(0.8, 0.1, 0.3);
-    });
+    test(
+      'FragmentProgram getUniformVec3',
+      () async {
+        final UniformVec3Slot slot = shader.getUniformVec3('iVec3Uniform');
+        slot.set(0.8, 0.1, 0.3);
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
-    _runSkiaTest('FragmentProgram getUniformVec3 wrong size', () async {
-      expect(
-        () => shader.getUniformVec3('iVec2Uniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('`iVec2Uniform` has size 2, not size 3.'),
+    test(
+      'FragmentProgram getUniformVec3 wrong size',
+      () async {
+        expect(
+          () => shader.getUniformVec3('iVec2Uniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('`iVec2Uniform` has size 2, not size 3.'),
+            ),
           ),
-        ),
-      );
-      expect(
-        () => shader.getUniformVec3('iVec4Uniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('`iVec4Uniform` has size 4, not size 3.'),
+        );
+        expect(
+          () => shader.getUniformVec3('iVec4Uniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('`iVec4Uniform` has size 4, not size 3.'),
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
     _runSkiaTest('FragmentProgram getUniformVec4', () async {
       final UniformVec4Slot slot = shader.getUniformVec4('iVec4Uniform');
@@ -218,37 +230,49 @@ void main() async {
       slots[0].set(1.0, 1.0);
     });
 
-    _runSkiaTest('FragmentProgram getUniformArrayVec2 wrong type', () async {
-      expect(
-        () => shader.getUniformVec2Array('iVec3ArrayUniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('Uniform size (9) for "iVec3ArrayUniform" is not a multiple of 2.'),
+    test(
+      'FragmentProgram getUniformArrayVec2 wrong type',
+      () async {
+        expect(
+          () => shader.getUniformVec2Array('iVec3ArrayUniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Uniform size (9) for "iVec3ArrayUniform" is not a multiple of 2.'),
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
-    _runSkiaTest('FragmentProgram getUniformArrayVec3', () async {
-      final UniformArray<UniformVec3Slot> slots = shader.getUniformVec3Array('iVec3ArrayUniform');
-      expect(slots.length, 3);
-      slots[0].set(1.0, 1.0, 1.0);
-    });
+    test(
+      'FragmentProgram getUniformArrayVec3',
+      () async {
+        final UniformArray<UniformVec3Slot> slots = shader.getUniformVec3Array('iVec3ArrayUniform');
+        expect(slots.length, 3);
+        slots[0].set(1.0, 1.0, 1.0);
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
-    _runSkiaTest('FragmentProgram getUniformArrayVec3 wrong type', () async {
-      expect(
-        () => shader.getUniformVec3Array('iFloatArrayUniform'),
-        throwsA(
-          isA<ArgumentError>().having(
-            (e) => e.message,
-            'message',
-            contains('Uniform size (10) for "iFloatArrayUniform" is not a multiple of 3.'),
+    test(
+      'FragmentProgram getUniformArrayVec3 wrong type',
+      () async {
+        expect(
+          () => shader.getUniformVec3Array('iFloatArrayUniform'),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              contains('Uniform size (10) for "iFloatArrayUniform" is not a multiple of 3.'),
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+      skip: Platform.executableArguments.contains('--impeller-backend=vulkan'),
+    );
 
     _runSkiaTest('FragmentProgram getUniformArrayVec4', () async {
       final UniformArray<UniformVec4Slot> slots = shader.getUniformVec4Array('iVec4ArrayUniform');


### PR DESCRIPTION
Updates GetDartSize to return the number of non-padding bytes. We used to send uniform information to the FragmentShader code that included the logical size of the uniforms (no padding), after https://github.com/flutter/flutter/pull/181340, we started to send the physical size of the uniforms (including padding).

This caused us to mis-represent the size of the uniforms in the FragmentShader API, and possibly caused other issues. 

This PR updates GetDartSize to return the number of non-padding bytes (old behavior), and re-enables tests for metal that verify this behavior.