### PR TITLE
Fix generating both `settings.gradle` and `settings.gradle.kts` for plugins

### DIFF
--- a/packages/flutter_tools/templates/plugin_shared/android.tmpl/settings.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/android.tmpl/settings.gradle.tmpl
@@ -1,1 +1,0 @@
-rootProject.name = '{{projectName}}'

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -319,7 +319,6 @@
     "templates/plugin_shared/.metadata.tmpl",
     "templates/plugin_shared/analysis_options.yaml.tmpl",
     "templates/plugin_shared/android.tmpl/.gitignore",
-    "templates/plugin_shared/android.tmpl/settings.gradle.tmpl",
     "templates/plugin_shared/android.tmpl/src/main/AndroidManifest.xml.tmpl",
     "templates/plugin_shared/CHANGELOG.md.tmpl",
     "templates/plugin_shared/LICENSE.tmpl",

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2912,7 +2912,6 @@ void main() {
     overrides: {FeatureFlags: () => TestFeatureFlags(), Logger: () => logger},
   );
 
-
   testUsingContext(
     'plugin includes only setting.gradle.kts',
     () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2913,6 +2913,27 @@ void main() {
   );
 
   testUsingContext(
+    'plugin includes only setting.gradle.kts',
+    () async {
+      final command = CreateCommand();
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+
+      await runner.run(<String>[
+        'create',
+        '--no-pub',
+        '--template=plugin',
+        '--org=com.example',
+        '--platforms=android',
+        projectDir.path,
+      ]);
+
+      expect(projectDir.childDirectory('android').childFile('settings.gradle.kts'), exists);
+      expect(projectDir.childDirectory('android').childFile('settings.gradle'), isNot(exists));
+    },
+    overrides: {FeatureFlags: () => TestFeatureFlags(), Logger: () => logger},
+  );
+
+  testUsingContext(
     'plugin includes native Swift unit tests',
     () async {
       final command = CreateCommand();

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2912,9 +2912,11 @@ void main() {
     overrides: {FeatureFlags: () => TestFeatureFlags(), Logger: () => logger},
   );
 
+
   testUsingContext(
     'plugin includes only setting.gradle.kts',
     () async {
+      // Regression test for https://github.com/flutter/flutter/issues/181565.
       final command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 


### PR DESCRIPTION
Fixes #181565
Fixes #142685
this was a side effect from #173993

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
