### PR TITLE
Remove `DisposableBuildContext` type argument

### DIFF
--- a/packages/flutter/lib/src/widgets/disposable_build_context.dart
+++ b/packages/flutter/lib/src/widgets/disposable_build_context.dart
@@ -22,14 +22,14 @@ import 'framework.dart';
 ///
 /// This object will not hold on to the [State] after disposal.
 @optionalTypeArgs
-class DisposableBuildContext<T extends State> {
+class DisposableBuildContext {
   /// Creates an object that provides access to a [BuildContext] without leaking
   /// a [State].
   ///
   /// Creators must call [dispose] when the [State] is disposed.
   ///
   /// [State.mounted] must be true.
-  DisposableBuildContext(T this._state)
+  DisposableBuildContext(State this._state)
     : assert(
         _state.mounted,
         'A DisposableBuildContext was given a BuildContext for an Element that is not mounted.',
@@ -37,7 +37,7 @@ class DisposableBuildContext<T extends State> {
     assert(debugMaybeDispatchCreated('widgets', 'DisposableBuildContext', this));
   }
 
-  T? _state;
+  State? _state;
 
   /// Provides safe access to the build context.
   ///

--- a/packages/flutter/lib/src/widgets/disposable_build_context.dart
+++ b/packages/flutter/lib/src/widgets/disposable_build_context.dart
@@ -21,7 +21,6 @@ import 'framework.dart';
 ///   2. They call [dispose] from [State.dispose].
 ///
 /// This object will not hold on to the [State] after disposal.
-@optionalTypeArgs
 class DisposableBuildContext {
   /// Creates an object that provides access to a [BuildContext] without leaking
   /// a [State].

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1115,7 +1115,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   late bool _invertColors;
   int? _frameNumber;
   bool _wasSynchronouslyLoaded = false;
-  late DisposableBuildContext<State<Image>> _scrollAwareContext;
+  late DisposableBuildContext _scrollAwareContext;
   Object? _lastException;
   StackTrace? _lastStack;
   ImageStreamCompleterHandle? _completerHandle;
@@ -1129,7 +1129,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _scrollAwareContext = DisposableBuildContext<State<Image>>(this);
+    _scrollAwareContext = DisposableBuildContext(this);
   }
 
   @override

--- a/packages/flutter/test/widgets/disposable_build_context_test.dart
+++ b/packages/flutter/test/widgets/disposable_build_context_test.dart
@@ -14,7 +14,7 @@ void main() {
     final TestWidgetState state = key.currentState!;
     expect(state.mounted, true);
 
-    final DisposableBuildContext context = DisposableBuildContext(state);
+    final context = DisposableBuildContext(state);
     expect(context.context, state.context);
 
     await tester.pumpWidget(const TestWidget(null));
@@ -37,10 +37,7 @@ void main() {
     final TestWidgetState state = key.currentState!;
 
     await expectLater(
-      await memoryEvents(
-        () => DisposableBuildContext<TestWidgetState>(state).dispose(),
-        DisposableBuildContext<TestWidgetState>,
-      ),
+      await memoryEvents(() => DisposableBuildContext(state).dispose(), DisposableBuildContext),
       areCreateAndDispose,
     );
   });

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -42,7 +42,7 @@ void main() {
   Future<DisposableBuildContext> createContext(WidgetTester tester) async {
     final key = GlobalKey<TestWidgetState>();
     await tester.pumpWidget(TestWidget(key));
-    final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+    final context = DisposableBuildContext(key.currentState!);
     addTearDown(context.dispose);
     return context;
   }
@@ -160,7 +160,7 @@ void main() {
     final key = GlobalKey<TestWidgetState>();
     await tester.pumpWidget(TestWidget(key));
 
-    final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+    final context = DisposableBuildContext(key.currentState!);
     addTearDown(context.dispose);
     final testImageProvider = TestImageProvider(testImage.clone());
     final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -195,7 +195,7 @@ void main() {
       ),
     );
 
-    final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+    final context = DisposableBuildContext(key.currentState!);
     addTearDown(context.dispose);
     final testImageProvider = TestImageProvider(testImage.clone());
     final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -241,7 +241,7 @@ void main() {
       ),
     );
 
-    final DisposableBuildContext context = DisposableBuildContext(keys.last.currentState!);
+    final context = DisposableBuildContext(keys.last.currentState!);
     addTearDown(context.dispose);
     final testImageProvider = TestImageProvider(testImage.clone());
     final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -304,7 +304,7 @@ void main() {
       ),
     );
 
-    final DisposableBuildContext context = DisposableBuildContext(keys.last.currentState!);
+    final context = DisposableBuildContext(keys.last.currentState!);
     addTearDown(context.dispose);
     final testImageProvider = TestImageProvider(testImage.clone());
     final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -377,7 +377,7 @@ void main() {
         ),
       );
 
-      final DisposableBuildContext context = DisposableBuildContext(keys.last.currentState!);
+      final context = DisposableBuildContext(keys.last.currentState!);
       addTearDown(context.dispose);
       final testImageProvider = TestImageProvider(cloneImage());
       final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -449,7 +449,7 @@ void main() {
         ),
       );
 
-      final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+      final context = DisposableBuildContext(key.currentState!);
       addTearDown(context.dispose);
       final testImageProvider = TestImageProvider(cloneImage());
       final imageProvider = ScrollAwareImageProvider<TestImageProvider>(
@@ -514,7 +514,7 @@ void main() {
         ),
       );
 
-      final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+      final context = DisposableBuildContext(key.currentState!);
       addTearDown(context.dispose);
       final testImageProvider = TestImageProvider(testImage.clone());
       final imageProvider = ScrollAwareImageProvider<TestImageProvider>(


### PR DESCRIPTION
[**DisposableBuildContext**](https://main-api.flutter.dev/flutter/widgets/DisposableBuildContext-class.html) has an unused type argument, so this PR aims to clean it up a bit.

I believe this PR is [test-exempt](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests) because it only removes dead code.

resolves #181935