### PR TITLE
Remove obsolete null checks from style guide

### DIFF
--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -711,7 +711,7 @@ When referencing a parameter, use backticks. However, when referencing a paramet
   /// The [bar] argument allows the baz to quux.
   ///
   /// The `baz` argument must be greater than zero.
-  Foo({this.bar, int baz}) : assert(baz > 0);
+  Foo({required this.bar, required int baz}) : assert(baz > 0);
 ```
 
 Avoid using terms like "above" or "below" to reference one dartdoc section from another. Dartdoc sections are often shown alone on a Web page, the full context of the class is not present.

--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -706,12 +706,12 @@ When referencing a parameter, use backticks. However, when referencing a paramet
 ```dart
 // GOOD
 
-  /// Creates a foobar, which allows a baz to quux the bar.
+  /// Creates a foobar.
   ///
-  /// The [bar] argument must not be null.
+  /// The [bar] argument allows the baz to quux.
   ///
   /// The `baz` argument must be greater than zero.
-  Foo({ this.bar, int baz }) : assert(bar != null), assert(baz > 0);
+  Foo({this.bar, int baz}) : assert(baz > 0);
 ```
 
 Avoid using terms like "above" or "below" to reference one dartdoc section from another. Dartdoc sections are often shown alone on a Web page, the full context of the class is not present.
@@ -924,7 +924,6 @@ the following pattern:
 TheType get theProperty => _theProperty;
 TheType _theProperty;
 void set theProperty(TheType value) {
-  assert(value != null);
   if (_theProperty == value) {
     return;
   }


### PR DESCRIPTION
A couple of the style guide examples were written prior to Dart's null safety era, so this PR aims to update those examples.

[Test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests) because it only affects the `.md` file.