### PR TITLE
POC NestedSlivers

### DIFF
--- a/packages/flutter/lib/rendering.dart
+++ b/packages/flutter/lib/rendering.dart
@@ -54,6 +54,7 @@ export 'src/rendering/layout_helper.dart';
 export 'src/rendering/list_body.dart';
 export 'src/rendering/list_wheel_viewport.dart';
 export 'src/rendering/mouse_tracker.dart';
+export 'src/rendering/nested_slivers.dart';
 export 'src/rendering/object.dart';
 export 'src/rendering/paragraph.dart';
 export 'src/rendering/performance_overlay.dart';

--- a/packages/flutter/lib/src/rendering/nested_slivers.dart
+++ b/packages/flutter/lib/src/rendering/nested_slivers.dart
@@ -1,0 +1,251 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:flutter/widgets.dart';
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/src/rendering/viewport.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'object.dart';
+import 'sliver.dart';
+
+/// A sliver that places multiple sliver children in a linear array along the
+/// main axis.
+///
+/// The layout algorithm lays out slivers one by one. If the sliver is at the top
+/// of the viewport or above the top, then we pass in a nonzero [SliverConstraints.scrollOffset]
+/// to inform the sliver at what point along the main axis we should start layout.
+/// For the slivers that come after it, we compute the amount of space taken up so
+/// far to be used as the [SliverPhysicalParentData.paintOffset] and the
+/// [SliverConstraints.remainingPaintExtent] to be passed in as a constraint.
+///
+/// Finally, this sliver will also ensure that all child slivers are painted within
+/// the total scroll extent of the group by adjusting the child's
+/// [SliverPhysicalParentData.paintOffset] as necessary. This can happen for
+/// slivers such as [SliverPersistentHeader] which, when pinned, positions itself
+/// at the top of the [Viewport] regardless of the scroll offset.
+class RenderNestedSlivers extends RenderSliver
+    with
+        ContainerRenderObjectMixin<RenderSliver, SliverPhysicalContainerParentData>,
+        SliverSequenceMixin {
+  RenderNestedSlivers({SliverPaintOrder? paintOrder}) : _paintOrder = paintOrder;
+
+  @override
+  SliverPaintOrder get paintOrder {
+    return _paintOrder ??
+        switch (RenderAbstractViewport.maybeOf(this)) {
+          RenderViewportBase(:final SliverPaintOrder paintOrder) => paintOrder,
+          _ => SliverPaintOrder.firstIsTop,
+        };
+  }
+
+  SliverPaintOrder? _paintOrder;
+  set paintOrder(SliverPaintOrder? value) {
+    if (_paintOrder == value) {
+      return;
+    }
+    _paintOrder = value;
+    markNeedsLayout();
+  }
+
+  @override
+  void setupParentData(RenderObject child) {
+    if (child.parentData is! SliverPhysicalContainerParentData) {
+      child.parentData = SliverPhysicalContainerParentData();
+    }
+  }
+
+  @override
+  double? childScrollOffset(RenderSliver child) {
+    assert(child.parent == this);
+
+    return scrollOffsetOf(child, -_maxScrollObstructionExtentBefore(child));
+  }
+
+  double _maxScrollObstructionExtentBefore(RenderSliver child) {
+    final GrowthDirection growthDirection = child.constraints.growthDirection;
+    switch (growthDirection) {
+      case GrowthDirection.forward:
+        var pinnedExtent = 0.0;
+        RenderSliver? current = firstChild;
+        while (current != child) {
+          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
+          current = childAfter(current);
+        }
+        return pinnedExtent;
+      case GrowthDirection.reverse:
+        var pinnedExtent = 0.0;
+        RenderSliver? current = lastChild;
+        while (current != child) {
+          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
+          current = childBefore(current);
+        }
+        return pinnedExtent;
+    }
+  }
+
+  @override
+  double childMainAxisPosition(RenderSliver child) {
+    final Offset childPaintOffset = paintOffsetOf(child);
+    return switch (applyGrowthDirectionToAxisDirection(
+      child.constraints.axisDirection,
+      child.constraints.growthDirection,
+    )) {
+      AxisDirection.down => childPaintOffset.dy,
+      AxisDirection.right => childPaintOffset.dx,
+      AxisDirection.up => geometry!.paintExtent - child.geometry!.paintExtent - childPaintOffset.dy,
+      AxisDirection.left =>
+        geometry!.paintExtent - child.geometry!.paintExtent - childPaintOffset.dx,
+    };
+  }
+
+  @override
+  double childCrossAxisPosition(RenderSliver child) => 0.0;
+
+  @override
+  void performLayout() {
+    final RenderSliver? leadingChild;
+    final RenderSliver? Function(RenderSliver) advance;
+
+    switch (constraints.growthDirection) {
+      case GrowthDirection.forward:
+        leadingChild = firstChild;
+        advance = childAfter;
+      case GrowthDirection.reverse:
+        leadingChild = lastChild;
+        advance = childBefore;
+    }
+
+    if (leadingChild == null) {
+      geometry = SliverGeometry.zero;
+      return;
+    }
+
+    final double scrollOffsetCorrection = layoutChildSequence(
+      child: leadingChild,
+      axisDirection: constraints.axisDirection,
+      crossAxisDirection: constraints.crossAxisDirection,
+      scrollOffset: constraints.scrollOffset,
+      overlap: constraints.overlap,
+      layoutOffset: -math.min(constraints.overlap, 0.0),
+      remainingPaintExtent: constraints.remainingPaintExtent,
+      mainAxisExtent: constraints.remainingPaintExtent,
+      crossAxisExtent: constraints.crossAxisExtent,
+      userScrollDirection: constraints.userScrollDirection,
+      growthDirection: constraints.growthDirection,
+      advance: advance,
+      remainingCacheExtent: constraints.remainingCacheExtent,
+      cacheOrigin: constraints.cacheOrigin,
+      updateParentGeometry: (geometry) {
+        this.geometry = geometry;
+      },
+    );
+
+    if (scrollOffsetCorrection != 0.0) {
+      geometry = SliverGeometry(scrollOffsetCorrection: scrollOffsetCorrection);
+    }
+
+    final AxisDirection appliedGrowthDirectionToAxisDirection = applyGrowthDirectionToAxisDirection(
+      constraints.axisDirection,
+      constraints.growthDirection,
+    );
+
+    if (appliedGrowthDirectionToAxisDirection == AxisDirection.left ||
+        appliedGrowthDirectionToAxisDirection == AxisDirection.up) {
+      RenderSliver? child = leadingChild;
+      while (child != null) {
+        final childParentData = child.parentData! as SliverPhysicalParentData;
+        childParentData.paintOffset += switch (axisDirectionToAxis(
+          appliedGrowthDirectionToAxisDirection,
+        )) {
+          Axis.horizontal => Offset(geometry!.paintExtent, 0.0),
+          Axis.vertical => Offset(0.0, geometry!.paintExtent),
+        };
+        child = advance(child);
+      }
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) => paintContents(context, offset);
+
+  @override
+  Offset paintOffsetOf(RenderSliver child) {
+    final childParentData = child.parentData! as SliverPhysicalParentData;
+    return childParentData.paintOffset;
+  }
+
+  @override
+  void applyPaintTransform(RenderSliver child, Matrix4 transform) {
+    final childParentData = child.parentData! as SliverPhysicalParentData;
+    childParentData.applyPaintTransform(transform);
+  }
+
+  @override
+  bool hitTestChildren(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    RenderSliver? child = firstChild;
+    while (child != null) {
+      final Offset paintOffset = (child.parentData! as SliverPhysicalParentData).paintOffset;
+      final bool isHit = result.addWithAxisOffset(
+        mainAxisPosition: mainAxisPosition,
+        crossAxisPosition: crossAxisPosition,
+        paintOffset: paintOffset,
+        mainAxisOffset: childMainAxisPosition(child),
+        crossAxisOffset: childCrossAxisPosition(child),
+        hitTest: child.hitTest,
+      );
+      if (isHit) {
+        return true;
+      }
+      child = childAfter(child);
+    }
+    return false;
+  }
+
+  @override
+  RenderSliver? get origin => switch (applyGrowthDirectionToAxisDirection(
+    constraints.axisDirection,
+    constraints.growthDirection,
+  )) {
+    AxisDirection.left || AxisDirection.up => lastChild,
+    AxisDirection.right || AxisDirection.down => firstChild,
+  };
+
+  @override
+  void updateChildLayoutOffset(
+    RenderSliver child,
+    double layoutOffset,
+    GrowthDirection growthDirection,
+  ) {
+    final childParentData = child.parentData! as SliverPhysicalParentData;
+    childParentData.paintOffset = switch (applyGrowthDirectionToAxisDirection(
+      constraints.axisDirection,
+      constraints.growthDirection,
+    )) {
+      AxisDirection.left => Offset(-layoutOffset - child.geometry!.paintExtent, 0.0),
+      AxisDirection.up => Offset(0.0, -layoutOffset - child.geometry!.paintExtent),
+      AxisDirection.right => Offset(layoutOffset, 0.0),
+      AxisDirection.down => Offset(0.0, layoutOffset),
+    };
+  }
+
+  @override
+  bool get ensureSemantics {
+    RenderSliver? child = firstChild;
+    while (child != null) {
+      if (child.ensureSemantics) {
+        return true;
+      }
+      child = childAfter(child);
+    }
+    return false;
+  }
+}

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -409,7 +409,7 @@ class RevealedOffset {
 ///    placed inside a [RenderSliver] (the opposite of this class).
 abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMixin<RenderSliver>>
     extends RenderBox
-    with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>
+    with ContainerRenderObjectMixin<RenderSliver, ParentDataClass>, SliverSequenceMixin
     implements RenderAbstractViewport {
   /// Initializes fields for subclasses.
   ///
@@ -468,18 +468,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     super.describeSemanticsConfiguration(config);
 
     config.addTagForChildren(RenderViewport.useTwoPaneSemantics);
-  }
-
-  @override
-  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
-    childrenInPaintOrder
-        .where(
-          (RenderSliver sliver) =>
-              sliver.geometry!.visible ||
-              sliver.geometry!.cacheExtent > 0.0 ||
-              sliver.ensureSemantics,
-        )
-        .forEach(visitor);
   }
 
   /// The direction in which the [SliverConstraints.scrollOffset] increases.
@@ -644,21 +632,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     markNeedsLayout();
   }
 
