### PR TITLE
Fix(Material): DateRangePicker ignores DatePickerTheme.dayShape

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2901,8 +2901,8 @@ class _DayItemState extends State<_DayItem> {
     _HighlightPainter? highlightPainter;
 
     if (widget.isSelectedDayStart || widget.isSelectedDayEnd) {
-      // The selected start and end dates gets a circle background
-      // highlight, and a contrasting text color.
+      // The selected start and end dates get a background highlight
+      // matching the day shape, and a contrasting text color.
       itemStyle = itemStyle?.apply(color: dayForegroundColor);
       decoration = ShapeDecoration(color: dayBackgroundColor, shape: dayShape);
 
@@ -2929,8 +2929,7 @@ class _DayItemState extends State<_DayItem> {
     } else if (widget.isDisabled) {
       itemStyle = itemStyle?.apply(color: colorScheme.onSurface.withOpacity(0.38));
     } else if (widget.isToday) {
-      // The current day gets a different text color and a circle stroke
-      // border.
+      // The current day gets a different text color and a stroke border.
       itemStyle = itemStyle?.apply(color: colorScheme.primary);
       final BorderSide todaySide = (datePickerTheme.todayBorder ?? defaults.todayBorder!).copyWith(
         color: colorScheme.primary,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2931,6 +2931,7 @@ class _DayItemState extends State<_DayItem> {
     } else if (widget.isToday) {
       // The current day gets a different text color and a circle stroke
       // border.
+      itemStyle = itemStyle?.apply(color: colorScheme.primary);
       final BorderSide todaySide = (datePickerTheme.todayBorder ?? defaults.todayBorder!).copyWith(
         color: colorScheme.primary,
       );

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2901,8 +2901,8 @@ class _DayItemState extends State<_DayItem> {
     _HighlightPainter? highlightPainter;
 
     if (widget.isSelectedDayStart || widget.isSelectedDayEnd) {
-      // The selected start and end dates get a background highlight
-      // matching the day shape, and a contrasting text color.
+      // The selected start and end dates get a custom shaped background
+      // highlight, and a contrasting text color.
       itemStyle = itemStyle?.apply(color: dayForegroundColor);
       decoration = ShapeDecoration(color: dayBackgroundColor, shape: dayShape);
 
@@ -2929,7 +2929,7 @@ class _DayItemState extends State<_DayItem> {
     } else if (widget.isDisabled) {
       itemStyle = itemStyle?.apply(color: colorScheme.onSurface.withOpacity(0.38));
     } else if (widget.isToday) {
-      // The current day gets a different text color and a stroke border.
+      // The current day gets a different text color and a custom shape border.
       itemStyle = itemStyle?.apply(color: colorScheme.primary);
       final BorderSide todaySide = (datePickerTheme.todayBorder ?? defaults.todayBorder!).copyWith(
         color: colorScheme.primary,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2855,7 +2855,7 @@ class _DayItemState extends State<_DayItem> {
     final TextDirection textDirection = Directionality.of(context);
     final Color highlightColor = widget.highlightColor;
 
-    BoxDecoration? decoration;
+    Decoration? decoration;
     TextStyle? itemStyle = textTheme.bodyMedium;
 
     T? effectiveValue<T>(T? Function(DatePickerThemeData? theme) getProperty) {
@@ -2894,13 +2894,17 @@ class _DayItemState extends State<_DayItem> {
       ),
     );
 
+    final OutlinedBorder dayShape =
+        resolve<OutlinedBorder?>((DatePickerThemeData? theme) => theme?.dayShape, states) ??
+        const CircleBorder();
+
     _HighlightPainter? highlightPainter;
 
     if (widget.isSelectedDayStart || widget.isSelectedDayEnd) {
       // The selected start and end dates gets a circle background
       // highlight, and a contrasting text color.
       itemStyle = itemStyle?.apply(color: dayForegroundColor);
-      decoration = BoxDecoration(color: dayBackgroundColor, shape: BoxShape.circle);
+      decoration = ShapeDecoration(color: dayBackgroundColor, shape: dayShape);
 
       if (widget.isRangeSelected && !widget.isOneDayRange) {
         final _HighlightPainterStyle style = widget.isSelectedDayStart
@@ -2927,11 +2931,11 @@ class _DayItemState extends State<_DayItem> {
     } else if (widget.isToday) {
       // The current day gets a different text color and a circle stroke
       // border.
-      itemStyle = itemStyle?.apply(color: colorScheme.primary);
-      decoration = BoxDecoration(
-        border: Border.all(color: colorScheme.primary),
-        shape: BoxShape.circle,
+      final BorderSide todaySide = (datePickerTheme.todayBorder ?? defaults.todayBorder!).copyWith(
+        color: colorScheme.primary,
       );
+
+      decoration = ShapeDecoration(shape: dayShape.copyWith(side: todaySide));
     }
 
     final String dayText = localizations.formatDecimal(widget.day.day);

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2974,7 +2974,8 @@ class _DayItemState extends State<_DayItem> {
       dayWidget = InkResponse(
         focusNode: widget.focusNode,
         onTap: () => widget.onChanged(widget.day),
-        radius: _monthItemRowHeight / 2 + 4,
+        customBorder: dayShape,
+        containedInkWell: true,
         statesController: _statesController,
         overlayColor: dayOverlayColor,
         onFocusChange: widget.onFocusChange,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2855,7 +2855,7 @@ class _DayItemState extends State<_DayItem> {
     final TextDirection textDirection = Directionality.of(context);
     final Color highlightColor = widget.highlightColor;
 
-    Decoration? decoration;
+    ShapeDecoration? decoration;
     TextStyle? itemStyle = textTheme.bodyMedium;
 
     T? effectiveValue<T>(T? Function(DatePickerThemeData? theme) getProperty) {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -2025,6 +2025,60 @@ void main() {
 
     expect(tester.takeException(), null);
   });
+
+  testWidgets('DateRangePicker respects DatePickerTheme.dayShape', (WidgetTester tester) async {
+    const OutlinedBorder customShape = BeveledRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(10)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          datePickerTheme: const DatePickerThemeData(
+            dayShape: WidgetStatePropertyAll<OutlinedBorder>(customShape),
+          ),
+        ),
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () => showDateRangePicker(
+                  context: context,
+                  firstDate: DateTime(2023),
+                  lastDate: DateTime(2024),
+                  initialDateRange: DateTimeRange(
+                    start: DateTime(2023, 1, 15),
+                    end: DateTime(2023, 1, 20),
+                  ),
+                ),
+                child: const Text('Open Picker'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open Picker'));
+    await tester.pumpAndSettle();
+
+    final Finder selectedDayText = find.text('15');
+
+    final Finder dayContainerFinder = find
+        .ancestor(
+          of: selectedDayText,
+          matching: find.byWidgetPredicate((Widget widget) {
+            return widget is Container && widget.decoration is ShapeDecoration;
+          }),
+        )
+        .first;
+
+    final Container dayContainer = tester.widget<Container>(dayContainerFinder);
+    final decoration = dayContainer.decoration! as ShapeDecoration;
+
+    expect(decoration.shape, customShape);
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -2034,7 +2034,6 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          useMaterial3: true,
           datePickerTheme: const DatePickerThemeData(
             dayShape: WidgetStatePropertyAll<OutlinedBorder>(customShape),
           ),


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This change fixes a problem where `showDateRangePicker` ignored the `dayShape` property in `DatePickerThemeData`, leading to days always rendering as circles regardless of the theme. This was caused by the internal `_DayItem` widget using a hardcoded `BoxDecoration` regardless of the theme configuration.

Fixes #181500

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/56a7c33e-ce91-4c30-8e62-ac0bceb1e3d3" width="350"> | <img src="https://github.com/user-attachments/assets/431c8ad2-0825-400a-8dd3-b264ec7430ce" width="350"> |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.