### PR TITLE
[Impeller] Fix type conversion warnings seen on Windows when Impeller GL API wrappers log arguments with function types

### DIFF
--- a/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/engine/src/flutter/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -143,9 +143,9 @@ std::shared_ptr<Context> PlaygroundImplGLES::GetContext() const {
 
   if (gl->GetDescription()->HasDebugExtension()) {
     gl->DebugMessageCallbackKHR(
-        [](GLenum /* source */, GLenum message_type, GLuint /* message_id */,
-           GLenum /* severity */, GLsizei /* length */, const GLchar* message,
-           const void* /* user_param */) {
+        +[](GLenum /* source */, GLenum message_type, GLuint /* message_id */,
+            GLenum /* severity */, GLsizei /* length */, const GLchar* message,
+            const void* /* user_param */) {
           switch (message_type) {
             case GL_DEBUG_TYPE_ERROR_KHR:
               FML_LOG(ERROR) << "GL Error: " << message;

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -51,9 +51,21 @@ struct AutoErrorCheck {
   }
 };
 
+template <typename Type>
+struct ArgLogger {
+  static void log(std::stringstream& stream, Type arg) { stream << arg; }
+};
+
+template <typename R, typename... Args>
+struct ArgLogger<R (*)(Args...)> {
+  static void log(std::stringstream& stream, R (*val)(Args...)) {
+    stream << reinterpret_cast<void*>(val);
+  }
+};
+
 template <class Type>
 void BuildGLArgumentsStream(std::stringstream& stream, Type arg) {
-  stream << arg;
+  ArgLogger<Type>::log(stream, arg);
 }
 
 constexpr void BuildGLArgumentsStream(std::stringstream& stream) {}


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/181157 introduced a call to the glDebugMessageCallback API using a lambda as the argument.  On Windows builds this produces a warning about a nonstandard implicit conversion when the Impeller GL API wrappers try to log the callback argument.