### PR TITLE
Enforce Swift 6 strict concurrency during Swift compilation

### DIFF
--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -76,6 +76,6 @@ config("compiler") {
     "-swift-version",
     _swift_version,
     "-strict-concurrency",
-    "complete",
+    "targeted",
   ]
 }

--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -75,5 +75,6 @@ config("compiler") {
     _target_triplet,
     "-swift-version",
     _swift_version,
+    "-strict-concurrency=complete",
   ]
 }

--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -75,6 +75,8 @@ config("compiler") {
     _target_triplet,
     "-swift-version",
     _swift_version,
-    "-strict-concurrency=complete",
+    "-warnings-as-errors",
+    "-strict-concurrency",
+    "targeted",
   ]
 }

--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -76,6 +76,6 @@ config("compiler") {
     "-swift-version",
     _swift_version,
     "-strict-concurrency",
-    "targeted",
+    "complete",
   ]
 }

--- a/engine/src/build/config/darwin/BUILD.gn
+++ b/engine/src/build/config/darwin/BUILD.gn
@@ -75,7 +75,6 @@ config("compiler") {
     _target_triplet,
     "-swift-version",
     _swift_version,
-    "-warnings-as-errors",
     "-strict-concurrency",
     "targeted",
   ]

--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -387,6 +387,7 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map):
       '-save-temps',
       '-no-color-diagnostics',
       '-serialize-diagnostics',
+      '-strict-concurrency=complete',
       '-emit-dependencies',
       '-emit-module',
       '-emit-module-path',

--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -381,13 +381,14 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map):
       args.target_triple,
       '-swift-version',
       args.swift_version,
+      '-strict-concurrency',
+      args.strict_concurrency,
       '-c',
       '-output-file-map',
       output_file_map,
       '-save-temps',
       '-no-color-diagnostics',
       '-serialize-diagnostics',
-      '-strict-concurrency=complete',
       '-emit-dependencies',
       '-emit-module',
       '-emit-module-path',
@@ -646,6 +647,10 @@ def main(args):
   parser.add_argument('-swift-version',
                       default='5',
                       help='version of the Swift language')
+
+  parser.add_argument('-strict-concurrency',
+                      default='complete',
+                      help='concurrency checking strictness')
 
   parser.add_argument(
       '-file-prefix-map',

--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -381,11 +381,12 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map):
       args.target_triple,
       '-swift-version',
       args.swift_version,
-      '-strict-concurrency',
-      args.strict_concurrency,
+      # -strict-concurrency must be a single string joined by an equals.
+      f'-strict-concurrency={args.strict_concurrency}',
       '-c',
       '-output-file-map',
       output_file_map,
+      '-warnings-as-errors',
       '-save-temps',
       '-no-color-diagnostics',
       '-serialize-diagnostics',
@@ -619,11 +620,6 @@ def main(args):
                       help='path to the iOS SDK')
 
   # Optional arguments (forwarded to the Swift compiler).
-  parser.add_argument('-warnings-as-errors',
-                      default=False,
-                      action='store_true',
-                      help='treat warnings as errors')
-
   parser.add_argument('-I',
                       action='append',
                       dest='include_dirs',

--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -619,6 +619,11 @@ def main(args):
                       help='path to the iOS SDK')
 
   # Optional arguments (forwarded to the Swift compiler).
+  parser.add_argument('-warnings-as-errors',
+                      default=False,
+                      action='store_true',
+                      help='treat warnings as errors')
+
   parser.add_argument('-I',
                       action='append',
                       dest='include_dirs',

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -19,7 +19,7 @@ config("config") {
 
   # Allow use of @testable imports in debug builds and when tests are enabled.
   if ((is_ios && enable_ios_unittests) || (is_mac && enable_unittests)) {
-    swiftflags = [ "-enable-testing" ]
+    swiftflags += [ "-enable-testing" ]
   }
 }
 
@@ -38,7 +38,7 @@ config("test_config") {
     ldflags = [ "-mmacosx-version-min=$mac_testing_deployment_target" ]
   }
   cflags += [ "-F$_platform_path/Developer/Library/Frameworks" ]
-  swiftflags = [ "-F$_platform_path/Developer/Library/Frameworks" ]
+  swiftflags += [ "-F$_platform_path/Developer/Library/Frameworks" ]
   include_dirs = [ "$_platform_path/Developer/usr/lib" ]
   framework_dirs = [ "$_platform_path/Developer/Library/Frameworks" ]
   lib_dirs = [ "$_platform_path/Developer/usr/lib" ]

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -19,7 +19,7 @@ config("config") {
 
   # Allow use of @testable imports in debug builds and when tests are enabled.
   if ((is_ios && enable_ios_unittests) || (is_mac && enable_unittests)) {
-    swiftflags += [ "-enable-testing" ]
+    swiftflags = [ "-enable-testing" ]
   }
 }
 
@@ -38,7 +38,7 @@ config("test_config") {
     ldflags = [ "-mmacosx-version-min=$mac_testing_deployment_target" ]
   }
   cflags += [ "-F$_platform_path/Developer/Library/Frameworks" ]
-  swiftflags += [ "-F$_platform_path/Developer/Library/Frameworks" ]
+  swiftflags = [ "-F$_platform_path/Developer/Library/Frameworks" ]
   include_dirs = [ "$_platform_path/Developer/usr/lib" ]
   framework_dirs = [ "$_platform_path/Developer/Library/Frameworks" ]
   lib_dirs = [ "$_platform_path/Developer/usr/lib" ]


### PR DESCRIPTION
Enforce Swift 6 strict concurrency during swift compilation to catch thread checker and other main actor errors and regressions as we migrate the engine to Swift 6 https://github.com/flutter/flutter/issues/181684

See https://www.swift.org/documentation/concurrency.

This only enforces for our few Swift files, not Objective-C headers being called from Swift.