### PR TITLE
Remove material from ticker mode test

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -172,7 +172,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/container_test.dart',
     'packages/flutter/test/widgets/drawer_test.dart',
     'packages/flutter/test/widgets/framework_test.dart',
-    'packages/flutter/test/widgets/ticker_mode_test.dart',
     'packages/flutter/test/widgets/absorb_pointer_test.dart',
     'packages/flutter/test/widgets/semantics_role_checks_test.dart',
     'packages/flutter/test/widgets/media_query_test.dart',

--- a/packages/flutter/test/widgets/ticker_mode_test.dart
+++ b/packages/flutter/test/widgets/ticker_mode_test.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'widgets_app_tester.dart';
 
 void main() {
   testWidgets('Nested TickerMode cannot turn tickers back on', (WidgetTester tester) async {
@@ -185,11 +187,11 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      MaterialApp(
-        routes: <String, WidgetBuilder>{'/foo': (BuildContext context) => const Text('New route')},
+      TestWidgetsApp(
         home: const Row(
           children: <Widget>[_TickingWidget(), _MultiTickingWidget(), Text('Old route')],
         ),
+        routes: <String, WidgetBuilder>{'/foo': (BuildContext context) => const Text('New route')},
       ),
     );
 

--- a/packages/flutter/test/widgets/widgets_app_tester.dart
+++ b/packages/flutter/test/widgets/widgets_app_tester.dart
@@ -15,7 +15,7 @@ import 'package:flutter/widgets.dart';
 /// app-level widgets (like [Directionality], [MediaQuery], etc.) that
 /// [WidgetsApp] provides, without the overhead of [MaterialApp] or [CupertinoApp].
 ///
-/// The [PageRouteBuilder] creates a [Navigator] which provides an [Overlay],
+/// The [pageRouteBuilder] creates a [Navigator] which provides an [Overlay],
 /// so widgets that need overlay support (like [Draggable], [Tooltip], etc.)
 /// will work correctly when placed in [home].
 ///

--- a/packages/flutter/test/widgets/widgets_app_tester.dart
+++ b/packages/flutter/test/widgets/widgets_app_tester.dart
@@ -15,7 +15,7 @@ import 'package:flutter/widgets.dart';
 /// app-level widgets (like [Directionality], [MediaQuery], etc.) that
 /// [WidgetsApp] provides, without the overhead of [MaterialApp] or [CupertinoApp].
 ///
-/// The [pageRouteBuilder] creates a [Navigator] which provides an [Overlay],
+/// The [PageRouteBuilder] creates a [Navigator] which provides an [Overlay],
 /// so widgets that need overlay support (like [Draggable], [Tooltip], etc.)
 /// will work correctly when placed in [home].
 ///


### PR DESCRIPTION
This PR removes Material imports from ticker_mode_test.dart.

part of: https://github.com/flutter/flutter/issues/177415
depends on: https://github.com/flutter/flutter/pull/181695

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.