### PR TITLE
Add buffer around rerasterized input to fragment shaders to maintain coordinate space when clipped

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -16,9 +16,6 @@
 #include "flutter/impeller/display_list/dl_runtime_effect_impeller.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 
-float fudge_x = 0;
-float fudge_y = 0;
-
 namespace impeller {
 namespace testing {
 
@@ -432,8 +429,6 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SliderFloat("sigma", &sigma, 0, 20);
-      ImGui::SliderFloat("fudge_x", &fudge_x, -20, 20);
-      ImGui::SliderFloat("fudge_y", &fudge_y, -20, 20);
       ImGui::End();
     }
     DisplayListBuilder builder;
@@ -457,7 +452,7 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     auto backdrop_filter = DlImageFilter::MakeCompose(/*outer=*/runtime_filter,
                                                       /*inner=*/blur_filter);
 
-    builder.ClipRect(DlRect::MakeXYWH(10, 10, 300, 300));
+    builder.ClipRect(DlRect::MakeXYWH(20, 20, 300, 300));
 
     DlPaint paint;
     auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -16,6 +16,9 @@
 #include "flutter/impeller/display_list/dl_runtime_effect_impeller.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 
+float fudge_x = 0;
+float fudge_y = 0;
+
 namespace impeller {
 namespace testing {
 
@@ -429,6 +432,8 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SliderFloat("sigma", &sigma, 0, 20);
+      ImGui::SliderFloat("fudge_x", &fudge_x, -20, 20);
+      ImGui::SliderFloat("fudge_y", &fudge_y, -20, 20);
       ImGui::End();
     }
     DisplayListBuilder builder;
@@ -452,7 +457,7 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     auto backdrop_filter = DlImageFilter::MakeCompose(/*outer=*/runtime_filter,
                                                       /*inner=*/blur_filter);
 
-    builder.ClipRect(DlRect::MakeXYWH(100, 100, 664, 418).Expand(20));
+    builder.ClipRect(DlRect::MakeXYWH(10, 10, 300, 300));
 
     DlPaint paint;
     auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -424,11 +424,13 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
   Scalar sigma = 5.0;
+  Scalar clip_x = 20.0;
 
   auto callback = [&]() -> sk_sp<DisplayList> {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SliderFloat("sigma", &sigma, 0, 20);
+      ImGui::SliderFloat("clip_x", &clip_x, 0, 50);
       ImGui::End();
     }
     DisplayListBuilder builder;
@@ -452,7 +454,7 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     auto backdrop_filter = DlImageFilter::MakeCompose(/*outer=*/runtime_filter,
                                                       /*inner=*/blur_filter);
 
-    builder.ClipRect(DlRect::MakeXYWH(20, 20, 300, 300));
+    builder.ClipRect(DlRect::MakeXYWH(clip_x, 20, 300, 300));
 
     DlPaint paint;
     auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -14,6 +14,9 @@
 #include "flutter/impeller/display_list/aiks_unittests.h"
 #include "flutter/impeller/display_list/dl_image_impeller.h"
 #include "flutter/impeller/display_list/dl_runtime_effect_impeller.h"
+#include "imgui.h"
+#include "impeller/geometry/point.h"
+#include "impeller/geometry/vector.h"
 #include "third_party/abseil-cpp/absl/status/status_matchers.h"
 
 namespace impeller {
@@ -324,8 +327,14 @@ TEST_P(AiksTest, ComposeBackdropRuntimeOuterBlurInner) {
     std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
         nullptr,
     };
+
+    struct FragUniforms {
+      Vector2 size;
+      Vector2 origin;
+    } frag_uniforms = {.size = Vector2(1, 1), .origin = Vector2(30.f, 30.f)};
     auto uniform_data = std::make_shared<std::vector<uint8_t>>();
-    uniform_data->resize(sizeof(Vector2));
+    uniform_data->resize(sizeof(FragUniforms));
+    memcpy(uniform_data->data(), &frag_uniforms, sizeof(FragUniforms));
 
     auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
         DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
@@ -383,8 +392,13 @@ TEST_P(AiksTest, ComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
         nullptr,
     };
+    struct FragUniforms {
+      Vector2 size;
+      Vector2 origin;
+    } frag_uniforms = {.size = Vector2(1, 1), .origin = Vector2(30.f, 30.f)};
     auto uniform_data = std::make_shared<std::vector<uint8_t>>();
-    uniform_data->resize(sizeof(Vector2));
+    uniform_data->resize(sizeof(FragUniforms));
+    memcpy(uniform_data->data(), &frag_uniforms, sizeof(FragUniforms));
 
     auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
         DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
@@ -424,13 +438,20 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
   Scalar sigma = 5.0;
-  Scalar clip_x = 20.0;
+  Vector2 clip_origin = Vector2(20.f, 20.f);
+  Vector2 clip_size = Vector2(300, 300);
+  Vector2 circle_origin = Vector2(30.f, 30.f);
 
   auto callback = [&]() -> sk_sp<DisplayList> {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SliderFloat("sigma", &sigma, 0, 20);
-      ImGui::SliderFloat("clip_x", &clip_x, 0, 50);
+      ImGui::SliderFloat("clip_x", &clip_origin.x, 0, 1024.f);
+      ImGui::SliderFloat("clip_y", &clip_origin.y, 0, 1024.f);
+      ImGui::SliderFloat("clip_width", &clip_size.x, 0, 1024.f);
+      ImGui::SliderFloat("clip_height", &clip_size.y, 0, 1024.f);
+      ImGui::SliderFloat("circle_x", &circle_origin.x, 0.f, 1024.f);
+      ImGui::SliderFloat("circle_y", &circle_origin.y, 0.f, 1024.f);
       ImGui::End();
     }
     DisplayListBuilder builder;
@@ -444,8 +465,13 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
         nullptr,
     };
+    struct FragUniforms {
+      Vector2 size;
+      Vector2 origin;
+    } frag_uniforms = {.size = Vector2(1, 1), .origin = circle_origin};
     auto uniform_data = std::make_shared<std::vector<uint8_t>>();
-    uniform_data->resize(sizeof(Vector2));
+    uniform_data->resize(sizeof(FragUniforms));
+    memcpy(uniform_data->data(), &frag_uniforms, sizeof(FragUniforms));
 
     auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
         DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
@@ -454,7 +480,8 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     auto backdrop_filter = DlImageFilter::MakeCompose(/*outer=*/runtime_filter,
                                                       /*inner=*/blur_filter);
 
-    builder.ClipRect(DlRect::MakeXYWH(clip_x, 20, 300, 300));
+    builder.ClipRect(DlRect::MakeXYWH(clip_origin.x, clip_origin.y, clip_size.x,
+                                      clip_size.y));
 
     DlPaint paint;
     auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -414,6 +414,67 @@ TEST_P(AiksTest, ComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
+  auto runtime_stages_result =
+      OpenAssetAsRuntimeStage("runtime_stage_filter_circle.frag.iplr");
+  ABSL_ASSERT_OK(runtime_stages_result);
+  std::shared_ptr<RuntimeStage> runtime_stage =
+      runtime_stages_result
+          .value()[PlaygroundBackendToRuntimeStageBackend(GetBackend())];
+  ASSERT_TRUE(runtime_stage);
+  ASSERT_TRUE(runtime_stage->IsDirty());
+  Scalar sigma = 5.0;
+
+  auto callback = [&]() -> sk_sp<DisplayList> {
+    if (AiksTest::ImGuiBegin("Controls", nullptr,
+                             ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::SliderFloat("sigma", &sigma, 0, 20);
+      ImGui::End();
+    }
+    DisplayListBuilder builder;
+    DlPaint background;
+    background.setColor(DlColor(1.0, 0.1, 0.1, 0.1, DlColorSpace::kSRGB));
+    builder.DrawPaint(background);
+
+    auto blur_filter =
+        DlImageFilter::MakeBlur(sigma, sigma, DlTileMode::kClamp);
+
+    std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
+        nullptr,
+    };
+    auto uniform_data = std::make_shared<std::vector<uint8_t>>();
+    uniform_data->resize(sizeof(Vector2));
+
+    auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
+        DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
+        uniform_data);
+
+    auto backdrop_filter = DlImageFilter::MakeCompose(/*outer=*/runtime_filter,
+                                                      /*inner=*/blur_filter);
+
+    builder.ClipRect(DlRect::MakeXYWH(100, 100, 664, 418).Expand(20));
+
+    DlPaint paint;
+    auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
+    builder.DrawImage(image, DlPoint(100.0, 100.0),
+                      DlImageSampling::kNearestNeighbor, &paint);
+
+    DlPaint save_paint;
+    save_paint.setBlendMode(DlBlendMode::kSrc);
+    builder.SaveLayer(std::nullopt, &save_paint, backdrop_filter.get());
+    builder.Restore();
+
+    DlPaint green;
+    green.setColor(DlColor::kGreen());
+    builder.DrawLine({100, 100}, {200, 100}, green);
+    builder.DrawLine({100, 100}, {100, 200}, green);
+
+    return builder.Build();
+  };
+
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
+}
+
 TEST_P(AiksTest, ClippedBackdropFilterWithShader) {
   struct FragUniforms {
     Vector2 uSize;

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -446,12 +446,12 @@ TEST_P(AiksTest, ClippedComposeBackdropRuntimeOuterBlurInnerSmallSigma) {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SliderFloat("sigma", &sigma, 0, 20);
-      ImGui::SliderFloat("clip_x", &clip_origin.x, 0, 1024.f);
-      ImGui::SliderFloat("clip_y", &clip_origin.y, 0, 1024.f);
-      ImGui::SliderFloat("clip_width", &clip_size.x, 0, 1024.f);
-      ImGui::SliderFloat("clip_height", &clip_size.y, 0, 1024.f);
-      ImGui::SliderFloat("circle_x", &circle_origin.x, 0.f, 1024.f);
-      ImGui::SliderFloat("circle_y", &circle_origin.y, 0.f, 1024.f);
+      ImGui::SliderFloat("clip_x", &clip_origin.x, 0, 2048.f);
+      ImGui::SliderFloat("clip_y", &clip_origin.y, 0, 1536.f);
+      ImGui::SliderFloat("clip_width", &clip_size.x, 0, 2048.f);
+      ImGui::SliderFloat("clip_height", &clip_size.y, 0, 1536.f);
+      ImGui::SliderFloat("circle_x", &circle_origin.x, 0.f, 2048.f);
+      ImGui::SliderFloat("circle_y", &circle_origin.y, 0.f, 1536.f);
       ImGui::End();
     }
     DisplayListBuilder builder;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -98,6 +98,18 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
           [maybe_input_coverage,
            entity_offset](const Entity& entity) -> std::optional<Rect> {
             Rect coverage = maybe_input_coverage.value();
+            // The LT values come from the offset of the clip rect, that creates
+            // the clipping effect on the content that will be rendered from
+            // the fragment shader.  The RB values define the region we'll be
+            // synthesizing and ultimately defines the width and the height of
+            // the rasterized image.  The LT values can be thought of shifting
+            // the window that will be rasterized. Since we are shifting from
+            // the top-left corner, that is effectively pushing the the bottom
+            // right corner lower, outside of the rendering space.  So, we can
+            // clamp those values to the coverage's RB values.  This doesn't
+            // cause the fragment shader's rendering to deform because the
+            // magic width/height values sent to the fragment shader don't take
+            // the rasterized image's size into account.
             return Rect::MakeLTRB(entity_offset.x, entity_offset.y,
                                   coverage.GetRight(), coverage.GetBottom());
           });

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -14,9 +14,6 @@
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/size.h"
 
-extern float fudge_x;
-extern float fudge_y;
-
 namespace impeller {
 
 void RuntimeEffectFilterContents::SetRuntimeStage(
@@ -97,9 +94,9 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
           },
           [maybe_input_coverage,
            entity_offset](const Entity& entity) -> std::optional<Rect> {
-            FML_LOG(ERROR) << "Doof: " << maybe_input_coverage.value();
-            // return maybe_input_coverage;
-            return Rect::MakeXYWH(entity_offset.x, entity_offset.y, 2048, 1536);
+            Rect coverage = maybe_input_coverage.value();
+            return Rect::MakeLTRB(entity_offset.x, entity_offset.y,
+                                  coverage.GetRight(), coverage.GetBottom());
           });
 
       Entity entity;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -87,6 +87,9 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
       texture_contents.SetStencilEnabled(false);
       texture_contents.SetSamplerDescriptor(input_snapshot->sampler_descriptor);
 
+      // Use an AnonymousContents to restore the padding around the input that
+      // may have been cut out with a clip rect to maintain the correct
+      // coordinates for the fragment shader to perform.
       auto anonymous_contents = AnonymousContents::Make(
           [&texture_contents](const ContentContext& renderer,
                               const Entity& entity, RenderPass& pass) -> bool {

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -98,7 +98,8 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
           [maybe_input_coverage,
            entity_offset](const Entity& entity) -> std::optional<Rect> {
             Rect coverage = maybe_input_coverage.value();
-            return coverage.Shift(entity_offset - coverage.GetOrigin());
+            return Rect::MakeLTRB(entity_offset.x, entity_offset.y,
+                                  coverage.GetRight(), coverage.GetBottom());
           });
 
       Entity entity;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -71,6 +71,8 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
   // this branch for the unit test `ComposePaintRuntimeOuter`, but do it for
   // `ComposeBackdropRuntimeOuterBlurInner`.
   if (input_snapshot->ShouldRasterizeForRuntimeEffects()) {
+    Vector2 entity_offset =
+        Vector2(entity.GetTransform().m[12], entity.GetTransform().m[13]);
     Matrix inverse = input_snapshot->transform.Invert();
     Quad quad = inverse.Transform(Quad{
         coverage.GetLeftTop(),     //
@@ -93,12 +95,11 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
                               const Entity& entity, RenderPass& pass) -> bool {
             return texture_contents.Render(renderer, entity, pass);
           },
-          [maybe_input_coverage](const Entity& entity) -> std::optional<Rect> {
+          [maybe_input_coverage,
+           entity_offset](const Entity& entity) -> std::optional<Rect> {
             FML_LOG(ERROR) << "Doof: " << maybe_input_coverage.value();
-            auto clip_rect_origin = Vector2(10, 10);
             // return maybe_input_coverage;
-            return Rect::MakeXYWH(-clip_rect_origin.x, -clip_rect_origin.y,
-                                  2048, 1536);
+            return Rect::MakeXYWH(entity_offset.x, entity_offset.y, 2048, 1536);
           });
 
       Entity entity;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -84,10 +84,19 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
       texture_contents.SetStencilEnabled(false);
       texture_contents.SetSamplerDescriptor(input_snapshot->sampler_descriptor);
 
+      auto anonymous_contents = AnonymousContents::Make(
+          [&texture_contents](const ContentContext& renderer,
+                              const Entity& entity, RenderPass& pass) -> bool {
+            return texture_contents.Render(renderer, entity, pass);
+          },
+          [maybe_input_coverage](const Entity& entity) -> std::optional<Rect> {
+            return maybe_input_coverage;
+          });
+
       Entity entity;
       // In order to maintain precise coordinates in the fragment shader we need
       // to eliminate the padding typically given to RenderToSnapshot results.
-      input_snapshot = texture_contents.RenderToSnapshot(
+      input_snapshot = anonymous_contents->RenderToSnapshot(
           renderer, entity, {.coverage_expansion = 0});
       if (!input_snapshot.has_value()) {
         return std::nullopt;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -98,8 +98,7 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
           [maybe_input_coverage,
            entity_offset](const Entity& entity) -> std::optional<Rect> {
             Rect coverage = maybe_input_coverage.value();
-            return Rect::MakeLTRB(entity_offset.x, entity_offset.y,
-                                  coverage.GetRight(), coverage.GetBottom());
+            return coverage.Shift(entity_offset - coverage.GetOrigin());
           });
 
       Entity entity;

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -11,7 +11,11 @@
 #include "impeller/entity/contents/anonymous_contents.h"
 #include "impeller/entity/contents/runtime_effect_contents.h"
 #include "impeller/entity/contents/texture_contents.h"
+#include "impeller/geometry/point.h"
 #include "impeller/geometry/size.h"
+
+extern float fudge_x;
+extern float fudge_y;
 
 namespace impeller {
 
@@ -90,7 +94,11 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
             return texture_contents.Render(renderer, entity, pass);
           },
           [maybe_input_coverage](const Entity& entity) -> std::optional<Rect> {
-            return maybe_input_coverage;
+            FML_LOG(ERROR) << "Doof: " << maybe_input_coverage.value();
+            auto clip_rect_origin = Vector2(10, 10);
+            // return maybe_input_coverage;
+            return Rect::MakeXYWH(-clip_rect_origin.x, -clip_rect_origin.y,
+                                  2048, 1536);
           });
 
       Entity entity;

--- a/engine/src/flutter/impeller/fixtures/runtime_stage_filter_circle.frag
+++ b/engine/src/flutter/impeller/fixtures/runtime_stage_filter_circle.frag
@@ -6,10 +6,10 @@
 
 uniform vec2 u_size;
 uniform sampler2D u_texture;
+uniform vec2 u_origin;
 
 out vec4 frag_color;
 
-vec2 origin = vec2(30.0, 30.0);
 float radius = 30.0;
 
 void main() {
@@ -18,7 +18,7 @@ void main() {
 #ifdef IMPELLER_TARGET_OPENGLES
   fixed_uv.y = 1.0 - fixed_uv.y;
 #endif
-  vec2 norm_origin = origin / u_size;
+  vec2 norm_origin = u_origin / u_size;
   float norm_radius = radius / max(u_size.x, u_size.y);
   if (distance(uv, norm_origin) < norm_radius) {
     frag_color = vec4(1.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/181660

This works by changing the rerasterization logic such that we will rerasterize the output from the blur filter to an image that matches the dimensions of the input.  The undoes the optimization of the clip rect but standardizes the input to the fragment shader so that it is behaving as if the input was the same as a backdrop filter without the blur before hand.

I think there may be opportunities in the future to find a way to make this more efficient if we could find some way to rerasterize only to the clipped region but tweak the coordinates in the fragment shader to make it act like it has a whole image.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
