### PR TITLE
Re-enable AddressSanitizer on the linux_unopt builder

### DIFF
--- a/engine/src/flutter/ci/builders/linux_unopt.json
+++ b/engine/src/flutter/ci/builders/linux_unopt.json
@@ -16,6 +16,7 @@
                 "debug",
                 "--unoptimized",
                 "--prebuilt-dart-sdk",
+                "--asan",
                 "--dart-debug",
                 "--rbe",
                 "--no-goma"

--- a/engine/src/flutter/testing/lsan_suppressions.txt
+++ b/engine/src/flutter/testing/lsan_suppressions.txt
@@ -65,3 +65,6 @@ leak:egl::*
 
 # False positives in libfontconfig. http://crbug.com/39050
 leak:libfontconfig
+
+# False positives in D-Bus.
+leak:libdbus-1.so


### PR DESCRIPTION
ASan had been disabled due to issues that were seen when the LUCI bots were upgraded to Ubuntu 24.  That upgrade was reverted, and ASan can be run on the current Ubuntu 22 bots.

Fixes https://github.com/flutter/flutter/issues/181639