### PR TITLE
Marks platform_views_scroll_perf_impeller__timeline_summary unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3254,7 +3254,6 @@ targets:
       task_name: platform_views_scroll_perf_impeller__timeline_summary
 
   - name: Linux_pixel_7pro platform_views_scroll_perf_impeller__timeline_summary
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/172210
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
[Last 50 commits were unflaky.](https://data.corp.google.com/sites/dash_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Linux_pixel_7pro%20platform_views_scroll_perf_impeller__timeline_summary%22)

Previous flakes were infra issues "devices not found", which should be resolved separately.
Fixes https://github.com/flutter/flutter/issues/172210.

