### PR TITLE
Remove Material library dependency from expansible_test.dart

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -156,7 +156,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/slivers_padding_test.dart',
     'packages/flutter/test/widgets/sliver_constraints_test.dart',
     'packages/flutter/test/widgets/autocomplete_test.dart',
-    'packages/flutter/test/widgets/expansible_test.dart',
     'packages/flutter/test/widgets/decorated_sliver_test.dart',
     'packages/flutter/test/widgets/shape_decoration_test.dart',
     'packages/flutter/test/widgets/run_app_test.dart',

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -4,27 +4,20 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-Future<void> pumpTestWidget(WidgetTester tester, Widget child) {
-  return tester.pumpWidget(
-    WidgetsApp(
-      builder: (BuildContext context, Widget? navigator) => child,
-      color: const Color(0xffffffff),
-    ),
-  );
-}
+import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Controller expands and collapses the widget', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -48,14 +41,15 @@ void main() {
       expansionState = controller.isExpanded;
     });
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -84,21 +78,23 @@ void main() {
   testWidgets('Can set expansible to be initially expanded', (WidgetTester tester) async {
     final controller = ExpansibleController();
     controller.expand();
-    await pumpTestWidget(
-      tester,
-      SingleChildScrollView(
-        child: Column(
-          children: <Widget>[
-            Expansible(
-              controller: controller,
-              bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                  const Text('Body'),
-              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-                onTap: controller.isExpanded ? controller.collapse : controller.expand,
-                child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              Expansible(
+                controller: controller,
+                bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                    const Text('Body'),
+                headerBuilder: (BuildContext context, Animation<double> animation) =>
+                    GestureDetector(
+                      onTap: controller.isExpanded ? controller.collapse : controller.expand,
+                      child: const Text('Header'),
+                    ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -115,19 +111,20 @@ void main() {
 
   testWidgets('Can compose header and body with expansibleBuilder', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
+          expansibleBuilder:
+              (BuildContext context, Widget header, Widget body, Animation<double> animation) {
+                return header;
+              },
         ),
-        expansibleBuilder:
-            (BuildContext context, Widget header, Widget body, Animation<double> animation) {
-              return header;
-            },
       ),
     );
 
@@ -159,31 +156,34 @@ void main() {
   testWidgets('Respects maintainState', (WidgetTester tester) async {
     final controller1 = ExpansibleController();
     final controller2 = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      SingleChildScrollView(
-        child: Column(
-          children: <Widget>[
-            Expansible(
-              controller: controller1,
-              maintainState: false,
-              bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                  const Text('Maintaining State'),
-              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-                onTap: controller1.isExpanded ? controller1.collapse : controller1.expand,
-                child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              Expansible(
+                controller: controller1,
+                maintainState: false,
+                bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                    const Text('Maintaining State'),
+                headerBuilder: (BuildContext context, Animation<double> animation) =>
+                    GestureDetector(
+                      onTap: controller1.isExpanded ? controller1.collapse : controller1.expand,
+                      child: const Text('Header'),
+                    ),
               ),
-            ),
-            Expansible(
-              controller: controller2,
-              bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                  const Text('Discarding State'),
-              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-                onTap: controller2.isExpanded ? controller2.collapse : controller2.expand,
-                child: const Text('Header'),
+              Expansible(
+                controller: controller2,
+                bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                    const Text('Discarding State'),
+                headerBuilder: (BuildContext context, Animation<double> animation) =>
+                    GestureDetector(
+                      onTap: controller2.isExpanded ? controller2.collapse : controller2.expand,
+                      child: const Text('Header'),
+                    ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -200,18 +200,19 @@ void main() {
 
   testWidgets('Respects animation duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        duration: const Duration(milliseconds: 120),
-        curve: Curves.easeOut,
-        reverseCurve: Curves.easeIn,
-        bodyBuilder: (BuildContext context, Animation<double> animation) =>
-            const SizedBox(height: 50.0, child: Placeholder()),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+          reverseCurve: Curves.easeIn,
+          bodyBuilder: (BuildContext context, Animation<double> animation) =>
+              const SizedBox(height: 50.0, child: Placeholder()),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -256,12 +257,13 @@ void main() {
       controller2.dispose();
     });
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller1,
-        headerBuilder: (_, _) => const Text('Header'),
-        bodyBuilder: (_, _) => const Text('Body'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller1,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
+        ),
       ),
     );
 
@@ -278,12 +280,13 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsNothing);
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller2,
-        headerBuilder: (_, _) => const Text('Header'),
-        bodyBuilder: (_, _) => const Text('Body'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller2,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
+        ),
       ),
     );
 
@@ -311,12 +314,13 @@ void main() {
       controller2.dispose();
     });
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller1,
-        headerBuilder: (_, _) => const Text('Header'),
-        bodyBuilder: (_, _) => const Text('Body'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller1,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
+        ),
       ),
     );
 
@@ -328,12 +332,13 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsOne);
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller2,
-        headerBuilder: (_, _) => const Text('Header'),
-        bodyBuilder: (_, _) => const Text('Body'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller2,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -354,20 +359,21 @@ void main() {
 
   testWidgets('Respects animationStyle duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        animationStyle: const AnimationStyle(
-          duration: Duration(milliseconds: 120),
-          curve: Curves.easeOut,
-          reverseCurve: Curves.easeIn,
-        ),
-        bodyBuilder: (BuildContext context, Animation<double> animation) =>
-            const SizedBox(height: 50.0, child: Placeholder()),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          animationStyle: const AnimationStyle(
+            duration: Duration(milliseconds: 120),
+            curve: Curves.easeOut,
+            reverseCurve: Curves.easeIn,
+          ),
+          bodyBuilder: (BuildContext context, Animation<double> animation) =>
+              const SizedBox(height: 50.0, child: Placeholder()),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -408,19 +414,20 @@ void main() {
     WidgetTester tester,
   ) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        animationStyle: const AnimationStyle(
-          duration: Duration(milliseconds: 100),
-          curve: Curves.linear,
-        ),
-        bodyBuilder: (BuildContext context, Animation<double> animation) =>
-            const SizedBox(height: 50.0, child: Placeholder()),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          animationStyle: const AnimationStyle(
+            duration: Duration(milliseconds: 100),
+            curve: Curves.linear,
+          ),
+          bodyBuilder: (BuildContext context, Animation<double> animation) =>
+              const SizedBox(height: 50.0, child: Placeholder()),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -447,15 +454,16 @@ void main() {
 
   testWidgets('AnimationStyle.noAnimation disables animation', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        animationStyle: AnimationStyle.noAnimation,
-        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-          onTap: controller.isExpanded ? controller.collapse : controller.expand,
-          child: const Text('Header'),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          animationStyle: AnimationStyle.noAnimation,
+          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+            onTap: controller.isExpanded ? controller.collapse : controller.expand,
+            child: const Text('Header'),
+          ),
         ),
       ),
     );
@@ -501,13 +509,14 @@ void main() {
     final controller = ExpansibleController();
     addTearDown(controller.dispose);
 
-    await pumpTestWidget(
-      tester,
-      Expansible(
-        controller: controller,
-        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-        headerBuilder: (BuildContext context, Animation<double> animation) =>
-            GestureDetector(onTap: controller.toggle, child: const Text('Header')),
+    await tester.pumpWidget(
+      TestWidgetsApp(
+        home: Expansible(
+          controller: controller,
+          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+          headerBuilder: (BuildContext context, Animation<double> animation) =>
+              GestureDetector(onTap: controller.toggle, child: const Text('Header')),
+        ),
       ),
     );
 

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -5,20 +5,27 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+Future<void> pumpTestWidget(WidgetTester tester, Widget child) {
+  return tester.pumpWidget(
+    WidgetsApp(
+      builder: (BuildContext context, Widget? navigator) => child,
+      color: const Color(0xffffffff),
+    ),
+  );
+}
+
 void main() {
   testWidgets('Controller expands and collapses the widget', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -41,17 +48,15 @@ void main() {
       expansionState = controller.isExpanded;
     });
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -79,25 +84,22 @@ void main() {
   testWidgets('Can set expansible to be initially expanded', (WidgetTester tester) async {
     final controller = ExpansibleController();
     controller.expand();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              Expansible(
-                controller: controller,
-                bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                    const Text('Body'),
-                headerBuilder: (BuildContext context, Animation<double> animation) =>
-                    GestureDetector(
-                      onTap: controller.isExpanded ? controller.collapse : controller.expand,
-                      child: const Text('Header'),
-                    ),
+    await pumpTestWidget(
+      tester,
+      SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            Expansible(
+              controller: controller,
+              bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                  const Text('Body'),
+              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+                onTap: controller.isExpanded ? controller.collapse : controller.expand,
+                child: const Text('Header'),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -113,21 +115,19 @@ void main() {
 
   testWidgets('Can compose header and body with expansibleBuilder', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
-          expansibleBuilder:
-              (BuildContext context, Widget header, Widget body, Animation<double> animation) {
-                return header;
-              },
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
         ),
-        color: const Color(0xffffffff),
+        expansibleBuilder:
+            (BuildContext context, Widget header, Widget body, Animation<double> animation) {
+              return header;
+            },
       ),
     );
 
@@ -159,36 +159,32 @@ void main() {
   testWidgets('Respects maintainState', (WidgetTester tester) async {
     final controller1 = ExpansibleController();
     final controller2 = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              Expansible(
-                controller: controller1,
-                maintainState: false,
-                bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                    const Text('Maintaining State'),
-                headerBuilder: (BuildContext context, Animation<double> animation) =>
-                    GestureDetector(
-                      onTap: controller1.isExpanded ? controller1.collapse : controller1.expand,
-                      child: const Text('Header'),
-                    ),
+    await pumpTestWidget(
+      tester,
+      SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            Expansible(
+              controller: controller1,
+              maintainState: false,
+              bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                  const Text('Maintaining State'),
+              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+                onTap: controller1.isExpanded ? controller1.collapse : controller1.expand,
+                child: const Text('Header'),
               ),
-              Expansible(
-                controller: controller2,
-                bodyBuilder: (BuildContext context, Animation<double> animation) =>
-                    const Text('Discarding State'),
-                headerBuilder: (BuildContext context, Animation<double> animation) =>
-                    GestureDetector(
-                      onTap: controller2.isExpanded ? controller2.collapse : controller2.expand,
-                      child: const Text('Header'),
-                    ),
+            ),
+            Expansible(
+              controller: controller2,
+              bodyBuilder: (BuildContext context, Animation<double> animation) =>
+                  const Text('Discarding State'),
+              headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+                onTap: controller2.isExpanded ? controller2.collapse : controller2.expand,
+                child: const Text('Header'),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -204,21 +200,19 @@ void main() {
 
   testWidgets('Respects animation duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          duration: const Duration(milliseconds: 120),
-          curve: Curves.easeOut,
-          reverseCurve: Curves.easeIn,
-          bodyBuilder: (BuildContext context, Animation<double> animation) =>
-              const SizedBox(height: 50.0, child: Placeholder()),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        duration: const Duration(milliseconds: 120),
+        curve: Curves.easeOut,
+        reverseCurve: Curves.easeIn,
+        bodyBuilder: (BuildContext context, Animation<double> animation) =>
+            const SizedBox(height: 50.0, child: Placeholder()),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -262,14 +256,12 @@ void main() {
       controller2.dispose();
     });
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller1,
-          headerBuilder: (_, _) => const Text('Header'),
-          bodyBuilder: (_, _) => const Text('Body'),
-        ),
-        color: const Color(0xffffffff),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller1,
+        headerBuilder: (_, _) => const Text('Header'),
+        bodyBuilder: (_, _) => const Text('Body'),
       ),
     );
 
@@ -286,14 +278,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsNothing);
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller2,
-          headerBuilder: (_, _) => const Text('Header'),
-          bodyBuilder: (_, _) => const Text('Body'),
-        ),
-        color: const Color(0xffffffff),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller2,
+        headerBuilder: (_, _) => const Text('Header'),
+        bodyBuilder: (_, _) => const Text('Body'),
       ),
     );
 
@@ -321,14 +311,12 @@ void main() {
       controller2.dispose();
     });
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller1,
-          headerBuilder: (_, _) => const Text('Header'),
-          bodyBuilder: (_, _) => const Text('Body'),
-        ),
-        color: const Color(0xffffffff),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller1,
+        headerBuilder: (_, _) => const Text('Header'),
+        bodyBuilder: (_, _) => const Text('Body'),
       ),
     );
 
@@ -340,14 +328,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Body'), findsOne);
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller2,
-          headerBuilder: (_, _) => const Text('Header'),
-          bodyBuilder: (_, _) => const Text('Body'),
-        ),
-        color: const Color(0xffffffff),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller2,
+        headerBuilder: (_, _) => const Text('Header'),
+        bodyBuilder: (_, _) => const Text('Body'),
       ),
     );
     await tester.pumpAndSettle();
@@ -368,23 +354,21 @@ void main() {
 
   testWidgets('Respects animationStyle duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          animationStyle: const AnimationStyle(
-            duration: Duration(milliseconds: 120),
-            curve: Curves.easeOut,
-            reverseCurve: Curves.easeIn,
-          ),
-          bodyBuilder: (BuildContext context, Animation<double> animation) =>
-              const SizedBox(height: 50.0, child: Placeholder()),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        animationStyle: const AnimationStyle(
+          duration: Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+          reverseCurve: Curves.easeIn,
         ),
-        color: const Color(0xffffffff),
+        bodyBuilder: (BuildContext context, Animation<double> animation) =>
+            const SizedBox(height: 50.0, child: Placeholder()),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
+        ),
       ),
     );
 
@@ -424,22 +408,20 @@ void main() {
     WidgetTester tester,
   ) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          animationStyle: const AnimationStyle(
-            duration: Duration(milliseconds: 100),
-            curve: Curves.linear,
-          ),
-          bodyBuilder: (BuildContext context, Animation<double> animation) =>
-              const SizedBox(height: 50.0, child: Placeholder()),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        animationStyle: const AnimationStyle(
+          duration: Duration(milliseconds: 100),
+          curve: Curves.linear,
         ),
-        color: const Color(0xffffffff),
+        bodyBuilder: (BuildContext context, Animation<double> animation) =>
+            const SizedBox(height: 50.0, child: Placeholder()),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
+        ),
       ),
     );
 
@@ -465,18 +447,16 @@ void main() {
 
   testWidgets('AnimationStyle.noAnimation disables animation', (WidgetTester tester) async {
     final controller = ExpansibleController();
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          animationStyle: AnimationStyle.noAnimation,
-          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-          headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
-            onTap: controller.isExpanded ? controller.collapse : controller.expand,
-            child: const Text('Header'),
-          ),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        animationStyle: AnimationStyle.noAnimation,
+        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+        headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
+          onTap: controller.isExpanded ? controller.collapse : controller.expand,
+          child: const Text('Header'),
         ),
-        color: const Color(0xffffffff),
       ),
     );
 
@@ -521,15 +501,13 @@ void main() {
     final controller = ExpansibleController();
     addTearDown(controller.dispose);
 
-    await tester.pumpWidget(
-      WidgetsApp(
-        builder: (context, child) => Expansible(
-          controller: controller,
-          bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
-          headerBuilder: (BuildContext context, Animation<double> animation) =>
-              GestureDetector(onTap: controller.toggle, child: const Text('Header')),
-        ),
-        color: const Color(0xffffffff),
+    await pumpTestWidget(
+      tester,
+      Expansible(
+        controller: controller,
+        bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
+        headerBuilder: (BuildContext context, Animation<double> animation) =>
+            GestureDetector(onTap: controller.toggle, child: const Text('Header')),
       ),
     );
 

--- a/packages/flutter/test/widgets/expansible_test.dart
+++ b/packages/flutter/test/widgets/expansible_test.dart
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Controller expands and collapses the widget', (WidgetTester tester) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
           headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
@@ -18,6 +18,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -41,8 +42,8 @@ void main() {
     });
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
           headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
@@ -50,6 +51,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -78,8 +80,8 @@ void main() {
     final controller = ExpansibleController();
     controller.expand();
     await tester.pumpWidget(
-      MaterialApp(
-        home: SingleChildScrollView(
+      WidgetsApp(
+        builder: (context, child) => SingleChildScrollView(
           child: Column(
             children: <Widget>[
               Expansible(
@@ -95,6 +97,7 @@ void main() {
             ],
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -111,8 +114,8 @@ void main() {
   testWidgets('Can compose header and body with expansibleBuilder', (WidgetTester tester) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
           headerBuilder: (BuildContext context, Animation<double> animation) => GestureDetector(
@@ -124,6 +127,7 @@ void main() {
                 return header;
               },
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -156,8 +160,8 @@ void main() {
     final controller1 = ExpansibleController();
     final controller2 = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: SingleChildScrollView(
+      WidgetsApp(
+        builder: (context, child) => SingleChildScrollView(
           child: Column(
             children: <Widget>[
               Expansible(
@@ -184,6 +188,7 @@ void main() {
             ],
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -200,8 +205,8 @@ void main() {
   testWidgets('Respects animation duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           duration: const Duration(milliseconds: 120),
           curve: Curves.easeOut,
@@ -213,6 +218,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -223,15 +229,15 @@ void main() {
     // Check that the curve is respected.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 90.08984375);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 56.08984375);
 
     // The animation has completed.
     await tester.pump(const Duration(milliseconds: 60) + const Duration(microseconds: 1));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 98.0);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 64.0);
 
     // Since the animation has completed, the vertical position doesn't change.
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 98.0);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 64.0);
 
     await tester.pumpAndSettle();
     await tester.tap(find.text('Header'));
@@ -239,7 +245,7 @@ void main() {
     // Check that the reverse curve is respected.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 80.91015625);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 46.91015625);
 
     // The animation has completed.
     await tester.pump(const Duration(milliseconds: 60) + const Duration(microseconds: 1));
@@ -257,14 +263,13 @@ void main() {
     });
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Expansible(
-            controller: controller1,
-            headerBuilder: (_, _) => const Text('Header'),
-            bodyBuilder: (_, _) => const Text('Body'),
-          ),
+      WidgetsApp(
+        builder: (context, child) => Expansible(
+          controller: controller1,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -282,14 +287,13 @@ void main() {
     expect(find.text('Body'), findsNothing);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Expansible(
-            controller: controller2,
-            headerBuilder: (_, _) => const Text('Header'),
-            bodyBuilder: (_, _) => const Text('Body'),
-          ),
+      WidgetsApp(
+        builder: (context, child) => Expansible(
+          controller: controller2,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -318,14 +322,13 @@ void main() {
     });
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Expansible(
-            controller: controller1,
-            headerBuilder: (_, _) => const Text('Header'),
-            bodyBuilder: (_, _) => const Text('Body'),
-          ),
+      WidgetsApp(
+        builder: (context, child) => Expansible(
+          controller: controller1,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -338,14 +341,13 @@ void main() {
     expect(find.text('Body'), findsOne);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Expansible(
-            controller: controller2,
-            headerBuilder: (_, _) => const Text('Header'),
-            bodyBuilder: (_, _) => const Text('Body'),
-          ),
+      WidgetsApp(
+        builder: (context, child) => Expansible(
+          controller: controller2,
+          headerBuilder: (_, _) => const Text('Header'),
+          bodyBuilder: (_, _) => const Text('Body'),
         ),
+        color: const Color(0xffffffff),
       ),
     );
     await tester.pumpAndSettle();
@@ -367,8 +369,8 @@ void main() {
   testWidgets('Respects animationStyle duration and curves', (WidgetTester tester) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           animationStyle: const AnimationStyle(
             duration: Duration(milliseconds: 120),
@@ -382,6 +384,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -392,15 +395,15 @@ void main() {
     // Check that the curve is respected.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 90.08984375);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 56.08984375);
 
     // The animation has completed.
     await tester.pump(const Duration(milliseconds: 60) + const Duration(microseconds: 1));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 98.0);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 64.0);
 
     // Since the animation has completed, the vertical position doesn't change.
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 98.0);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 64.0);
 
     await tester.pumpAndSettle();
     await tester.tap(find.text('Header'));
@@ -408,7 +411,7 @@ void main() {
     // Check that the reverse curve is respected.
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 80.91015625);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 46.91015625);
 
     // The animation has completed.
     await tester.pump(const Duration(milliseconds: 60) + const Duration(microseconds: 1));
@@ -422,8 +425,8 @@ void main() {
   ) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           animationStyle: const AnimationStyle(
             duration: Duration(milliseconds: 100),
@@ -436,6 +439,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -448,13 +452,13 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
     // With linear curve at 50ms out of 100ms, should be at approximately 50% height
     final double midAnimationY = tester.getBottomLeft(find.byType(Placeholder)).dy;
-    // Should be more than base (48.0) and less than fully expanded (98.0)
-    expect(midAnimationY, greaterThan(48.0));
-    expect(midAnimationY, lessThan(98.0));
+    // Should be more than base (14.0) and less than fully expanded (64.0)
+    expect(midAnimationY, greaterThan(14.0));
+    expect(midAnimationY, lessThan(64.0));
 
     // Animation should complete at 100ms
     await tester.pump(const Duration(milliseconds: 50) + const Duration(microseconds: 1));
-    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 98.0);
+    expect(tester.getBottomLeft(find.byType(Placeholder)).dy, 64.0);
 
     controller.dispose();
   });
@@ -462,8 +466,8 @@ void main() {
   testWidgets('AnimationStyle.noAnimation disables animation', (WidgetTester tester) async {
     final controller = ExpansibleController();
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           animationStyle: AnimationStyle.noAnimation,
           bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
@@ -472,6 +476,7 @@ void main() {
             child: const Text('Header'),
           ),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 
@@ -517,13 +522,14 @@ void main() {
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: Expansible(
+      WidgetsApp(
+        builder: (context, child) => Expansible(
           controller: controller,
           bodyBuilder: (BuildContext context, Animation<double> animation) => const Text('Body'),
           headerBuilder: (BuildContext context, Animation<double> animation) =>
               GestureDetector(onTap: controller.toggle, child: const Text('Header')),
         ),
+        color: const Color(0xffffffff),
       ),
     );
 


### PR DESCRIPTION
This PR removes the unnecessary dependency on the Material library from expansible_test.dart by replacing `MaterialApp` with `WidgetsApp`.

Part of #177415

### Changes

1. **Import change**: Replaced `package:flutter/material.dart` with `package:flutter/widgets.dart`

2. **Widget setup**: Changed from `MaterialApp(home: ...)` to `TestWidgetsApp(home: ...)` 
   - `WidgetsApp` requires either `builder`, `onGenerateRoute`, or `pageRouteBuilder` to be provided 
   If neither builder nor onGenerateRoute are provided, the pageRouteBuilder must be specified so that the default handler will know what kind of PageRoute transition to build.

3. **Updated position assertions**: Since `WidgetsApp` with `builder` doesn't include the default scaffold/status bar padding that `MaterialApp` with `home` provides, the expected y-coordinate values were adjusted by -34 pixels:
   - `90.08984375` → `56.08984375`
   - `98.0` → `64.0`
   - `80.91015625` → `46.91015625`
   - `48.0` → `14.0`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
