### PR TITLE
fix(web_ui): handle non-invertible matrices in ImageFilter.matrix

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1045,12 +1045,12 @@ extension type SkImageFilterNamespace(JSObject _) implements JSObject {
   );
 
   @JS('MakeMatrixTransform')
-  external SkImageFilter _MakeMatrixTransform(
+  external SkImageFilter? _MakeMatrixTransform(
     JSFloat32Array matrix, // 3x3 matrix
     CkFilterOptions filterOptions,
     void input, // we don't use this yet
   );
-  SkImageFilter MakeMatrixTransform(
+  SkImageFilter? MakeMatrixTransform(
     Float32List matrix, // 3x3 matrix
     CkFilterOptions filterOptions,
     void input, // we don't use this yet

--- a/engine/src/flutter/lib/web_ui/test/ui/image_filter_non_invertible_matrix_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/image_filter_non_invertible_matrix_test.dart
@@ -1,0 +1,102 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/rendering.dart';
+import '../common/test_initialization.dart';
+import 'utils.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(withImplicitView: true, setUpTestViewDimensions: false);
+
+  test('scene.pushImageFilter with a non-invertible matrix does not crash', () async {
+    final sceneBuilder = ui.SceneBuilder();
+    // A matrix of all zeros is non-invertible.
+    final Float64List nonInvertibleMatrix = Matrix4.zero().toFloat64();
+    final filter = ui.ImageFilter.matrix(nonInvertibleMatrix);
+
+    sceneBuilder.pushImageFilter(filter);
+    sceneBuilder.addPicture(
+      ui.Offset.zero,
+      drawPicture((ui.Canvas canvas) {
+        canvas.drawRect(
+          const ui.Rect.fromLTWH(0, 0, 100, 100),
+          ui.Paint()..color = const ui.Color(0xFF00FF00),
+        );
+      }),
+    );
+    sceneBuilder.pop();
+
+    final ui.Scene scene = sceneBuilder.build();
+    await renderScene(scene);
+    // If we reached here without crashing, the test passed.
+  });
+
+  test('Paint with a non-invertible matrix ImageFilter does not crash', () async {
+    final Float64List nonInvertibleMatrix = Matrix4.zero().toFloat64();
+    final filter = ui.ImageFilter.matrix(nonInvertibleMatrix);
+
+    final paint = ui.Paint()..imageFilter = filter;
+    final ui.Picture picture = drawPicture((ui.Canvas canvas) {
+      canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 100, 100), paint);
+    });
+
+    final sceneBuilder = ui.SceneBuilder();
+    sceneBuilder.addPicture(ui.Offset.zero, picture);
+    final ui.Scene scene = sceneBuilder.build();
+    await renderScene(scene);
+
+    picture.dispose();
+    // If we reached here without crashing, the test passed.
+  });
+
+  test('scene.pushImageFilter with a zero-scale matrix does not crash', () async {
+    final sceneBuilder = ui.SceneBuilder();
+    // A matrix with zero scale is non-invertible.
+    final matrix = Matrix4.identity()..scale(0.0, 0.0, 1.0);
+    final filter = ui.ImageFilter.matrix(matrix.toFloat64());
+
+    sceneBuilder.pushImageFilter(filter);
+    sceneBuilder.addPicture(
+      ui.Offset.zero,
+      drawPicture((ui.Canvas canvas) {
+        canvas.drawRect(
+          const ui.Rect.fromLTWH(0, 0, 100, 100),
+          ui.Paint()..color = const ui.Color(0xFF00FF00),
+        );
+      }),
+    );
+    sceneBuilder.pop();
+
+    final ui.Scene scene = sceneBuilder.build();
+    await renderScene(scene);
+  });
+
+  test('Paint with a zero-scale matrix ImageFilter does not crash', () async {
+    final matrix = Matrix4.identity()..scale(0.0, 0.0, 1.0);
+    final filter = ui.ImageFilter.matrix(matrix.toFloat64());
+
+    final paint = ui.Paint()..imageFilter = filter;
+    final ui.Picture picture = drawPicture((ui.Canvas canvas) {
+      canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 100, 100), paint);
+    });
+
+    final sceneBuilder = ui.SceneBuilder();
+    sceneBuilder.addPicture(ui.Offset.zero, picture);
+    final ui.Scene scene = sceneBuilder.build();
+    await renderScene(scene);
+
+    picture.dispose();
+  });
+}


### PR DESCRIPTION
In CanvasKit, `MakeMatrixTransform` returns null if the matrix is non-invertible (e.g., all zeros or zero scale). Previously, the web engine assumed this would always return a valid object, leading to a crash when calling methods like `delete()` or `getOutputBounds()` on the null result.

This change:
- Updates `MakeMatrixTransform` signature to allow returning null.
- Gracefully handles null filters in `CkMatrixImageFilter` by skipping the borrow callback.
- Defaults `filterBounds` to `ui.Rect.zero` when the filter is null, indicating that no content is rendered.
- Adds a comprehensive test suite to ensure non-invertible matrices do not cause crashes during scene building or painting.

Fixes https://github.com/flutter/flutter/issues/181411

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
