### PR TITLE
[Impeller] Ensure that HostBuffers/DeviceBuffers allocated by RendererTest tests are valid for the lifetime of the RenderPass

### DIFF
--- a/engine/src/flutter/impeller/renderer/renderer_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/renderer_unittests.cc
@@ -95,8 +95,8 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
   raw_ptr<const Sampler> sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     static bool wireframe;
     ImGui::Checkbox("Wireframe", &wireframe);
@@ -170,6 +170,7 @@ TEST_P(RendererTest, BabysFirstTriangle) {
   auto vertex_buffer = vertex_buffer_builder.CreateVertexBuffer(
       *context->GetResourceAllocator());
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
     pass.SetPipeline(pipeline);
     pass.SetVertexBuffer(vertex_buffer);
@@ -177,7 +178,6 @@ TEST_P(RendererTest, BabysFirstTriangle) {
     FS::FragInfo frag_info;
     frag_info.time = fml::TimePoint::Now().ToEpochDelta().ToSecondsF();
 
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     FS::BindFragInfo(pass, data_host_buffer->EmplaceUniform(frag_info));
 
     return pass.Draw().ok();
@@ -252,8 +252,8 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
   ASSERT_TRUE(sampler);
 
   Vector3 euler_angles;
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     static Degrees fov_y(60);
     static Scalar distance = 10;
 
@@ -331,8 +331,8 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
   raw_ptr<const Sampler> sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     for (size_t i = 0; i < 1; i++) {
       for (size_t j = 0; j < 1; j++) {
         pass.SetCommandLabel("Box");
@@ -505,9 +505,9 @@ TEST_P(RendererTest, CanRenderInstanced) {
     instances.colors[i] = Color::Random();
   }
 
+  auto [data_host_buffer, indexes_host_buffer] =
+      createHostBuffers(GetContext());
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
-    auto [data_host_buffer, indexes_host_buffer] =
-        createHostBuffers(GetContext());
     pass.SetPipeline(pipeline);
     pass.SetCommandLabel("InstancedDraw");
 
@@ -578,8 +578,8 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   Playground::RenderCallback callback = [&](RenderTarget& render_target) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     auto buffer = context->CreateCommandBuffer();
     if (!buffer) {
       return false;
@@ -693,8 +693,8 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
       vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
   ASSERT_TRUE(vertex_buffer);
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   Playground::RenderCallback callback = [&](RenderTarget& render_target) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     {
       auto buffer = context->CreateCommandBuffer();
       if (!buffer) {
@@ -806,8 +806,8 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
   ASSERT_TRUE(vertex_buffer);
 
   bool first_frame = true;
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   Playground::RenderCallback callback = [&](RenderTarget& render_target) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     const char* mip_filter_names[] = {"Base", "Nearest", "Linear"};
     const MipFilter mip_filters[] = {MipFilter::kBase, MipFilter::kNearest,
                                      MipFilter::kLinear};
@@ -919,8 +919,8 @@ TEST_P(RendererTest, TheImpeller) {
   raw_ptr<const Sampler> cube_map_sampler =
       context->GetSamplerLibrary()->GetSampler({});
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     auto size = pass.GetRenderTargetSize();
 
     pass.SetPipeline(pipeline);
@@ -968,8 +968,8 @@ TEST_P(RendererTest, Planet) {
       context->GetPipelineLibrary()->GetPipeline(pipeline_descriptor).Get();
   ASSERT_TRUE(pipeline && pipeline->IsValid());
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     static Scalar speed = 0.1;
     static Scalar planet_size = 550.0;
     static bool show_normals = false;
@@ -1034,8 +1034,8 @@ TEST_P(RendererTest, ArrayUniforms) {
       context->GetPipelineLibrary()->GetPipeline(pipeline_descriptor).Get();
   ASSERT_TRUE(pipeline && pipeline->IsValid());
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     auto size = pass.GetRenderTargetSize();
 
     pass.SetPipeline(pipeline);
@@ -1092,8 +1092,8 @@ TEST_P(RendererTest, InactiveUniforms) {
       context->GetPipelineLibrary()->GetPipeline(pipeline_descriptor).Get();
   ASSERT_TRUE(pipeline && pipeline->IsValid());
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     auto size = pass.GetRenderTargetSize();
 
     pass.SetPipeline(pipeline);
@@ -1257,8 +1257,8 @@ TEST_P(RendererTest, StencilMask) {
   static int current_back_compare =
       CompareFunctionUI().IndexOf(CompareFunction::kLessEqual);
 
+  auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
   Playground::RenderCallback callback = [&](RenderTarget& render_target) {
-    auto [data_host_buffer, indexes_host_buffer] = createHostBuffers(context);
     auto buffer = context->CreateCommandBuffer();
     if (!buffer) {
       return false;
@@ -1469,11 +1469,10 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
   const auto& sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
 
+  auto buffer = HostBuffer::Create(
+      context->GetResourceAllocator(), context->GetIdleWaiter(),
+      context->GetCapabilities()->GetMinimumUniformAlignment());
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto buffer = HostBuffer::Create(
-        context->GetResourceAllocator(), context->GetIdleWaiter(),
-        context->GetCapabilities()->GetMinimumUniformAlignment());
-
     // Draw the texture.
     {
       pass.SetPipeline(texture_pipeline);
@@ -1564,11 +1563,10 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
   const auto& sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
 
+  auto data_buffer = HostBuffer::Create(
+      context->GetResourceAllocator(), context->GetIdleWaiter(),
+      context->GetCapabilities()->GetMinimumUniformAlignment());
   SinglePassCallback callback = [&](RenderPass& pass) {
-    auto data_buffer = HostBuffer::Create(
-        context->GetResourceAllocator(), context->GetIdleWaiter(),
-        context->GetCapabilities()->GetMinimumUniformAlignment());
-
     // Draw the texture.
     {
       pass.SetPipeline(texture_pipeline);


### PR DESCRIPTION
RenderPass holds a list of BufferViews that may hold raw pointers to DeviceBuffers.  HostBuffers and the underlying DeviceBuffers must not be deleted until the RenderPass is no longer using them.

See https://github.com/flutter/flutter/issues/181287