### PR TITLE
[flutter_tools] Deprecate web hot reload flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -699,10 +699,8 @@ class RunCommand extends RunCommandBase {
       throwToolExit('Skwasm renderer requires --wasm');
     }
 
-    if (webMode && (argResults?.wasParsed(FlutterOptions.kWebExperimentalHotReload) ?? false)) {
-      final bool webEnableHotReload =
-          argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
-          boolArg(FlutterOptions.kWebExperimentalHotReload);
+    if (argResults?.wasParsed(FlutterOptions.kWebExperimentalHotReload) ?? false) {
+      final bool webEnableHotReload = boolArg(FlutterOptions.kWebExperimentalHotReload);
       if (webEnableHotReload) {
         globals.printWarning(
           'Hot reload on the web is now enabled by default. '

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -714,8 +714,9 @@ class RunCommand extends RunCommandBase {
           'Hot reload on the web is now enabled by default. '
           'The "--no-${FlutterOptions.kWebExperimentalHotReload}" flag is deprecated '
           'and will be removed in an upcoming release. '
-          'If your web development workflow depends on disabling hot reload, please open an issue '
-          'explaining why at https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml',
+          'If your web development workflow depends on disabling hot reload, '
+          'please open an issue explaining why at '
+          'https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml.',
         );
       }
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -699,6 +699,27 @@ class RunCommand extends RunCommandBase {
       throwToolExit('Skwasm renderer requires --wasm');
     }
 
+    if (webMode && (argResults?.wasParsed(FlutterOptions.kWebExperimentalHotReload) ?? false)) {
+      final bool webEnableHotReload =
+          argParser.options.containsKey(FlutterOptions.kWebExperimentalHotReload) &&
+          boolArg(FlutterOptions.kWebExperimentalHotReload);
+      if (webEnableHotReload) {
+        globals.printWarning(
+          'Hot reload on the web is now enabled by default. '
+          'The "--${FlutterOptions.kWebExperimentalHotReload}" flag is deprecated '
+          'and will be removed in an upcoming release.',
+        );
+      } else {
+        globals.printWarning(
+          'Hot reload on the web is now enabled by default. '
+          'The "--no-${FlutterOptions.kWebExperimentalHotReload}" flag is deprecated '
+          'and will be removed in an upcoming release. '
+          'If your web development workflow depends on disabling hot reload, please open an issue '
+          'explaining why at https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml',
+        );
+      }
+    }
+
     final String? flavor = stringArg('flavor');
     final bool flavorsSupportedOnEveryDevice = devices!.every(
       (Device device) => device.supportsFlavors,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -372,7 +372,9 @@ abstract class FlutterCommand extends Command<void> {
     );
     argParser.addFlag(
       FlutterOptions.kWebExperimentalHotReload,
-      help: 'Enables new module format that supports hot reload.',
+      help:
+          '(deprecated; will be removed in a future release) '
+          'Enables new module format that supports hot reload.',
       defaultsTo: true,
       hide: !verboseHelp,
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1638,6 +1638,101 @@ server:
       Logger: () => BufferLogger.test(),
     },
   );
+
+  group('run --web-experimental-hot-reload flag', () {
+    late BufferLogger logger;
+    late TestDeviceManager testDeviceManager;
+    late FileSystem fileSystem;
+
+    setUp(() {
+      logger = BufferLogger.test();
+
+      final fakeDevice = FakeDevice(
+        id: 'chrome',
+        name: 'Chrome',
+        targetPlatform: TargetPlatform.web_javascript,
+      );
+      testDeviceManager = TestDeviceManager(logger: logger)..devices = <Device>[fakeDevice];
+
+      fileSystem = MemoryFileSystem.test();
+      fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
+      final Directory libDir = fileSystem.currentDirectory.childDirectory('lib');
+      libDir.createSync();
+      final File mainFile = libDir.childFile('main.dart');
+      mainFile.writeAsStringSync('void main() {}');
+    });
+    testUsingContext(
+      'no warning triggered when web hot reload flag not present',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run', '-d', 'chrome']);
+        expect(testLogger.warningText, isEmpty);
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
+
+    testUsingContext(
+      'warning triggered when web hot reload flag is passed (enabled)',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run', '-d', 'chrome', '--web-experimental-hot-reload']);
+        expect(
+          testLogger.warningText,
+          contains(
+            'Hot reload on the web is now enabled by default. '
+            'The "--web-experimental-hot-reload" flag is deprecated '
+            'and will be removed in an upcoming release.',
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
+
+    testUsingContext(
+      'warning triggered when web hot reload flag is passed (disabled)',
+      () async {
+        final CommandRunner<void> runner = createTestCommandRunner(
+          TestRunCommandThatOnlyValidates(),
+        );
+        await runner.run(<String>['run', '-d', 'chrome', '--no-web-experimental-hot-reload']);
+
+        expect(
+          testLogger.warningText,
+          contains(
+            'Hot reload on the web is now enabled by default. '
+            'The "--no-web-experimental-hot-reload" flag is deprecated '
+            'and will be removed in an upcoming release. '
+            'If your web development workflow depends on disabling hot reload, please open an issue '
+            'explaining why at https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml'
+          ),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      },
+      initializeFlutterRoot: false,
+    );
+  });
 }
 
 class TestDeviceManager extends DeviceManager {
@@ -1654,6 +1749,8 @@ class TestDeviceManager extends DeviceManager {
 
 class FakeDevice extends Fake implements Device {
   FakeDevice({
+    this.id = 'fake_device',
+    this.name = 'FakeDevice',
     bool isLocalEmulator = false,
     TargetPlatform targetPlatform = TargetPlatform.ios,
     String sdkNameAndVersion = '',
@@ -1680,7 +1777,7 @@ class FakeDevice extends Fake implements Device {
   Category get category => Category.mobile;
 
   @override
-  String get id => 'fake_device';
+  final String id;
 
   Never _throwToolExit(int code) => throwToolExit('FakeDevice tool exit', exitCode: code);
 
@@ -1732,7 +1829,7 @@ class FakeDevice extends Fake implements Device {
   }
 
   @override
-  String get name => 'FakeDevice';
+  final String name;
 
   @override
   String get displayName => name;

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1719,8 +1719,9 @@ server:
             'Hot reload on the web is now enabled by default. '
             'The "--no-web-experimental-hot-reload" flag is deprecated '
             'and will be removed in an upcoming release. '
-            'If your web development workflow depends on disabling hot reload, please open an issue '
-            'explaining why at https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml'
+            'If your web development workflow depends on disabling hot reload, '
+            'please open an issue explaining why at '
+            'https://github.com/dart-lang/sdk/issues/new?template=5_web_hot_reload.yml.',
           ),
         );
       },

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1647,12 +1647,9 @@ server:
     setUp(() {
       logger = BufferLogger.test();
 
-      final fakeDevice = FakeDevice(
-        id: 'chrome',
-        name: 'Chrome',
-        targetPlatform: TargetPlatform.web_javascript,
-      );
+      final fakeDevice = FakeDevice();
       testDeviceManager = TestDeviceManager(logger: logger)..devices = <Device>[fakeDevice];
+      testDeviceManager.specifiedDeviceId = fakeDevice.id;
 
       fileSystem = MemoryFileSystem.test();
       fileSystem.currentDirectory.childFile('pubspec.yaml').writeAsStringSync('name: my_app');
@@ -1668,7 +1665,7 @@ server:
         final CommandRunner<void> runner = createTestCommandRunner(
           TestRunCommandThatOnlyValidates(),
         );
-        await runner.run(<String>['run', '-d', 'chrome']);
+        await runner.run(<String>['run']);
         expect(testLogger.warningText, isEmpty);
       },
       overrides: <Type, Generator>{
@@ -1686,7 +1683,7 @@ server:
         final CommandRunner<void> runner = createTestCommandRunner(
           TestRunCommandThatOnlyValidates(),
         );
-        await runner.run(<String>['run', '-d', 'chrome', '--web-experimental-hot-reload']);
+        await runner.run(<String>['run', '--web-experimental-hot-reload']);
         expect(
           testLogger.warningText,
           contains(
@@ -1711,7 +1708,7 @@ server:
         final CommandRunner<void> runner = createTestCommandRunner(
           TestRunCommandThatOnlyValidates(),
         );
-        await runner.run(<String>['run', '-d', 'chrome', '--no-web-experimental-hot-reload']);
+        await runner.run(<String>['run', '--no-web-experimental-hot-reload']);
 
         expect(
           testLogger.warningText,
@@ -1750,8 +1747,6 @@ class TestDeviceManager extends DeviceManager {
 
 class FakeDevice extends Fake implements Device {
   FakeDevice({
-    this.id = 'fake_device',
-    this.name = 'FakeDevice',
     bool isLocalEmulator = false,
     TargetPlatform targetPlatform = TargetPlatform.ios,
     String sdkNameAndVersion = '',
@@ -1778,7 +1773,7 @@ class FakeDevice extends Fake implements Device {
   Category get category => Category.mobile;
 
   @override
-  final String id;
+  String get id => 'fake_device';
 
   Never _throwToolExit(int code) => throwToolExit('FakeDevice tool exit', exitCode: code);
 
@@ -1830,7 +1825,7 @@ class FakeDevice extends Fake implements Device {
   }
 
   @override
-  final String name;
+  String get name => 'FakeDevice';
 
   @override
   String get displayName => name;


### PR DESCRIPTION
Warn when the flag is passed, and prompt to file an issue if disabling is required for a web development workflow.

The flag is enabled by default. It is still functional, but will be removed in an upcoming release.