### PR TITLE
Encourage splitting large test files in testing documentation

### DIFF
--- a/docs/contributing/testing/Running-and-writing-tests.md
+++ b/docs/contributing/testing/Running-and-writing-tests.md
@@ -47,7 +47,7 @@ runs them, run `dart dev/bots/test.dart` and `dart --enable-asserts dev/bots/ana
 
 ### Organizing test files
 
-Avoid creating overly large test files that contain many unrelated test cases.
+Avoid creating overly large test files that contain many unrelated test cases.  
 Instead, organize tests into smaller files grouped by feature, widget, or behavior.
 
 Splitting large test files has several benefits:
@@ -56,6 +56,26 @@ Splitting large test files has several benefits:
 - Navigation
 - Maintainability
 - Reviewability for contributors
+
+#### Naming conventions and examples
+
+Instead of keeping everything in a single file like:
+
+- `button_test.dart`
+
+that includes layout, semantics, and interaction tests, it can be split into:
+
+- `button_layout_test.dart`
+- `button_semantics_test.dart`
+- `button_interaction_test.dart`
+
+Or group tests by behavior:
+
+- `navigator_push_test.dart`
+- `navigator_pop_test.dart`
+- `navigator_transition_test.dart`
+
+The goal is to keep each test file focused on a single feature or behavior so it remains easier to understand, review, and maintain over time.
 
 ### Locally built engines
 

--- a/docs/contributing/testing/Running-and-writing-tests.md
+++ b/docs/contributing/testing/Running-and-writing-tests.md
@@ -45,6 +45,18 @@ before the test runs.
 To run analysis and all the tests for the entire Flutter repository, the same way that LUCI
 runs them, run `dart dev/bots/test.dart` and `dart --enable-asserts dev/bots/analyze.dart`.
 
+### Organizing test files
+
+Avoid creating overly large test files that contain many unrelated test cases.
+Instead, organize tests into smaller files grouped by feature, widget, or behavior.
+
+Splitting large test files has several benefits:
+
+- Readability
+- Navigation
+- Maintainability
+- Reviewability for contributors
+
 ### Locally built engines
 
 If you've built your own flutter engine (see [Setting up the Engine development environment](../../../docs/engine/contributing/Setting-up-the-Engine-development-environment.md)), you

--- a/docs/contributing/testing/Running-and-writing-tests.md
+++ b/docs/contributing/testing/Running-and-writing-tests.md
@@ -47,8 +47,9 @@ runs them, run `dart dev/bots/test.dart` and `dart --enable-asserts dev/bots/ana
 
 ### Organizing test files
 
-Avoid creating overly large test files that contain many unrelated test cases.  
-Instead, organize tests into smaller files grouped by feature, widget, or behavior.
+Organize tests into smaller, focused files grouped by feature, widget, or behavior, rather than creating large files with many unrelated test cases.
+
+This approach aligns with the Flutter style guide's principle to [prefer more test files and avoid long test files](../Style-guide-for-Flutter-repo.md#prefer-more-test-files-avoid-long-test-files).
 
 Splitting large test files has several benefits:
 


### PR DESCRIPTION
This PR updates the testing documentation to encourage contributors to split large test files into smaller, feature-focused files.

Smaller test files improve readability, navigation, maintainability, and reviewability.

Fixes #181819
