### PR TITLE
engine: Use a super-parameter in one missed case

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -376,8 +376,8 @@ final class _EngineFlutterViewImpl extends EngineFlutterView {
   _EngineFlutterViewImpl(
     EnginePlatformDispatcher platformDispatcher,
     DomElement hostElement, {
-    JsViewConstraints? viewConstraints,
-  }) : super._(_nextViewId++, platformDispatcher, hostElement, viewConstraints: viewConstraints);
+    super.viewConstraints,
+  }) : super._(_nextViewId++, platformDispatcher, hostElement);
 }
 
 /// The Web implementation of [ui.SingletonFlutterWindow].


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/58729

The lint rule will suggest using a super-parameter for a named parameter even if the positional parameters cannot be super-parameters.