### PR TITLE
Impeller: avoid blocking on image upload scheduling

### DIFF
--- a/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/image_decoder_impeller.cc
@@ -540,15 +540,15 @@ ImageDecoderImpeller::UnsafeUploadTextureToPrivate(
                        << "GPU Error submitting image decoding command buffer.";
                  }
                },
-               /*block_on_schedule=*/true)
+               /*block_on_schedule=*/false)
            .ok()) {
     std::string decode_error("Failed to submit image decoding command buffer.");
     FML_DLOG(ERROR) << decode_error;
     return std::make_pair(nullptr, decode_error);
   }
 
-  // Flush the pending command buffer to ensure that its output becomes visible
-  // to the raster thread.
+  // Ensure the upload is enqueued before the image is used. Backend-specific
+  // synchronization is handled via tracking fences when available.
   if (context->AddTrackingFence(result_texture)) {
     command_buffer->WaitUntilScheduled();
   } else {


### PR DESCRIPTION
Change:
- In ImageDecoderImpeller::UnsafeUploadTextureToPrivate, submit the image upload command buffer with block_on_schedule=false, while keeping the existing fence-based wait when available.

Why:
- Upload scheduling was synchronously blocking the CPU, inflating UploadTextureToPrivate time and causing jank. The fence already provides correctness for GPU visibility, so we can avoid the schedule wait without changing the upload work itself.

Performance (large_image_changer macrobenchmark, iPhone 14 Pro Max, iOS 26.2, profile mode, Impeller):
- Before: avg build 12.86ms, avg raster 27.73ms, worst raster 397.16ms; UploadTextureToPrivate max 2,731,526µs.
- After:  avg build 0.742ms, avg raster 13.07ms, worst raster 177.14ms; UploadTextureToPrivate max 6,421µs.
- Relative: ~17.3x faster avg build, ~2.1x faster avg raster, ~425x lower UploadTextureToPrivate max.

Benchmark command:
- flutter drive --profile -d <device-id> -t test_driver/large_image_changer.dart --driver test_driver/large_image_changer_test.dart