### PR TITLE
Unmark `hybrid_android_views_integration_test` as bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2848,7 +2848,6 @@ targets:
   - name: Linux_mokey hybrid_android_views_integration_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/148085
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
they are passing, see the dashboard

e.g. https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_mokey%20hybrid_android_views_integration_test/18721/overview