### PR TITLE
In the Web codec tests, skip an undecodable image that is used to test a Skia error handling code path.

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/codecs_test.dart
@@ -143,6 +143,10 @@ Future<void> testMain() async {
         // https://github.com/flutter/flutter/issues/152709
         continue;
       }
+      if (testFile == 'b464333052.jpg') {
+        // This is an undecodable image used to test a Skia failure code path.
+        continue;
+      }
       testCodecs.add(
         UrlTestCodec(
           testFile,


### PR DESCRIPTION
A recent Skia change added an invalid image file that tests a decoding failure case (see https://skia.googlesource.com/skia/+/12cb69b2700acfccee52bacf63321800af8c138c)

That file should be excluded from the set of Skia image assets used by the Flutter Web codec tests.