### PR TITLE
Export `ValueListenable` in widgets library

### DIFF
--- a/examples/api/lib/material/selection_area/selection_area.1.dart
+++ b/examples/api/lib/material/selection_area/selection_area.1.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [SelectionArea].

--- a/examples/api/lib/material/selection_area/selection_area.2.dart
+++ b/examples/api/lib/material/selection_area/selection_area.2.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:math';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/examples/api/lib/services/text_input/text_input_control.0.dart
+++ b/examples/api/lib/services/text_input/text_input_control.0.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -9,7 +9,6 @@
 /// @docImport 'icons.dart';
 library;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'bottom_app_bar_theme.dart';

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'debug.dart';

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -28,7 +28,13 @@ import 'widget_span.dart';
 
 export 'package:flutter/animation.dart';
 export 'package:flutter/foundation.dart'
-    show ChangeNotifier, FlutterErrorDetails, Listenable, TargetPlatform, ValueNotifier;
+    show
+        ChangeNotifier,
+        FlutterErrorDetails,
+        Listenable,
+        TargetPlatform,
+        ValueListenable,
+        ValueNotifier;
 export 'package:flutter/painting.dart';
 export 'package:flutter/rendering.dart'
     show

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/ticker_mode_test.dart
+++ b/packages/flutter/test/widgets/ticker_mode_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/value_listenable_builder_test.dart
+++ b/packages/flutter/test/widgets/value_listenable_builder_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
#181700 proposes adopting the [**ValueListenable**](https://main-api.flutter.dev/flutter/foundation/ValueListenable-class.html) API for a few transition widgets.

The goal of this PR is to allow future changes to be made more cleanly and thus easier to review.