### PR TITLE
Disable content sizing

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -94,12 +94,6 @@ public class FlutterImageView extends View implements RenderSurface {
     setAlpha(0.0f);
   }
 
-  /*
-  @Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }*/
-
   private static void logW(String format, Object... args) {
     Log.w(TAG, String.format(Locale.US, format, args));
   }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -94,10 +94,11 @@ public class FlutterImageView extends View implements RenderSurface {
     setAlpha(0.0f);
   }
 
+  /*
   @Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }
+  }*/
 
   private static void logW(String format, Object... args) {
     Log.w(TAG, String.format(Locale.US, format, args));

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -121,11 +121,6 @@ public class FlutterSurfaceView extends SurfaceView implements RenderSurface {
     getHolder().addCallback(surfaceHolderCallbackCompat);
   }
 
-  /*@Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }*/
-
   // This is a work around for TalkBack.
   // If Android decides that our layer is transparent because, e.g. the status-
   // bar is transparent, TalkBack highlighting stops working.

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -121,10 +121,10 @@ public class FlutterSurfaceView extends SurfaceView implements RenderSurface {
     getHolder().addCallback(surfaceHolderCallbackCompat);
   }
 
-  @Override
+  /*@Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }
+  }*/
 
   // This is a work around for TalkBack.
   // If Android decides that our layer is transparent because, e.g. the status-

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -118,10 +118,10 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     setSurfaceTextureListener(surfaceTextureListener);
   }
 
-  @Override
+  /*@Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }
+  }*/
 
   @Nullable
   @Override

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -118,11 +118,6 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     setSurfaceTextureListener(surfaceTextureListener);
   }
 
