### PR TITLE
[Shortcuts] Improve focus node debug labels

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1137,7 +1137,7 @@ class _ShortcutsState extends State<Shortcuts> {
   @override
   Widget build(BuildContext context) {
     return Focus(
-      debugLabel: '$Shortcuts${widget.debugLabel != null ? ': ${widget.debugLabel}' : ''}',
+      debugLabel: widget.debugLabel != null ? '$Shortcuts: ${widget.debugLabel}' : '$Shortcuts',
       canRequestFocus: false,
       onKeyEvent: _handleOnKeyEvent,
       includeSemantics: widget.includeSemantics,

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1137,7 +1137,7 @@ class _ShortcutsState extends State<Shortcuts> {
   @override
   Widget build(BuildContext context) {
     return Focus(
-      debugLabel: '$Shortcuts',
+      debugLabel: '$Shortcuts${widget.debugLabel != null ? ': ${widget.debugLabel}' : ''}',
       canRequestFocus: false,
       onKeyEvent: _handleOnKeyEvent,
       includeSemantics: widget.includeSemantics,
@@ -1547,7 +1547,11 @@ class _ShortcutRegistrarState extends State<ShortcutRegistrar> {
   Widget build(BuildContext context) {
     return _ShortcutRegistrarScope(
       registry: registry,
-      child: Shortcuts.manager(manager: manager, child: widget.child),
+      child: Shortcuts.manager(
+        manager: manager,
+        debugLabel: '<Shortcut Registrar>',
+        child: widget.child,
+      ),
     );
   }
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1211,6 +1211,20 @@ void main() {
       );
     });
 
+    testWidgets('Shortcuts pass debug label to focus node.', (WidgetTester tester) async {
+      const debugLabel = '<My Shortcuts Debug Label>';
+      await tester.pumpWidget(
+        const Shortcuts(
+          debugLabel: debugLabel,
+          shortcuts: <LogicalKeySet, Intent>{},
+          child: SizedBox(),
+        ),
+      );
+
+      final FocusNode focusNode = Focus.of(tester.element(find.byType(SizedBox)));
+      expect(focusNode.debugLabel, contains(debugLabel));
+    });
+
     testWidgets('Shortcuts support multiple intents', (WidgetTester tester) async {
       tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       bool? value = true;
@@ -2120,6 +2134,12 @@ void main() {
         await memoryEvents(() => ShortcutRegistry().dispose(), ShortcutRegistry),
         areCreateAndDispose,
       );
+    });
+
+    testWidgets('sets debug label on focus node', (WidgetTester tester) async {
+      await tester.pumpWidget(const ShortcutRegistrar(child: SizedBox()));
+      final FocusNode focusNode = Focus.of(tester.element(find.byType(SizedBox)));
+      expect(focusNode.debugLabel, 'Shortcuts: <Shortcut Registrar>');
     });
   });
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1222,7 +1222,7 @@ void main() {
       );
 
       final FocusNode focusNode = Focus.of(tester.element(find.byType(SizedBox)));
-      expect(focusNode.debugLabel, contains(debugLabel));
+      expect(focusNode.debugLabel, 'Shortcuts: <My Shortcuts Debug Label>');
     });
 
     testWidgets('Shortcuts support multiple intents', (WidgetTester tester) async {


### PR DESCRIPTION
### Problem

The `Shortcuts` widget creates focus nodes to listen to key events. If your `Shortcuts` don't work as expected, you can enable [`debugFocusChanges`](https://api.flutter.dev/flutter/cupertino/debugFocusChanges.html) to debug your app. However, the log for when a `Shortcuts` widget handles a key event did not make it clear _which_ `Shortcuts` widget handled the key event:

```
FOCUS: Node FocusNode#12e36(Shortcuts [IN FOCUS PATH])(context: Focus, NOT FOCUSABLE, IN FOCUS PATH) stopped key event propagation: KeyMessage([KeyDownEvent#7b499(physicalKey: PhysicalKeyboardKey#7002c(usbHidUsage: "0x0007002c", debugName: "Space"), logicalKey: LogicalKeyboardKey#00020(keyId: "0x00000020", keyLabel: " ", debugName: "Space"), character: " ", timeStamp: 0:00:04.982699)]).
```

Being able to distinguish `Shortcuts` widgets is important as even a minimal Material app has 4 `Shortcuts` widgets.

### Solution

This change updates the `Shortcuts` widget to pass its debug label down to the focus node it creates. This improves focus logs to make it clearer which `Shortcuts` handled a key event:

### Before and after examples

Example log when a `Shortcuts` handles a key event:

```diff
- FOCUS: Node FocusNode#12e36(Shortcuts [IN FOCUS PATH])(context: Focus, NOT FOCUSABLE, IN FOCUS PATH) stopped key event propagation: KeyMessage([KeyDownEvent#7b499(physicalKey: PhysicalKeyboardKey#7002c(usbHidUsage: "0x0007002c", debugName: "Space"), logicalKey: LogicalKeyboardKey#00020(keyId: "0x00000020", keyLabel: " ", debugName: "Space"), character: " ", timeStamp: 0:00:04.982699)]).
+ FOCUS: Node FocusNode#12e36(Shortcuts: <Web Disabling Text Editing Shortcuts> [IN FOCUS PATH])(context: Focus, NOT FOCUSABLE, IN FOCUS PATH) stopped key event propagation: KeyMessage([KeyDownEvent#7b499(physicalKey: PhysicalKeyboardKey#7002c(usbHidUsage: "0x0007002c", debugName: "Space"), logicalKey: LogicalKeyboardKey#00020(keyId: "0x00000020", keyLabel: " ", debugName: "Space"), character: " ", timeStamp: 0:00:04.982699)]).
```

Example focus tree for a minimal Material app:

<details><summary>Focus tree...</summary>

App:

```dart
import 'package:flutter/material.dart';

void main() {
  debugFocusChanges = true;
  runApp(
    const MaterialApp(
      home: Scaffold(
        body: Center(
          child: Text('Hello, World!'),
        ),
      ),
    ),
  );
}
```

Resulting focus tree before and after this change:

```diff
FocusManager#76dc7
 │ primaryFocus: FocusScopeNode#553ee(Root Focus Scope [PRIMARY
 │   FOCUS])
 └─rootScope: FocusScopeNode#553ee(Root Focus Scope [PRIMARY FOCUS])
   │ PRIMARY FOCUS
   │ focusedChildren: FocusScopeNode#9bb6a(View Scope)
   └─Child 1: _FocusTraversalGroupNode#85c63(FocusTraversalGroup)
     │ context: Focus
     │ NOT FOCUSABLE
     └─Child 1: FocusScopeNode#9bb6a(View Scope)
       │ context: _FocusScopeWithExternalFocusNode
       │ focusedChildren: FocusScopeNode#b6f31(Navigator Scope)
-      └─Child 1: FocusNode#bb974(Shortcuts)
+      └─Child 1: FocusNode#bb974(Shortcuts: <Default WidgetsApp Shortcuts>)
         │ context: Focus
         │ NOT FOCUSABLE
-        └─Child 1: FocusNode#255fb(Shortcuts)
+        └─Child 1: FocusNode#255fb(Shortcuts: <Default Text Editing Shortcuts>)
           │ context: Focus
           │ NOT FOCUSABLE
-           └─Child 1: FocusNode#af347(Shortcuts)
+          └─Child 1: FocusNode#af347(Shortcuts: <Web Disabling Text Editing Shortcuts>)
             │ context: Focus
             │ NOT FOCUSABLE
             └─Child 1: _FocusTraversalGroupNode#bf036(FocusTraversalGroup)
               │ context: Focus
               │ NOT FOCUSABLE
-               └─Child 1: FocusNode#8e60c(Shortcuts)
+               └─Child 1: FocusNode#8e60c(Shortcuts: <Shortcut Registrar>)
                 │ context: Focus
                 │ NOT FOCUSABLE
                 └─Child 1: FocusNode#54bda
                   │ context: Focus
                   │ NOT FOCUSABLE
                   └─Child 1: FocusScopeNode#b6f31(Navigator Scope)
                     │ context: FocusScope
                     │ focusedChildren: FocusScopeNode#2df85(_ModalScopeState<dynamic>
                     │   Focus Scope)
                     └─Child 1: _FocusTraversalGroupNode#82ab3(FocusTraversalGroup)
                       │ context: Focus
                       │ NOT FOCUSABLE
                       └─Child 1: FocusNode#4b8f5(Navigator)
                         │ context: Focus
                         └─Child 1: FocusScopeNode#2df85(_ModalScopeState<dynamic> Focus Scope)
                             context: _FocusScopeWithExternalFocusNode
```

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