-  /// {@template flutter.rendering.RenderViewportBase.paintOrder}
-  /// The order in which to paint the slivers;
-  /// equivalently, the order in which to arrange them in the z-direction.
-  ///
-  /// Whichever order the slivers are painted in,
-  /// they will be hit-tested in the opposite order.
-  ///
-  /// To think of this as an ordering in the z-direction:
-  /// whichever sliver is painted last (and hit-tested first) is on top,
-  /// because it will paint over other slivers if there is overlap.
-  /// Similarly, whichever sliver is painted first (and hit-tested last)
-  /// is on the bottom.
-  /// {@endtemplate}
-  ///
-  /// The default is [SliverPaintOrder.firstIsTop].
+  @override
   SliverPaintOrder get paintOrder => _paintOrder;
   SliverPaintOrder _paintOrder;
   set paintOrder(SliverPaintOrder value) {
@@ -750,137 +724,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
 
   @override
   bool get isRepaintBoundary => true;
-
-  /// Determines the size and position of some of the children of the viewport.
-  ///
-  /// This function is the workhorse of `performLayout` implementations in
-  /// subclasses.
-  ///
-  /// Layout starts with `child`, proceeds according to the `advance` callback,
-  /// and stops once `advance` returns null.
-  ///
-  ///  * `scrollOffset` is the [SliverConstraints.scrollOffset] to pass the
-  ///    first child. The scroll offset is adjusted by
-  ///    [SliverGeometry.scrollExtent] for subsequent children.
-  ///  * `overlap` is the [SliverConstraints.overlap] to pass the first child.
-  ///    The overlay is adjusted by the [SliverGeometry.paintOrigin] and
-  ///    [SliverGeometry.paintExtent] for subsequent children.
-  ///  * `layoutOffset` is the layout offset at which to place the first child.
-  ///    The layout offset is updated by the [SliverGeometry.layoutExtent] for
-  ///    subsequent children.
-  ///  * `remainingPaintExtent` is [SliverConstraints.remainingPaintExtent] to
-  ///    pass the first child. The remaining paint extent is updated by the
-  ///    [SliverGeometry.layoutExtent] for subsequent children.
-  ///  * `mainAxisExtent` is the [SliverConstraints.viewportMainAxisExtent] to
-  ///    pass to each child.
-  ///  * `crossAxisExtent` is the [SliverConstraints.crossAxisExtent] to pass to
-  ///    each child.
-  ///  * `growthDirection` is the [SliverConstraints.growthDirection] to pass to
-  ///    each child.
-  ///
-  /// Returns the first non-zero [SliverGeometry.scrollOffsetCorrection]
-  /// encountered, if any. Otherwise returns 0.0. Typical callers will call this
-  /// function repeatedly until it returns 0.0.
-  @protected
-  double layoutChildSequence({
-    required RenderSliver? child,
-    required double scrollOffset,
-    required double overlap,
-    required double layoutOffset,
-    required double remainingPaintExtent,
-    required double mainAxisExtent,
-    required double crossAxisExtent,
-    required GrowthDirection growthDirection,
-    required RenderSliver? Function(RenderSliver child) advance,
-    required double remainingCacheExtent,
-    required double cacheOrigin,
-  }) {
-    assert(scrollOffset.isFinite);
-    assert(scrollOffset >= 0.0);
-    final initialLayoutOffset = layoutOffset;
-    final ScrollDirection adjustedUserScrollDirection = applyGrowthDirectionToScrollDirection(
-      offset.userScrollDirection,
-      growthDirection,
-    );
-    double maxPaintOffset = layoutOffset + overlap;
-    var precedingScrollExtent = 0.0;
-
-    while (child != null) {
-      final sliverScrollOffset = scrollOffset <= 0.0 ? 0.0 : scrollOffset;
-      // If the scrollOffset is too small we adjust the paddedOrigin because it
-      // doesn't make sense to ask a sliver for content before its scroll
-      // offset.
-      final double correctedCacheOrigin = math.max(cacheOrigin, -sliverScrollOffset);
-      final double cacheExtentCorrection = cacheOrigin - correctedCacheOrigin;
-
-      assert(sliverScrollOffset >= correctedCacheOrigin.abs());
-      assert(correctedCacheOrigin <= 0.0);
-      assert(sliverScrollOffset >= 0.0);
-      assert(cacheExtentCorrection <= 0.0);
-
-      child.layout(
-        SliverConstraints(
-          axisDirection: axisDirection,
-          growthDirection: growthDirection,
-          userScrollDirection: adjustedUserScrollDirection,
-          scrollOffset: sliverScrollOffset,
-          precedingScrollExtent: precedingScrollExtent,
-          overlap: maxPaintOffset - layoutOffset,
-          remainingPaintExtent: math.max(
-            0.0,
-            remainingPaintExtent - layoutOffset + initialLayoutOffset,
-          ),
-          crossAxisExtent: crossAxisExtent,
-          crossAxisDirection: crossAxisDirection,
-          viewportMainAxisExtent: mainAxisExtent,
-          remainingCacheExtent: math.max(0.0, remainingCacheExtent + cacheExtentCorrection),
-          cacheOrigin: correctedCacheOrigin,
-        ),
-        parentUsesSize: true,
-      );
-
-      final SliverGeometry childLayoutGeometry = child.geometry!;
-      assert(childLayoutGeometry.debugAssertIsValid());
-
-      // If there is a correction to apply, we'll have to start over.
-      if (childLayoutGeometry.scrollOffsetCorrection != null) {
-        return childLayoutGeometry.scrollOffsetCorrection!;
-      }
-
-      // We use the child's paint origin in our coordinate system as the
-      // layoutOffset we store in the child's parent data.
-      final double effectiveLayoutOffset = layoutOffset + childLayoutGeometry.paintOrigin;
-
-      // `effectiveLayoutOffset` becomes meaningless once we moved past the trailing edge
-      // because `childLayoutGeometry.layoutExtent` is zero. Using the still increasing
-      // 'scrollOffset` to roughly position these invisible slivers in the right order.
-      if (childLayoutGeometry.visible || scrollOffset > 0) {
-        updateChildLayoutOffset(child, effectiveLayoutOffset, growthDirection);
-      } else {
-        updateChildLayoutOffset(child, -scrollOffset + initialLayoutOffset, growthDirection);
-      }
-
-      maxPaintOffset = math.max(
-        effectiveLayoutOffset + childLayoutGeometry.paintExtent,
-        maxPaintOffset,
-      );
-      scrollOffset -= childLayoutGeometry.scrollExtent;
-      precedingScrollExtent += childLayoutGeometry.scrollExtent;
-      layoutOffset += childLayoutGeometry.layoutExtent;
-      if (childLayoutGeometry.cacheExtent != 0.0) {
-        remainingCacheExtent -= childLayoutGeometry.cacheExtent - cacheExtentCorrection;
-        cacheOrigin = math.min(correctedCacheOrigin + childLayoutGeometry.cacheExtent, 0.0);
-      }
-
-      updateOutOfBandData(growthDirection, childLayoutGeometry);
-
-      // move on to the next child
-      child = advance(child);
-    }
-
-    // we made it without a correction, whee!
-    return 0.0;
-  }
 
   @override
   Rect? describeApproximatePaintClip(RenderSliver child) {
@@ -975,13 +818,13 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
         needsCompositing,
         offset,
         Offset.zero & size,
-        _paintContents,
+        paintContents,
         clipBehavior: clipBehavior,
         oldLayer: _clipRectLayer.layer,
       );
     } else {
       _clipRectLayer.layer = null;
-      _paintContents(context, offset);
+      paintContents(context, offset);
     }
   }
 
