### PR TITLE
[flutter_tools] Deprecate `plugin_ffi` template

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -297,6 +297,16 @@ class CreateCommand extends FlutterCommand with CreateBase {
     final String? sampleArgument = stringArg('sample');
     final bool emptyArgument = boolArg('empty');
     final FlutterTemplateType template = _getProjectType(projectDir);
+
+    if (template == FlutterTemplateType.pluginFfi) {
+      globals.printWarning(
+        'The "plugin_ffi" template is deprecated and will be removed in a future '
+        'version of Flutter. Use the "package_ffi" template instead. '
+        'For more information, see: '
+        'https://docs.flutter.dev/platform-integration/bind-native-code',
+      );
+    }
+
     if (sampleArgument != null) {
       if (template != FlutterTemplateType.app) {
         throwToolExit(

--- a/packages/flutter_tools/lib/src/flutter_project_metadata.dart
+++ b/packages/flutter_tools/lib/src/flutter_project_metadata.dart
@@ -109,9 +109,10 @@ enum FlutterTemplateType implements ParsedFlutterTemplateType {
   /// This is an FFI native plugin project.
   pluginFfi(
     helpText:
-        'Generate a shareable Flutter project containing an API '
+        '(deprecated) Generate a shareable Flutter project containing an API '
         'in Dart code with a platform-specific implementation through dart:ffi for Android, iOS, '
-        'Linux, macOS, Windows, or any combination of these.',
+        'Linux, macOS, Windows, or any combination of these. '
+        'Use "package_ffi" instead.',
   );
 
   const FlutterTemplateType({required this.helpText});

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
@@ -281,6 +281,14 @@ void main() {
         ),
       },
     );
+
+    testUsingContext('plugin_ffi template is marked as deprecated in help', () {
+      final command = CreateCommand();
+      final String? templateHelp =
+          command.argParser.options['template']?.allowedHelp?['plugin_ffi'];
+      expect(templateHelp, contains('(deprecated)'));
+      expect(templateHelp, contains('Use "package_ffi" instead.'));
+    });
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -4257,6 +4257,25 @@ void main() {
     );
   });
 
+  testUsingContext('plugin_ffi template shows deprecation warning', () async {
+    final command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--template=plugin_ffi',
+      '--platforms=android',
+      projectDir.path,
+    ]);
+    expect(logger.warningText, contains('The "plugin_ffi" template is deprecated'));
+    expect(logger.warningText, contains('Use the "package_ffi" template instead.'));
+    expect(
+      logger.warningText,
+      contains('https://docs.flutter.dev/platform-integration/bind-native-code'),
+    );
+  }, overrides: {Logger: () => logger});
+
   testUsingContext(
     'should show warning when disabled platforms are selected while creating an FFI plugin',
     () async {


### PR DESCRIPTION
Add deprecation marker to `flutter create --template=plugin_ffi`.

The new way of bundling native code is `flutter create --template=package_ffi`. (Or if the Flutter Plugin API or Android Play components need to be bundled: `flutter create --template=plugin)`

Issue:

* https://github.com/flutter/flutter/issues/131209