### PR TITLE
Remove material from Modal barrier tests

### DIFF
--- a/dev/bots/check_tests_cross_imports.dart
+++ b/dev/bots/check_tests_cross_imports.dart
@@ -142,7 +142,6 @@ class TestsCrossImportChecker {
     'packages/flutter/test/widgets/sliver_main_axis_group_test.dart',
     'packages/flutter/test/widgets/color_filter_test.dart',
     'packages/flutter/test/widgets/semantics_merge_test.dart',
-    'packages/flutter/test/widgets/modal_barrier_test.dart',
     'packages/flutter/test/widgets/sliver_semantics_test.dart',
     'packages/flutter/test/widgets/sliver_constraints_test.dart',
     'packages/flutter/test/widgets/autocomplete_test.dart',

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -4,12 +4,13 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
+import 'widgets_app_tester.dart';
 
 void main() {
   late bool tapped;
@@ -20,7 +21,7 @@ void main() {
 
   setUp(() {
     tapped = false;
-    colorAnimation = const AlwaysStoppedAnimation<Color?>(Colors.red);
+    colorAnimation = const AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000));
     tapTarget = GestureDetector(
       onTap: () {
         tapped = true;
@@ -194,7 +195,7 @@ void main() {
         '/modal': (BuildContext context) => const SecondWidget(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -227,7 +228,7 @@ void main() {
         '/modal': (BuildContext context) => const SecondWidget(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -263,7 +264,7 @@ void main() {
         '/modal': (BuildContext context) => const SecondWidgetWithCompetence(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -305,7 +306,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -351,7 +352,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -388,7 +389,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -415,10 +416,8 @@ void main() {
 
       final barrierKey = UniqueKey();
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: ModalBarrier(key: barrierKey, onDismiss: () => throw Exception('deliberate')),
-          ),
+        TestWidgetsApp(
+          home: ModalBarrier(key: barrierKey, onDismiss: () => throw Exception('deliberate')),
         ),
       );
       await tester.tap(find.byKey(barrierKey));
@@ -434,7 +433,7 @@ void main() {
         '/modal': (BuildContext context) => SecondWidget(onDismiss: () {}),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -661,7 +660,7 @@ void main() {
         '/modal': (BuildContext context) => const AnimatedSecondWidget(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -694,7 +693,7 @@ void main() {
         '/modal': (BuildContext context) => const AnimatedSecondWidget(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -730,7 +729,7 @@ void main() {
         '/modal': (BuildContext context) => const AnimatedSecondWidgetWithCompetence(),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -772,7 +771,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -818,7 +817,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -855,7 +854,7 @@ void main() {
         ),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -879,7 +878,7 @@ void main() {
         '/modal': (BuildContext context) => AnimatedSecondWidget(onDismiss: () {}),
       };
 
-      await tester.pumpWidget(MaterialApp(routes: routes));
+      await tester.pumpWidget(TestWidgetsApp(routes: routes));
 
       // Initially the barrier is not visible
       expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
@@ -1047,7 +1046,7 @@ class AnimatedSecondWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedModalBarrier(
       key: const ValueKey<String>('barrier'),
-      color: const AlwaysStoppedAnimation<Color?>(Colors.red),
+      color: const AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000)),
       onDismiss: onDismiss,
     );
   }
@@ -1078,7 +1077,7 @@ class AnimatedSecondWidgetWithCompetence extends StatelessWidget {
       children: <Widget>[
         const AnimatedModalBarrier(
           key: ValueKey<String>('barrier'),
-          color: AlwaysStoppedAnimation<Color?>(Colors.red),
+          color: AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000)),
         ),
         GestureDetector(
           onVerticalDragStart: (_) {},

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -12,6 +12,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'semantics_tester.dart';
 import 'widgets_app_tester.dart';
 
+const Color _kTestRed = Color(0xFFFF0000);
+
 void main() {
   late bool tapped;
   late bool hovered;
@@ -21,7 +23,7 @@ void main() {
 
   setUp(() {
     tapped = false;
-    colorAnimation = const AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000));
+    colorAnimation = const AlwaysStoppedAnimation<Color?>(_kTestRed);
     tapTarget = GestureDetector(
       onTap: () {
         tapped = true;
@@ -1046,7 +1048,7 @@ class AnimatedSecondWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedModalBarrier(
       key: const ValueKey<String>('barrier'),
-      color: const AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000)),
+      color: const AlwaysStoppedAnimation<Color?>(_kTestRed),
       onDismiss: onDismiss,
     );
   }
@@ -1077,7 +1079,7 @@ class AnimatedSecondWidgetWithCompetence extends StatelessWidget {
       children: <Widget>[
         const AnimatedModalBarrier(
           key: ValueKey<String>('barrier'),
-          color: AlwaysStoppedAnimation<Color?>(Color(0xFFFF0000)),
+          color: AlwaysStoppedAnimation<Color?>(_kTestRed),
         ),
         GestureDetector(
           onVerticalDragStart: (_) {},


### PR DESCRIPTION
This PR removes Material imports from modal_barrier_test.dart.

part of: https://github.com/flutter/flutter/issues/177415
depends on: https://github.com/flutter/flutter/pull/181695

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.