@@ -991,14 +834,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   void dispose() {
     _clipRectLayer.layer = null;
     super.dispose();
-  }
-
-  void _paintContents(PaintingContext context, Offset offset) {
-    for (final RenderSliver child in childrenInPaintOrder) {
-      if (child.geometry!.visible) {
-        context.paintChild(child, offset + paintOffsetOf(child));
-      }
-    }
   }
 
   @override
@@ -1298,50 +1133,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   @protected
   bool get hasVisualOverflow;
 
-  /// Called during [layoutChildSequence] for each child.
-  ///
-  /// Typically used by subclasses to update any out-of-band data, such as the
-  /// max scroll extent, for each child.
-  @protected
-  void updateOutOfBandData(GrowthDirection growthDirection, SliverGeometry childLayoutGeometry);
-
-  /// Called during [layoutChildSequence] to store the layout offset for the
-  /// given child.
-  ///
-  /// Different subclasses using different representations for their children's
-  /// layout offset (e.g., logical or physical coordinates). This function lets
-  /// subclasses transform the child's layout offset before storing it in the
-  /// child's parent data.
-  @protected
-  void updateChildLayoutOffset(
-    RenderSliver child,
-    double layoutOffset,
-    GrowthDirection growthDirection,
-  );
-
-  /// The offset at which the given `child` should be painted.
-  ///
-  /// The returned offset is from the top left corner of the inside of the
-  /// viewport to the top left corner of the paint coordinate system of the
-  /// `child`.
-  ///
-  /// See also:
-  ///
-  ///  * [computeAbsolutePaintOffset], which computes the paint offset from an
-  ///    explicit layout offset and growth direction instead of using the values
-  ///    computed for the child during layout.
-  @protected
-  Offset paintOffsetOf(RenderSliver child);
-
-  /// Returns the scroll offset within the viewport for the given
-  /// `scrollOffsetWithinChild` within the given `child`.
-  ///
-  /// The returned value is an estimate that assumes the slivers within the
-  /// viewport do not change the layout extent in response to changes in their
-  /// scroll offset.
-  @protected
-  double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild);
-
   /// Returns the total scroll obstruction extent of all slivers in the viewport
   /// before [child].
   ///
