### PR TITLE
Remove nonstandard ndkpath for `hybrid_android_views` integration test

### DIFF
--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -29,15 +29,6 @@ android {
     namespace = "io.flutter.integration.platformviews"
     compileSdk flutter.compileSdkVersion
 
-    // Flutter's CI installs the NDK at a non-standard path.
-    // This non-standard structure is initially created by
-    // https://github.com/flutter/engine/blob/3.27.0/tools/android_sdk/create_cipd_packages.sh.
-    String systemNdkPath = System.getenv("ANDROID_NDK_PATH")
-    if (systemNdkPath != null) {
-        ndkVersion = flutter.ndkVersion
-        ndkPath = systemNdkPath
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
This is not true any more, since https://github.com/flutter/flutter/pull/179920

This was only triggered on ci because that environment var isn't set elsewhere.

