### PR TITLE
[ Tool ] Fix regression introduced in flutter/flutter#181421

### DIFF
--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -102,7 +102,7 @@ class TestCompiler {
   ///
   /// If [testTimeRecorder] is passed, times will be recorded in it.
   TestCompiler(
-    this.buildInfo,
+    BuildInfo buildInfo,
     this.flutterProject, {
     String? precompiledDillPath,
     this.testTimeRecorder,
@@ -121,6 +121,7 @@ class TestCompiler {
              ),
            ),
        shouldCopyDillFile = precompiledDillPath == null {
+    this.buildInfo = buildInfo.copyWith(initializeFromDill: testFilePath);
     // Compiler maintains and updates single incremental dill file.
     // Incremental compilation requests done for each test copy that file away
     // for independent execution.
@@ -144,7 +145,7 @@ class TestCompiler {
   final compilerController = StreamController<_CompilationRequest>();
   final compilationQueue = <_CompilationRequest>[];
   final FlutterProject? flutterProject;
-  final BuildInfo buildInfo;
+  late final BuildInfo buildInfo;
   final String testFilePath;
   final bool shouldCopyDillFile;
   final TestTimeRecorder? testTimeRecorder;

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -271,6 +271,9 @@ class FakeTestCompiler extends TestCompiler {
 
   @override
   Future<ResidentCompiler?> createCompiler() async {
+    // Verify that the compiler was correctly initialized with the generated
+    // dill for the test.
+    expect(buildInfo.initializeFromDill, testFilePath);
     return residentCompiler;
   }
 }


### PR DESCRIPTION
`dev/devicelab/bin/task/flutter_test_performance.dart` regressed due to the CFE not being initialized with the correct dill file for the target test. This change updates `TestCompiler` to pass the correct dill file when creating the `ResidentCompiler` and adds a test to verify that the `ResidentCompiler` is initialized with the correct dill.

See: flutter#181421.