### PR TITLE
Extend the Windows tool_integration_tests_2_9 shard timeout to 1 hour

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -6332,7 +6332,7 @@ targets:
       subshard: "2_9"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "2700"
+      test_timeout_secs: "3600"
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
This shard has been timing out often (see https://github.com/flutter/flutter/issues/180413)

Some new tests were added to the shard that may have made it exceed the timeout (see https://github.com/flutter/flutter/commit/a5b3c4bd69504764fa054c397f2d3f441ed0e006)