### PR TITLE
Temporarily remove the Pixel 9/API 36 device from the Firebase Test Lab tests.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -712,6 +712,8 @@ targets:
       tags: >
         ["firebaselab"]
       task_name: release_smoke_test
+      # TODO(flutter/flutter#181954) Restore the Pixel 9/API 36 device when
+      # it is available in Firebase Test Lab.
       physical_devices: >-
         [
           "--device", "model=shiba,version=34",

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -714,8 +714,6 @@ targets:
       task_name: release_smoke_test
       physical_devices: >-
         [
-          # Temporarily disabled due to Firebase Test Lab issues.
-          # "--device", "model=tokay,version=36",
           "--device", "model=shiba,version=34",
           "--device", "model=redfin,version=30",
           "--device", "model=griffin,version=24"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -714,7 +714,8 @@ targets:
       task_name: release_smoke_test
       physical_devices: >-
         [
-          "--device", "model=tokay,version=36",
+          # Temporarily disabled due to Firebase Test Lab issues.
+          # "--device", "model=tokay,version=36",
           "--device", "model=shiba,version=34",
           "--device", "model=redfin,version=30",
           "--device", "model=griffin,version=24"


### PR DESCRIPTION
There appears to be a Firebase outage that currently affects this device type.

See https://github.com/flutter/flutter/issues/181954