### PR TITLE
[ Tool ] Don't use `globals.platform` in `getFlutterRoot()`

### DIFF
--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -52,7 +52,7 @@ String getFlutterRoot() {
   }
 
   Error invalidScript() => StateError(
-    'Could not determine flutter_tools/ path from script URL (${globals.platform.script}); consider setting FLUTTER_ROOT explicitly.',
+    'Could not determine flutter_tools/ path from script URL (${platform.script}); consider setting FLUTTER_ROOT explicitly.',
   );
 
   Uri scriptUri;


### PR DESCRIPTION
This can cause a confusing error message when tests are run with `dart test`, which results in `platform.script` returning a dill file. In particular, tests run using `testWithoutContext` or without a `Platform` override that invoke `getFlutterRoot()` will encounter an error about `context.get<Platform>` not being supported.

Fixes https://github.com/flutter/flutter/issues/181856