### PR TITLE
[stable] Fix layout for macOS frameworks for code assets

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -146,18 +146,23 @@ Future<void> copyNativeCodeAssetsMacOS(
     await resourcesDir.create(recursive: true);
     final File dylibFile = versionADir.childFile(name);
     final Link currentLink = versionsDir.childLink('Current');
+    final Directory currentLinkAsDirectory = versionsDir.childDirectory('Current');
+
     await currentLink.create(
       fileSystem.path.relative(versionADir.path, from: currentLink.parent.path),
     );
     final Link resourcesLink = frameworkDir.childLink('Resources');
     await resourcesLink.create(
-      fileSystem.path.relative(resourcesDir.path, from: resourcesLink.parent.path),
+      fileSystem.path.relative(
+        currentLinkAsDirectory.childFile('Resources').path,
+        from: resourcesLink.parent.path,
+      ),
     );
     await lipoDylibs(dylibFile, sources);
     final Link dylibLink = frameworkDir.childLink(name);
     await dylibLink.create(
       fileSystem.path.relative(
-        versionsDir.childDirectory('Current').childFile(name).path,
+        currentLinkAsDirectory.childFile(name).path,
         from: dylibLink.parent.path,
       ),
     );

--- a/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/macos/native_assets_test.dart
@@ -351,6 +351,20 @@ void main() {
           // Multi arch.
           expect(buildRunner.buildInvocations, flutterTester ? 1 : 2);
           expect(buildRunner.linkInvocations, buildMode == BuildMode.release ? 2 : 0);
+
+          if (!flutterTester) {
+            // Not running on the host system, so the code asset has been turned into a framework.
+            final Directory frameworkRoot = fileSystem.directory(
+              '/build/native_assets/macos/bar.framework',
+            );
+
+            // MacOS frameworks use symlinks for versioned content:
+            // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html
+            expect(frameworkRoot.childLink('bar').targetSync(), 'Versions/Current/bar');
+            expect(frameworkRoot.childLink('Resources').targetSync(), 'Versions/Current/Resources');
+
+            expect(frameworkRoot.childLink('Versions/Current').targetSync(), 'A');
+          }
         },
       );
     }


### PR DESCRIPTION
Cherry-pick of #178625 to stable.

## Impacted Users

All Flutter macOS developers using native assets (e.g., `package:objective_c`) who need to distribute their apps via the App Store.

## Impact Description

Apps are rejected by the App Store with error ITMS-90291 due to malformed framework structure. The `Resources` symlink in generated frameworks points to `Versions/A/Resources` instead of `Versions/Current/Resources`, violating Apple's framework specification.

This blocks production app releases - developers cannot ship their macOS apps to the App Store without manual workarounds.

## Workaround

Users must manually fix the symlinks after each build:
```bash
cd YourApp.app/Contents/Frameworks/objective_c.framework
rm Resources
ln -s Versions/Current/Resources Resources
```

## Risk

Low. The change is minimal (7 lines added, 2 removed) and only affects the symlink target path. The fix aligns the code with Apple's documented framework specification.

## Test Coverage

Yes. The original PR #178625 includes tests that verify the symlink targets are correct:
- `frameworkRoot.childLink('bar').targetSync()` equals `'Versions/Current/bar'`
- `frameworkRoot.childLink('Resources').targetSync()` equals `'Versions/Current/Resources'`

## Validation Steps

1. Create a Flutter macOS app that uses native assets (e.g., add `package:objective_c` dependency)
2. Build the app: `flutter build macos --release`
3. Inspect the framework structure in `build/macos/Build/Products/Release/YourApp.app/Contents/Frameworks/`
4. Verify `Resources` symlink points to `Versions/Current/Resources` (not `Versions/A/Resources`)
5. Submit to App Store Connect - should no longer receive ITMS-90291 error

## Related Issues

- Closes #181616
- Original fix: #178625
- Original issue: #178623
- Related dart-lang issue: https://github.com/dart-lang/native/issues/3021