@@ -1382,50 +1173,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   /// Used by [debugDescribeChildren] to label the children.
   @protected
   String labelForChild(int index);
-
-  /// Provides an iterable that walks the children of the viewport, in the order
-  /// that they should be painted.
-  ///
-  /// This should be the reverse order of [childrenInHitTestOrder].
-  @protected
-  Iterable<RenderSliver> get childrenInPaintOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenLastToFirst,
-      SliverPaintOrder.lastIsTop => _childrenFirstToLast,
-    };
-  }
-
-  /// Provides an iterable that walks the children of the viewport, in the order
-  /// that hit-testing should use.
-  ///
-  /// This should be the reverse order of [childrenInPaintOrder].
-  @protected
-  Iterable<RenderSliver> get childrenInHitTestOrder {
-    return switch (paintOrder) {
-      SliverPaintOrder.firstIsTop => _childrenFirstToLast,
-      SliverPaintOrder.lastIsTop => _childrenLastToFirst,
-    };
-  }
-
-  Iterable<RenderSliver> get _childrenLastToFirst {
-    final children = <RenderSliver>[];
-    RenderSliver? child = lastChild;
-    while (child != null) {
-      children.add(child);
-      child = childBefore(child);
-    }
-    return children;
-  }
-
-  Iterable<RenderSliver> get _childrenFirstToLast {
-    final children = <RenderSliver>[];
-    RenderSliver? child = firstChild;
-    while (child != null) {
-      children.add(child);
-      child = childAfter(child);
-    }
-    return children;
-  }
 
   @override
   void showOnScreen({
@@ -1690,6 +1437,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   bool _hasVisualOverflow = false;
 
   @override
+  RenderSliver? get origin => center;
+
+  @override
   void performLayout() {
     // Ignore the return value of applyViewportDimension because we are
     // doing a layout regardless.
@@ -1810,6 +1560,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     if (leadingNegativeChild != null) {
       // negative scroll offsets
       final double result = layoutChildSequence(
+        axisDirection: axisDirection,
+        crossAxisDirection: crossAxisDirection,
+        userScrollDirection: offset.userScrollDirection,
         child: leadingNegativeChild,
         scrollOffset: math.max(mainAxisExtent, centerOffset) - mainAxisExtent,
         overlap: 0.0,
@@ -1829,6 +1582,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
 
     // positive scroll offsets
     return layoutChildSequence(
+      axisDirection: axisDirection,
+      crossAxisDirection: crossAxisDirection,
+      userScrollDirection: offset.userScrollDirection,
       child: center,
       scrollOffset: math.max(0.0, -centerOffset),
       overlap: leadingNegativeChild == null ? math.min(0.0, -centerOffset) : 0.0,
@@ -1878,51 +1634,19 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
   }
 
   @override
-  double scrollOffsetOf(RenderSliver child, double scrollOffsetWithinChild) {
-    assert(child.parent == this);
-    final GrowthDirection growthDirection = child.constraints.growthDirection;
-    switch (growthDirection) {
-      case GrowthDirection.forward:
-        var scrollOffsetToChild = 0.0;
-        RenderSliver? current = center;
-        while (current != child) {
-          scrollOffsetToChild += current!.geometry!.scrollExtent;
-          current = childAfter(current);
-        }
-        return scrollOffsetToChild + scrollOffsetWithinChild;
-      case GrowthDirection.reverse:
-        var scrollOffsetToChild = 0.0;
-        RenderSliver? current = childBefore(center!);
-        while (current != child) {
-          scrollOffsetToChild -= current!.geometry!.scrollExtent;
-          current = childBefore(current);
-        }
-        return scrollOffsetToChild - scrollOffsetWithinChild;
-    }
-  }
-
-  @override
   double maxScrollObstructionExtentBefore(RenderSliver child) {
     assert(child.parent == this);
     final GrowthDirection growthDirection = child.constraints.growthDirection;
-    switch (growthDirection) {
-      case GrowthDirection.forward:
-        var pinnedExtent = 0.0;
-        RenderSliver? current = center;
-        while (current != child) {
-          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
-          current = childAfter(current);
-        }
-        return pinnedExtent;
-      case GrowthDirection.reverse:
-        var pinnedExtent = 0.0;
-        RenderSliver? current = childBefore(center!);
-        while (current != child) {
-          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
-          current = childBefore(current);
-        }
-        return pinnedExtent;
-    }
+    return switch (growthDirection) {
+      GrowthDirection.forward => computeMaxScrollObstructionExtentBefore(
+        child,
+        advance: childAfter,
+      ),
+      GrowthDirection.reverse => computeMaxScrollObstructionExtentBefore(
+        child,
+        advance: childBefore,
+      ),
+    };
   }
 
   @override
@@ -2082,6 +1806,9 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   }
 
   @override
+  RenderSliver? get origin => firstChild;
+
+  @override
   void performLayout() {
     final BoxConstraints constraints = this.constraints;
     if (firstChild == null) {
@@ -2158,6 +1885,9 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     }
 
     return layoutChildSequence(
+      axisDirection: axisDirection,
+      crossAxisDirection: crossAxisDirection,
+      userScrollDirection: offset.userScrollDirection,
       child: firstChild,
       scrollOffset: math.max(0.0, correctedOffset),
       overlap: math.min(0.0, correctedOffset),
@@ -2223,13 +1953,8 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
   double maxScrollObstructionExtentBefore(RenderSliver child) {
     assert(child.parent == this);
     assert(child.constraints.growthDirection == GrowthDirection.forward);
-    var pinnedExtent = 0.0;
-    RenderSliver? current = firstChild;
-    while (current != child) {
-      pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
-      current = childAfter(current);
-    }
-    return pinnedExtent;
+
+    return computeMaxScrollObstructionExtentBefore(child, advance: childAfter);
   }
 
   @override

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -85,7 +85,7 @@ void main() {
     expect(first.constraints.scrollOffset, equals(19 * 300.0));
     expect((second.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(1 * 300.0));
 
-    final RenderSliverMainAxisGroup renderGroup = tester.renderObject<RenderSliverMainAxisGroup>(
+    final RenderSliverUnpinned renderGroup = tester.renderObject<RenderSliverUnpinned>(
       find.byType(SliverMainAxisGroup),
     );
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
@@ -166,7 +166,7 @@ void main() {
     expect(first.constraints.scrollOffset, equals(19 * 300.0));
     expect((second.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
 
-    final RenderSliverMainAxisGroup renderGroup = tester.renderObject<RenderSliverMainAxisGroup>(
+    final RenderSliverUnpinned renderGroup = tester.renderObject<RenderSliverUnpinned>(
       find.byType(SliverMainAxisGroup),
     );
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
@@ -250,7 +250,7 @@ void main() {
     expect(first.constraints.scrollOffset, equals(20 * 300.0));
     expect((second.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
 
-    final RenderSliverMainAxisGroup renderGroup = tester.renderObject<RenderSliverMainAxisGroup>(
+    final RenderSliverUnpinned renderGroup = tester.renderObject<RenderSliverUnpinned>(
       find.byType(SliverMainAxisGroup),
     );
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
@@ -335,7 +335,7 @@ void main() {
     expect(first.constraints.scrollOffset, equals(20 * 300.0));
     expect((second.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
 
-    final RenderSliverMainAxisGroup renderGroup = tester.renderObject<RenderSliverMainAxisGroup>(
+    final RenderSliverUnpinned renderGroup = tester.renderObject<RenderSliverUnpinned>(
       find.byType(SliverMainAxisGroup),
     );
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
@@ -460,8 +460,8 @@ void main() {
     await tester.pumpAndSettle();
 
     final visitedChildren = <RenderSliver>[];
-    final RenderSliverMainAxisGroup renderGroup = tester.renderObject<RenderSliverMainAxisGroup>(
-      find.byType(SliverMainAxisGroup),
+    final RenderNestedSlivers renderGroup = tester.renderObject<RenderNestedSlivers>(
+      find.byType(NestedSlivers),
     );
     void visitor(RenderObject child) {
       visitedChildren.add(child as RenderSliver);
@@ -469,9 +469,9 @@ void main() {
 
     renderGroup.visitChildrenForSemantics(visitor);
     expect(visitedChildren.length, equals(3));
-    expect(visitedChildren[0].geometry!.scrollExtent, equals(300));
+    expect(visitedChildren[0].geometry!.scrollExtent, equals(400));
     expect(visitedChildren[1].geometry!.scrollExtent, equals(500));
-    expect(visitedChildren[2].geometry!.scrollExtent, equals(400));
+    expect(visitedChildren[2].geometry!.scrollExtent, equals(300));
   });
 
   testWidgets('SliverPinnedPersistentHeader is painted within bounds of SliverMainAxisGroup', (
@@ -491,16 +491,18 @@ void main() {
       ),
     );
     final renderGroup =
-        tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+        tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
     // Scroll extent is the total of the box sliver and the sliver persistent header.
     expect(renderGroup.geometry!.scrollExtent, equals(600.0 + 60.0));
+    expect(renderGroup.geometry!.paintOrigin, equals(0.0));
     controller.jumpTo(620);
     await tester.pumpAndSettle();
     final renderHeader =
         tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
     // Paint extent after header's layout is 60.0, so we must offset by -20.0 to fit within the 40.0 remaining extent.
+    expect(renderGroup.geometry!.paintOrigin, equals(-20.0));
     expect(renderHeader.geometry!.paintExtent, equals(60.0));
-    expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-20.0));
+    expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
   });
 
   testWidgets('SliverFloatingPersistentHeader is painted within bounds of SliverMainAxisGroup', (
@@ -521,7 +523,7 @@ void main() {
     );
     await tester.pumpAndSettle();
     final renderGroup =
-        tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+        tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
     expect(renderGroup.geometry!.scrollExtent, equals(660));
     controller.jumpTo(660.0);
     await tester.pumpAndSettle();
@@ -552,15 +554,16 @@ void main() {
         ),
       );
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       final renderHeader =
           tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
       controller.jumpTo(630);
       await tester.pumpAndSettle();
       // Paint extent of the header is 40.0, so we must provide an offset of -10.0 to make it fit in the 30.0 remaining paint extent of the group.
+      expect(renderGroup.geometry!.paintOrigin, equals(-10.0));
       expect(renderHeader.geometry!.paintExtent, equals(40.0));
-      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-10.0));
+      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
       controller.jumpTo(610);
       await tester.pumpAndSettle();
       expect(renderHeader.geometry!.paintExtent, equals(40.0));
@@ -586,7 +589,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       final renderHeader =
           tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
@@ -630,7 +633,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       final renderHeader =
           tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
@@ -642,8 +645,9 @@ void main() {
       await gesture.moveBy(const Offset(0.0, 30.0));
       await tester.pump();
       // Paint extent after header's layout is 40.0, so we need to adjust by -10.0.
+      expect(renderGroup.geometry!.paintOrigin, equals(-10.0));
       expect(renderHeader.geometry!.paintExtent, equals(40.0));
-      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-10.0));
+      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
       // Pinned floating headers should expand to maximum extent as we continue scrolling.
       await gesture.moveBy(const Offset(0.0, 20.0));
       await tester.pump();
@@ -670,7 +674,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
 
       controller.jumpTo(660);
@@ -705,7 +709,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       final renderHeader =
           tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
@@ -718,14 +722,16 @@ void main() {
       await tester.pump();
 
       // The snap animation does not go through until the gesture is released.
+      expect(renderGroup.geometry!.paintOrigin, equals(0.0));
       expect(renderHeader.geometry!.paintExtent, equals(10));
       expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
 
       // Once it is released, the header's paint extent becomes the maximum and the group sets an offset of -50.0.
       await gesture.up();
       await tester.pumpAndSettle();
+      expect(renderGroup.geometry!.paintOrigin, equals(0.0));
       expect(renderHeader.geometry!.paintExtent, equals(60));
-      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-50.0));
+      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
     },
   );
 
@@ -753,7 +759,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       final renderGroup =
-          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverMainAxisGroup;
+          tester.renderObject(find.byType(SliverMainAxisGroup)) as RenderSliverUnpinned;
       final renderHeader =
           tester.renderObject(find.byType(SliverPersistentHeader)) as RenderSliverPersistentHeader;
       expect(renderGroup.geometry!.scrollExtent, equals(660));
@@ -765,14 +771,16 @@ void main() {
       await gesture.moveBy(const Offset(0.0, 10));
       await tester.pump();
 
+      expect(renderGroup.geometry!.paintOrigin, equals(-20.0));
       expect(renderHeader.geometry!.paintExtent, equals(30.0));
-      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-20.0));
+      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
 
       // Once we lift the gesture up, the animation should finish.
       await gesture.up();
       await tester.pumpAndSettle();
+      expect(renderGroup.geometry!.paintOrigin, equals(-20.0));
       expect(renderHeader.geometry!.paintExtent, equals(60.0));
-      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(-50.0));
+      expect((renderHeader.parentData! as SliverPhysicalParentData).paintOffset.dy, equals(0.0));
     },
   );
 
@@ -853,7 +861,7 @@ void main() {
     expect(buildsPerGroup[1], 1); // Second only lays out one child
     expect(buildsPerGroup[2], 1); // Third only lays out one child
     final renderGroup =
-        tester.renderObject(find.byType(SliverMainAxisGroup).first) as RenderSliverMainAxisGroup;
+        tester.renderObject(find.byType(SliverMainAxisGroup).first) as RenderSliverUnpinned;
     expect(renderGroup.geometry!.cacheExtent, 850.0);
   });
 
@@ -1187,7 +1195,7 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/173274
   testWidgets(
-    'In multiple SliverMainAxisGroups, children after a PinnedHeaderSliver do not overscroll.',
+    'In multiple SliverMainAxisGroups, children after a PinnedHeaderSliver do overscroll.',
     (WidgetTester tester) async {
       final controller = ScrollController();
       addTearDown(controller.dispose);
@@ -1229,7 +1237,7 @@ void main() {
       expect(tester.getBottomRight(find.byKey(key)), offset - const Offset(0.0, 10.0));
       controller.jumpTo(90);
       await tester.pumpAndSettle();
-      expect(tester.getBottomRight(find.byKey(key)), offset - const Offset(0.0, 20.0));
+      expect(tester.getBottomRight(find.byKey(key)), offset - const Offset(0.0, 30.0));
     },
   );
 


### PR DESCRIPTION
Related to #178809 and #18345.

This PR explores a new approach by introducing the `NestedSlivers` widget (note: this name is provisional and open to suggestions).

The core characteristic of this widget is that it leverages `ViewportBase`'s `layoutChildSequence` algorithm via a new mixin, `SliverSequenceMixin` (introduced here as a basic version for this POC).

By design, this unifies the construction of multiple nested slivers, offering several key advantages:

* **Robustness:** We benefit from the `Viewport`'s proven and robust algorithm.
* **Consistency & Maintenance:** Any future modifications to the `Viewport`'s behavior regarding slivers will naturally prompt developers to consider applying those changes here as well. This is particularly relevant for issues such as #174369, #175671, and #175760. I also want to highlight `SliverPaintOrder`, which is not currently handled but could be aligned.
* **Simplification:** I was able to significantly simplify the implementation of `SliverMainAxisGroup`. I achieved this by wrapping `NestedSlivers` with a simple "modifier" (`SliverUnpinned`) to readjust the non-persistent header behavior. This adheres to the principle of [aggressive composability](https://docs.flutter.dev/resources/inside-flutter#aggressive-composability). The behavior remains strictly identical to the previous version (verified via `sliver_main_axis_group_test.dart`), but with improved overlap support (fixing a bug related to `SliverAppBar` overscroll).

**master `SliverMainAxisGroup`**

https://github.com/user-attachments/assets/47536308-169f-4a78-adf9-1c3347d101c8


**`SliverMainAxisGroup` with `NesteSlivers` and `SliverUnpinned`**

https://github.com/user-attachments/assets/75e5cdd8-13ac-4611-8165-d08ee4e72633

<details><summary>Code sample overscroll demo</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) => MaterialApp(
    title: 'NestedSlivers Demo',
    theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
    home: const Scaffold(body: NumberList()),
  );
}

class NumberList extends StatelessWidget {
  const NumberList({super.key});

  @override
  Widget build(BuildContext context) => CustomScrollView(
    physics: const BouncingScrollPhysics(),
    slivers: <Widget>[
      SliverMainAxisGroup(
        slivers: [
          SliverAppBar(
            pinned: true,
            stretch: true,
            expandedHeight: 200,
            backgroundColor: Colors.yellow,
            flexibleSpace: FlexibleSpaceBar(title: Text('Coucou')),
          ),
          for (int i = 1; i <= 5; i++)
            SliverMainAxisGroup(
              slivers: <Widget>[
                PinnedHeaderSliver(
                  child: Container(
                    color: Theme.of(context).colorScheme.primaryContainer,
                    padding: const EdgeInsetsGeometry.all(16),
                    child: Text('Group $i', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                  ),
                ),
                SliverList.builder(
                  itemCount: 10,
                  itemBuilder: (BuildContext context, int index) => ListTile(
                    title: Text('Item $index'),
                    leading: CircleAvatar(child: Text('$index')),
                    onTap: () {},
                  ),
                ),
              ],
            ),
        ],
      ),
    ],
  );
}
```

</details>

**Implementation Note:**
Regarding `SliverSequenceMixin`, I debated between extracting it or simply duplicating the `layoutChildSequence` code. Paradoxically, I found the logic more approachable through `NestedSlivers` than through `Viewport`, as the latter requires understanding a much larger set of concepts.

WDYT @Piinks?

Here is the code and a demo:

<details><summary>Code sample full demo</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) => MaterialApp(
    title: 'NestedSlivers Demo',
    theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
    home: const Scaffold(body: NumberList()),
  );
}

class NumberList extends StatelessWidget {
  const NumberList({super.key});

  @override
  Widget build(BuildContext context) => CustomScrollView(
    physics: const BouncingScrollPhysics(),
    slivers: <Widget>[
      MyHeaderSliver(),
      for (int i = 1; i <= 5; i++)
        SliverMainAxisGroup(
          slivers: <Widget>[
            PinnedHeaderSliver(
              child: Container(
                color: Theme.of(context).colorScheme.primaryContainer,
                padding: const EdgeInsetsGeometry.all(16),
                child: Text('Group $i', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
              ),
            ),
            SliverList.builder(
              itemCount: 10,
              itemBuilder: (BuildContext context, int index) => ListTile(
                title: Text('Item $index'),
                leading: CircleAvatar(child: Text('$index')),
                onTap: () {},
              ),
            ),
          ],
        ),
      SliverToBoxAdapter(child: SizedBox(height: MediaQuery.paddingOf(context).bottom)),
    ],
  );
}

class MyHeaderSliver extends StatelessWidget {
  const MyHeaderSliver({super.key});

  @override
  Widget build(BuildContext context) => NestedSlivers(
    slivers: <Widget>[
      SliverAppBar(
        pinned: true,
        stretch: true,
        // floating: true,
        // snap: true,
        expandedHeight: 200,
        backgroundColor: Colors.yellow,
        flexibleSpace: FlexibleSpaceBar(title: Text('My App Bar')),
      ),
      SliverToBoxAdapter(
        child: Container(
          height: 150,
          color: Colors.grey[200],
          alignment: Alignment.center,
          child: const Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              Text('SliverToBoxAdapter', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
              SizedBox(height: 8),
              Text('This content will disappear under the pinned headers'),
            ],
          ),
        ),
      ),
      PinnedHeaderSliver(
        child: Container(
          color: Theme.of(context).colorScheme.tertiaryContainer,
          padding: const EdgeInsetsGeometry.all(16),
          child: Text('My Pinned header', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
        ),
      ),
    ],
  );
}
```

</details>


https://github.com/user-attachments/assets/2ea59070-3acd-401e-85ca-ae63b1b8072a