-  /*@Override
-  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    FlutterMeasureSpec.onMeasure(widthMeasureSpec, heightMeasureSpec, this::setMeasuredDimension);
-  }*/
-
   @Nullable
   @Override
   public FlutterRenderer getAttachedRenderer() {

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -114,6 +114,8 @@ public class FlutterView extends FrameLayout
   private static final String TAG = "FlutterView";
   private static final String GBOARD_PACKAGE_NAME = "com.google.android.inputmethod.latin";
 
+  private static final boolean DISABLE_CONTENT_SIZING = true;
+
   // Boolean that gates if view port metrics should be sent.  When the
   // engine informs the embedder of a resize, it is not necessary to send
   // the viewport metrics back to the engine.
@@ -520,7 +522,7 @@ public class FlutterView extends FrameLayout
     viewportMetrics.width = width;
     viewportMetrics.height = height;
 
-    if (heightMode == MeasureSpec.UNSPECIFIED) {
+    if (!DISABLE_CONTENT_SIZING && heightMode == MeasureSpec.UNSPECIFIED) {
       Log.d(TAG, "FlutterView height is set to wrap content - updating viewport metrics to max");
       viewportMetrics.minHeight = 0;
       viewportMetrics.maxHeight = CONTENT_SIZING_MAX;
@@ -528,7 +530,7 @@ public class FlutterView extends FrameLayout
       viewportMetrics.minHeight = viewportMetrics.height;
       viewportMetrics.maxHeight = viewportMetrics.height;
     }
-    if (widthMode == MeasureSpec.UNSPECIFIED) {
+    if (!DISABLE_CONTENT_SIZING && widthMode == MeasureSpec.UNSPECIFIED) {
       Log.d(TAG, "FlutterView width is set to wrap content - updating viewport metrics to max");
       viewportMetrics.minWidth = 0;
       viewportMetrics.maxWidth = CONTENT_SIZING_MAX;
@@ -537,7 +539,7 @@ public class FlutterView extends FrameLayout
       viewportMetrics.maxWidth = viewportMetrics.width;
     }
 
-    if (shouldSendViewportMetrics.compareAndSet(false, true)) {
+    if (!DISABLE_CONTENT_SIZING && shouldSendViewportMetrics.compareAndSet(false, true)) {
       Log.d(
           TAG,
           "Resize was in response to the engine resizing the view. Not sending viewport metrics.");

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -114,8 +114,6 @@ public class FlutterView extends FrameLayout
   private static final String TAG = "FlutterView";
   private static final String GBOARD_PACKAGE_NAME = "com.google.android.inputmethod.latin";
 
-  private static final boolean DISABLE_CONTENT_SIZING = true;
-
   // Boolean that gates if view port metrics should be sent.  When the
   // engine informs the embedder of a resize, it is not necessary to send
   // the viewport metrics back to the engine.
@@ -521,31 +519,11 @@ public class FlutterView extends FrameLayout
             + height);
     viewportMetrics.width = width;
     viewportMetrics.height = height;
-
-    if (!DISABLE_CONTENT_SIZING && heightMode == MeasureSpec.UNSPECIFIED) {
-      Log.d(TAG, "FlutterView height is set to wrap content - updating viewport metrics to max");
-      viewportMetrics.minHeight = 0;
-      viewportMetrics.maxHeight = CONTENT_SIZING_MAX;
-    } else {
-      viewportMetrics.minHeight = viewportMetrics.height;
-      viewportMetrics.maxHeight = viewportMetrics.height;
-    }
-    if (!DISABLE_CONTENT_SIZING && widthMode == MeasureSpec.UNSPECIFIED) {
-      Log.d(TAG, "FlutterView width is set to wrap content - updating viewport metrics to max");
-      viewportMetrics.minWidth = 0;
-      viewportMetrics.maxWidth = CONTENT_SIZING_MAX;
-    } else {
-      viewportMetrics.minWidth = viewportMetrics.width;
-      viewportMetrics.maxWidth = viewportMetrics.width;
-    }
-
-    if (!DISABLE_CONTENT_SIZING && shouldSendViewportMetrics.compareAndSet(false, true)) {
-      Log.d(
-          TAG,
-          "Resize was in response to the engine resizing the view. Not sending viewport metrics.");
-    } else {
-      sendViewportMetricsToFlutter();
-    }
+    viewportMetrics.minHeight = viewportMetrics.height;
+    viewportMetrics.maxHeight = viewportMetrics.height;
+    viewportMetrics.minWidth = viewportMetrics.width;
+    viewportMetrics.maxWidth = viewportMetrics.width;
+    sendViewportMetricsToFlutter();
   }
 
   @VisibleForTesting()

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -1304,30 +1304,6 @@ public class FlutterViewTest {
   }
 
   @Test
-  public void onMeasure_whenWrapContent_sendsCorrectViewportMetrics() {
-    FlutterSurfaceView flutterSurfaceView = spy(new FlutterSurfaceView(ctx));
-    FlutterView flutterView = new FlutterView(ctx, flutterSurfaceView);
-    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
-    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
-    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
-    flutterView.onMeasure(
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-        View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
-
-    flutterView.onSizeChanged(1, 1, 0, 0);
-    flutterView.attachToFlutterEngine(flutterEngine);
-
-    ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
-        ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
-    verify(flutterRenderer, times(1)).setViewportMetrics(viewportMetricsCaptor.capture());
-    FlutterRenderer.ViewportMetrics metrics = viewportMetricsCaptor.getValue();
-    assertEquals(0, metrics.minWidth);
-    assertEquals(FlutterView.CONTENT_SIZING_MAX, metrics.maxWidth);
-    assertEquals(0, metrics.minHeight);
-    assertEquals(FlutterView.CONTENT_SIZING_MAX, metrics.maxHeight);
-  }
-
-  @Test
   public void resizeEngineView_resizesTheSurfaceView() {
     FlutterSurfaceView flutterSurfaceView = spy(new FlutterSurfaceView(ctx));
     FlutterView flutterView = new FlutterView(ctx, flutterSurfaceView);


### PR DESCRIPTION
Due to https://github.com/flutter/flutter/issues/181573, disable content sizing in this candidate. 

A threading issue may cause the app to crash if the users try to use content sizing. 

Justification for disabling a feature between beta and its promotion to stable: 
* This feature has not be advertised or promoted, yet. 
* This feature has no flag opt in or out it happens on android when the size of the android view is wrap_content. 
* There is a threading issue that crashes the app in some situations.
* Existing android apps may have wrap_content and not know it because the size of the android view was not something flutter considered before.  

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
